### PR TITLE
fix: egress guard blocks Ollama on private IPs (SSRF check runs befor…

### DIFF
--- a/src/security/guards/egress-guard.js
+++ b/src/security/guards/egress-guard.js
@@ -360,7 +360,8 @@ class EgressGuard {
     }
 
     // Check private IP patterns (SSRF prevention)
-    if (this._isPrivateIP(hostname)) {
+    // Exempt the configured Ollama host — it's expected to be on a private IP
+    if (this._isPrivateIP(hostname) && !(this.ollamaHost && hostname.toLowerCase() === this.ollamaHost)) {
       return {
         allowed: false,
         reason: `Blocked private IP: ${hostname}`,

--- a/test/unit/guards/egress-guard.test.js
+++ b/test/unit/guards/egress-guard.test.js
@@ -58,10 +58,10 @@ test('TC-EG-003: Constructor auto-adds nextcloudDomain', () => {
 
 test('TC-EG-004: Constructor auto-adds ollamaHost', () => {
   const guard = new EgressGuard({
-    ollamaHost: 'YOUR_OLLAMA_IP',
+    ollamaHost: '10.0.0.2',
   });
-  assert.ok(guard.allowedDomains.has('YOUR_OLLAMA_IP'));
-  assert.strictEqual(guard.ollamaHost, 'YOUR_OLLAMA_IP');
+  assert.ok(guard.allowedDomains.has('10.0.0.2'));
+  assert.strictEqual(guard.ollamaHost, '10.0.0.2');
 });
 
 test('TC-EG-005: Constructor accepts additionalBlocked domains', () => {
@@ -342,10 +342,10 @@ test('TC-EG-072: ALLOW configured Nextcloud domain', () => {
 test('TC-EG-073: ALLOW configured Ollama host (HTTP)', () => {
   const guard = new EgressGuard({
     allowedDomains: ['api.anthropic.com'],
-    ollamaHost: 'YOUR_OLLAMA_IP',
+    ollamaHost: '10.0.0.2',
   });
   // Ollama typically runs on HTTP
-  const result = guard.evaluate('http://YOUR_OLLAMA_IP:11434/api/generate');
+  const result = guard.evaluate('http://10.0.0.2:11434/api/generate');
   assert.strictEqual(result.allowed, true);
 });
 


### PR DESCRIPTION
…e exemption)

The SSRF private-IP block ran before the Ollama host exemption, so any Ollama VM on a private network (10.x, 192.168.x) was blocked. Added an exemption for the configured ollamaHost in the private-IP check.

Also replaced placeholder YOUR_OLLAMA_IP in tests with 10.0.0.2.

## What

<!-- What does this PR change? One or two sentences. -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #000 -->

## How

<!-- Brief description of the approach. Mention any architectural decisions. -->

## Testing

<!-- How did you verify this works? -->

- [ ] Tests pass (`npm test`)
- [ ] Tested manually against a Nextcloud instance
- [ ] No language-specific logic added (multilingual by default)

## Checklist

- [ ] Commit messages are descriptive
- [ ] No credentials, IPs, or client-specific data in the diff
- [ ] Documentation updated if needed
