### PR TITLE
Sessions 46-48: PAUSED guards, board map injection, cockpit stability, cost metering

### DIFF
--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -1177,7 +1177,7 @@ class CockpitManager {
     // Store card metadata for heartbeat writeback
     result._cardId = card.id;
     result._cardDescription = card.description || '';
-    result._userConfig = configSection;
+    result._userConfig = configSection.trim() + '\n';
     result._cardLabels = (card.labels || []).map(l => l.title);
 
     this._lastModelsConfig = result;

--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -1936,16 +1936,17 @@ class CockpitManager {
 
     const lines = [];
 
-    // Daily line
-    const dailyEur = totals.daily.costEur.toFixed(2);
+    // Daily line — use displayCostEur (external calls only) so idle
+    // heartbeat housekeeping doesn't flip the rounded EUR value on every pulse.
+    const dailyEur = totals.daily.displayCostEur.toFixed(2);
     if (budget.dailyLimit) {
       lines.push(`Today: \u20ac${dailyEur} / \u20ac${budget.dailyLimit.toFixed(2)}`);
     } else {
       lines.push(`Today: \u20ac${dailyEur}`);
     }
 
-    // Monthly line
-    const monthlyEur = totals.monthly.costEur.toFixed(2);
+    // Monthly line — same reasoning.
+    const monthlyEur = totals.monthly.displayCostEur.toFixed(2);
     if (budget.monthlyLimit) {
       lines.push(`This month: \u20ac${monthlyEur} / \u20ac${budget.monthlyLimit.toFixed(2)}`);
     } else {
@@ -1966,11 +1967,10 @@ class CockpitManager {
       }
     }
 
-    // Timestamp (rounded to 15-min bucket so unchanged heartbeats don't trigger writes)
-    const now = new Date();
-    now.setMinutes(Math.floor(now.getMinutes() / 15) * 15, 0, 0);
-    lines.push('');
-    lines.push(`_Updated: ${now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}_`);
+    // No "_Updated:" timestamp line by design. Idle heartbeats must not
+    // produce any Status card writes; any non-constant line (even bucketed)
+    // eventually flips the hash and rewrites the card. Card freshness is
+    // observable via Deck's own lastModified field.
 
     return lines.join('\n');
   }

--- a/src/lib/integrations/collectives-client.js
+++ b/src/lib/integrations/collectives-client.js
@@ -520,6 +520,38 @@ class CollectivesClient {
   }
 
   /**
+   * Ensure a directory path exists inside the collective, creating any
+   * missing segments via WebDAV MKCOL. Idempotent — a 405 (collection
+   * already exists) for any segment is treated as success.
+   *
+   * Required before writing pages to a new sub-folder: Nextcloud's WebDAV
+   * returns 404 on PUT when the parent collection is missing, so callers
+   * must create the tree first.
+   *
+   * @param {string} dirPath - Directory path relative to the collective root
+   *                           (e.g. "Memory/Episodes"). Must not contain "..".
+   * @returns {Promise<void>}
+   */
+  async ensureDirectory(dirPath) {
+    if (!dirPath) return;
+    if (dirPath.includes('..')) throw new CollectivesApiError('Path traversal not allowed');
+
+    const segments = dirPath.split('/').filter(Boolean);
+    let acc = '';
+    for (const seg of segments) {
+      acc = acc ? `${acc}/${seg}` : seg;
+      const fullPath = `${this._webdavBasePath()}/${acc}`;
+      try {
+        await this._webdavRequest('MKCOL', fullPath);
+      } catch (err) {
+        // 405 Method Not Allowed = collection already exists; acceptable.
+        if (err && err.statusCode === 405) continue;
+        throw err;
+      }
+    }
+  }
+
+  /**
    * Touch a page via OCS API to invalidate NC Text editor cache.
    * Call after WebDAV writes so the Collectives UI re-reads the .md file.
    * @param {number} collectiveId - Collective ID

--- a/src/lib/integrations/heartbeat-intelligence.js
+++ b/src/lib/integrations/heartbeat-intelligence.js
@@ -180,7 +180,7 @@ Write a brief prep summary (max 200 words) for the human. Include: who's attendi
         task: 'meeting_prep',
         content: prompt,
         requirements: { role: 'value' },
-        context: { trigger: 'heartbeat_meeting_prep' }
+        context: { trigger: 'heartbeat_meeting_prep', internal: true }
       });
 
       const header = `Meeting prep: ${event.summary}\nTime: ${event.start}\n\n`;

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -84,7 +84,7 @@ class HeartbeatManager {
 
     // DeckTaskProcessor creates its own internal DeckClient
     this.deckProcessor = new DeckTaskProcessor(deckConfig, this.llmRouter, this.auditLog, {
-      routeContext: { trigger: 'heartbeat_deck' },
+      routeContext: { trigger: 'heartbeat_deck', internal: true },
       notifyUser: config.notifyUser || null,
       reviewUser: config.reviewUser || config.ownerUser || null
     });

--- a/src/lib/llm/cost-tracker.js
+++ b/src/lib/llm/cost-tracker.js
@@ -67,8 +67,14 @@ class CostTracker {
     this.usdToEur = usdToEur;
 
     // In-memory accumulators (survive until process restart)
-    this.daily = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
-    this.monthly = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
+    //
+    // Two parallel accumulators per period:
+    //  • `cost` / `byJob` — TOTAL (incl. internal heartbeat housekeeping).
+    //    Used by BudgetEnforcer: runaway internal calls must still trip limits.
+    //  • `displayCost` / `displayByJob` — EXTERNAL only (excl. internal).
+    //    Used by Cockpit Status cards: the observer must not change the observed.
+    this.daily = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
+    this.monthly = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
 
     // Track current period boundaries
     this.currentDay = this._todayKey();
@@ -119,8 +125,8 @@ class CostTracker {
     if (!raw || typeof raw !== 'string') return;
 
     // Reset accumulators before rehydrating
-    this.daily = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
-    this.monthly = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
+    this.daily = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
+    this.monthly = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
 
     const lines = raw.split('\n');
     let restored = 0;
@@ -138,28 +144,41 @@ class CostTracker {
 
       const entryDate = (entry.timestamp || '').slice(0, 10);
       const isLocal = !!entry.is_local;
+      const isInternal = !!entry.internal;
       const cost = Number(entry.cost_usd) || 0;
 
       // Monthly accumulation (all entries in this file are current month)
       if (isLocal) {
-        this.monthly.localCalls++;
+        if (!isInternal) this.monthly.localCalls++;
       } else {
         this.monthly.cost += cost;
-        this.monthly.cloudCalls++;
+        if (!isInternal) {
+          this.monthly.displayCost += cost;
+          this.monthly.cloudCalls++;
+        }
       }
 
       const jobKey = `${entry.job || 'unknown'}:${isLocal ? 'local' : 'cloud'}`;
       this.monthly.byJob[jobKey] = (this.monthly.byJob[jobKey] || 0) + cost;
+      if (!isInternal) {
+        this.monthly.displayByJob[jobKey] = (this.monthly.displayByJob[jobKey] || 0) + cost;
+      }
 
       // Daily accumulation (only today's entries)
       if (entryDate === today) {
         if (isLocal) {
-          this.daily.localCalls++;
+          if (!isInternal) this.daily.localCalls++;
         } else {
           this.daily.cost += cost;
-          this.daily.cloudCalls++;
+          if (!isInternal) {
+            this.daily.displayCost += cost;
+            this.daily.cloudCalls++;
+          }
         }
         this.daily.byJob[jobKey] = (this.daily.byJob[jobKey] || 0) + cost;
+        if (!isInternal) {
+          this.daily.displayByJob[jobKey] = (this.daily.displayByJob[jobKey] || 0) + cost;
+        }
       }
 
       restored++;
@@ -197,8 +216,12 @@ class CostTracker {
     const isLocal = entry.isLocal || this._isLocalModel(entry.model);
     const isInternal = !!entry.internal;
 
-    // Accumulate — internal calls still track cost (for budget enforcement)
-    // but are excluded from call counts (which feed Status cards)
+    // Accumulate.
+    //  • `cost` / `byJob` always track everything — BudgetEnforcer reads these
+    //    and must still trip on runaway internal usage.
+    //  • `displayCost` / `displayByJob` / `cloudCalls` / `localCalls` are the
+    //    user-facing counters that Cockpit Status cards read. Internal calls
+    //    are excluded so idle heartbeats don't flap the card content.
     if (isLocal) {
       if (!isInternal) {
         this.daily.localCalls++;
@@ -208,17 +231,24 @@ class CostTracker {
       this.daily.cost += cost;
       this.monthly.cost += cost;
       if (!isInternal) {
+        this.daily.displayCost += cost;
+        this.monthly.displayCost += cost;
         this.daily.cloudCalls++;
         this.monthly.cloudCalls++;
       }
     }
 
-    // Track by job
+    // Track by job — parallel total and display accumulators
     const jobKey = `${entry.job || 'unknown'}:${isLocal ? 'local' : 'cloud'}`;
     this.daily.byJob[jobKey] = (this.daily.byJob[jobKey] || 0) + cost;
     this.monthly.byJob[jobKey] = (this.monthly.byJob[jobKey] || 0) + cost;
+    if (!isInternal) {
+      this.daily.displayByJob[jobKey] = (this.daily.displayByJob[jobKey] || 0) + cost;
+      this.monthly.displayByJob[jobKey] = (this.monthly.displayByJob[jobKey] || 0) + cost;
+    }
 
-    // Buffer audit entry
+    // Buffer audit entry — `internal` is persisted so restore() can
+    // reconstruct the display accumulators accurately after a restart.
     this._buffer.push({
       timestamp: new Date().toISOString(),
       model: entry.model,
@@ -231,6 +261,7 @@ class CostTracker {
       cache_read_tokens: entry.cacheReadTokens || 0,
       cost_usd: Math.round(cost * 1000000) / 1000000,
       is_local: isLocal,
+      internal: isInternal,
     });
 
     console.log(
@@ -243,7 +274,15 @@ class CostTracker {
 
   /**
    * Get current totals for display and budget checks.
-   * Returns both USD and EUR values.
+   *
+   * Two parallel cost views:
+   *  • `costUsd` / `costEur` — TOTAL spend (incl. internal heartbeat calls).
+   *    Read by BudgetEnforcer; must reflect real wallet impact.
+   *  • `displayCostUsd` / `displayCostEur` — EXTERNAL-only spend.
+   *    Read by Cockpit Status cards; stable across idle heartbeats.
+   *
+   * `topSpending` uses `displayByJob` so the card doesn't rank internal
+   * housekeeping jobs above user-facing work.
    */
   getTotals() {
     this._checkReset();
@@ -251,12 +290,16 @@ class CostTracker {
       daily: {
         costUsd: this.daily.cost,
         costEur: this.daily.cost * this.usdToEur,
+        displayCostUsd: this.daily.displayCost,
+        displayCostEur: this.daily.displayCost * this.usdToEur,
         cloudCalls: this.daily.cloudCalls,
         localCalls: this.daily.localCalls,
       },
       monthly: {
         costUsd: this.monthly.cost,
         costEur: this.monthly.cost * this.usdToEur,
+        displayCostUsd: this.monthly.displayCost,
+        displayCostEur: this.monthly.displayCost * this.usdToEur,
         cloudCalls: this.monthly.cloudCalls,
         localCalls: this.monthly.localCalls,
       },
@@ -483,7 +526,9 @@ class CostTracker {
   }
 
   _topSpending() {
-    return Object.entries(this.monthly.byJob)
+    // Reads from displayByJob (external only) so internal heartbeat jobs
+    // don't rank in the Cockpit Status card breakdown.
+    return Object.entries(this.monthly.displayByJob)
       .filter(([, cost]) => cost > 0)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 5)
@@ -499,13 +544,13 @@ class CostTracker {
 
     if (today !== this.currentDay) {
       console.log(`[CostTracker] Day reset: ${this.currentDay} → ${today}`);
-      this.daily = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
+      this.daily = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
       this.currentDay = today;
     }
 
     if (month !== this.currentMonth) {
       console.log(`[CostTracker] Month reset: ${this.currentMonth} → ${month}`);
-      this.monthly = { cost: 0, cloudCalls: 0, localCalls: 0, byJob: {} };
+      this.monthly = { cost: 0, displayCost: 0, cloudCalls: 0, localCalls: 0, byJob: {}, displayByJob: {} };
       this.currentMonth = month;
     }
   }

--- a/src/lib/llm/cost-tracker.js
+++ b/src/lib/llm/cost-tracker.js
@@ -188,22 +188,29 @@ class CostTracker {
    * @param {number} [entry.cacheReadTokens=0] - Anthropic cache read tokens
    * @param {boolean} [entry.isLocal=false] - Whether this was a local model call
    * @param {string} [entry.provider] - Provider ID for attribution
+   * @param {boolean} [entry.internal=false] - Internal heartbeat call (excluded from display counters)
    */
   record(entry) {
     this._checkReset();
 
     const cost = this._computeCost(entry);
     const isLocal = entry.isLocal || this._isLocalModel(entry.model);
+    const isInternal = !!entry.internal;
 
-    // Accumulate
+    // Accumulate — internal calls still track cost (for budget enforcement)
+    // but are excluded from call counts (which feed Status cards)
     if (isLocal) {
-      this.daily.localCalls++;
-      this.monthly.localCalls++;
+      if (!isInternal) {
+        this.daily.localCalls++;
+        this.monthly.localCalls++;
+      }
     } else {
       this.daily.cost += cost;
-      this.daily.cloudCalls++;
       this.monthly.cost += cost;
-      this.monthly.cloudCalls++;
+      if (!isInternal) {
+        this.daily.cloudCalls++;
+        this.monthly.cloudCalls++;
+      }
     }
 
     // Track by job

--- a/src/lib/llm/router.js
+++ b/src/lib/llm/router.js
@@ -174,10 +174,14 @@ class LLMRouter {
    */
   async route(request) {
     const startTime = Date.now();
-    this.stats.totalCalls++;
-
     // Normalize request
     const { task, content, requirements = {}, context = {} } = request;
+    const isInternal = !!context.internal;
+
+    // Internal calls (heartbeat housekeeping) are excluded from user-facing stats
+    if (!isInternal) {
+      this.stats.totalCalls++;
+    }
     const role = requirements.role || 'value';
     const options = {
       maxTokens: requirements.maxTokens,
@@ -334,12 +338,15 @@ class LLMRouter {
             cacheCreationTokens: result.cacheCreationTokens || 0,
             cacheReadTokens: result.cacheReadTokens || 0,
             isLocal: provider.type === 'local',
+            internal: isInternal,
           });
         }
 
-        // Track stats
-        this.stats.successfulCalls++;
-        this.stats.byProvider[providerId] = (this.stats.byProvider[providerId] || 0) + 1;
+        // Track stats (internal calls excluded from user-facing counters)
+        if (!isInternal) {
+          this.stats.successfulCalls++;
+          this.stats.byProvider[providerId] = (this.stats.byProvider[providerId] || 0) + 1;
+        }
 
         if (failoverPath.length > 0) {
           this.stats.failovers++;
@@ -1218,6 +1225,7 @@ class LLMRouter {
    * @param {number} [outcome.outputTokens] - Output tokens
    * @param {Object} [outcome.headers] - Response headers (for rate limit tracking)
    * @param {string} [outcome.opType] - 'proactive' | 'reactive'
+   * @param {boolean} [outcome.internal] - Whether this is an internal housekeeping call
    */
   recordOutcome(providerId, outcome = {}) {
     if (outcome.success) {
@@ -1236,9 +1244,11 @@ class LLMRouter {
         }
       }
 
-      // Track stats
-      this.stats.successfulCalls++;
-      this.stats.byProvider[providerId] = (this.stats.byProvider[providerId] || 0) + 1;
+      // Track stats (internal calls excluded from user-facing counters)
+      if (!outcome.internal) {
+        this.stats.successfulCalls++;
+        this.stats.byProvider[providerId] = (this.stats.byProvider[providerId] || 0) + 1;
+      }
     } else {
       const error = outcome.error || new Error('unknown');
       this.circuitBreaker.recordFailure(providerId, error);

--- a/src/lib/memory/daily-digest.js
+++ b/src/lib/memory/daily-digest.js
@@ -188,7 +188,8 @@ Rules:
       const rawResponse = await this.router.route({
         job: 'synthesis',
         content: prompt,
-        requirements: { maxTokens: 300 }
+        requirements: { maxTokens: 300 },
+        context: { trigger: 'heartbeat_digest', internal: true }
       });
       return (rawResponse.result || rawResponse || '').toString().trim() || 'Activity recorded.';
     } catch (err) {

--- a/src/lib/memory/daily-digest.js
+++ b/src/lib/memory/daily-digest.js
@@ -57,7 +57,14 @@ class DailyDigest {
   async generate(dateStr) {
     const date = dateStr || new Date().toISOString().slice(0, 10);
 
-    // Idempotency: never write the same day twice in one process lifetime
+    // Idempotency: never attempt the same day twice in one process lifetime.
+    //
+    // The guard is claimed BEFORE any LLM call so a failing write cannot
+    // cause the expensive narrative generation to repeat every heartbeat.
+    // On failure we log and move on; a restart clears `_lastDigestDate`
+    // and the next process lifetime gets a fresh attempt. Without this
+    // ordering a single 404 on PUT caused ~288 wasted synthesis calls per
+    // day (one per heartbeat pulse). See issue #19.
     if (this._lastDigestDate === date) {
       return { skipped: true, date };
     }
@@ -73,23 +80,37 @@ class DailyDigest {
     const changeList    = wikiChanges.status  === 'fulfilled' ? wikiChanges.value  : [];
     const deckList      = deckActivity.status === 'fulfilled' ? deckActivity.value : [];
 
-    // Nothing to write
+    // Nothing to write — skip, but DO claim the date so we don't keep
+    // scanning activity sources every 5 minutes on quiet days.
     if (sessionList.length === 0 && changeList.length === 0 && deckList.length === 0) {
+      this._lastDigestDate = date;
       return { skipped: true, date, reason: 'no activity' };
     }
 
+    // Claim the date up-front so a downstream failure (LLM timeout, WebDAV
+    // 404, network glitch) cannot re-trigger the whole path on the next pulse.
+    this._lastDigestDate = date;
+
     const activity = { sessions: sessionList, wikiChanges: changeList, deckActions: deckList };
 
-    const narrative = await this._generateNarrative(date, activity);
-    const page      = this._buildPage(date, narrative, activity);
-    const pagePath  = `${EPISODE_PATH_PREFIX}/${date}`;
+    try {
+      const narrative = await this._generateNarrative(date, activity);
+      const page      = this._buildPage(date, narrative, activity);
+      const pagePath  = `${EPISODE_PATH_PREFIX}/${date}`;
 
-    await this.wiki.writePageContent(pagePath, page);
+      // Ensure the parent collection exists — Nextcloud WebDAV returns 404
+      // on PUT when the parent folder is missing, not 409.
+      if (typeof this.wiki.ensureDirectory === 'function') {
+        await this.wiki.ensureDirectory(EPISODE_PATH_PREFIX);
+      }
+      await this.wiki.writePageContent(pagePath, page);
 
-    this._lastDigestDate = date;
-    this.logger.info(`[DailyDigest] Episode written: ${pagePath}`);
-
-    return { written: true, date, path: pagePath };
+      this.logger.info(`[DailyDigest] Episode written: ${pagePath}`);
+      return { written: true, date, path: pagePath };
+    } catch (err) {
+      this.logger.warn(`[DailyDigest] Episode write failed for ${date}: ${err.message}`);
+      return { skipped: true, date, reason: `write failed: ${err.message}` };
+    }
   }
 
   /**

--- a/src/lib/memory/heartbeat-extractor.js
+++ b/src/lib/memory/heartbeat-extractor.js
@@ -139,7 +139,8 @@ Rules:
     const rawResponse = await this.router.route({
       job: 'synthesis',
       content: prompt,
-      requirements: { maxTokens: 500, format: MEMORY_SCHEMA }
+      requirements: { maxTokens: 500, format: MEMORY_SCHEMA },
+      context: { trigger: 'heartbeat_extract', internal: true }
     });
 
     const extracted = this._parseJson(rawResponse.result || rawResponse);

--- a/src/lib/memory/metadata-gardener.js
+++ b/src/lib/memory/metadata-gardener.js
@@ -217,7 +217,8 @@ Respond with ONLY the YAML key-value pairs (NO --- delimiters, no other text):`;
     const rawResponse = await this.router.route({
       job: 'quick',
       content: prompt,
-      requirements: { maxTokens: 300 }
+      requirements: { maxTokens: 300 },
+      context: { trigger: 'heartbeat_garden', internal: true }
     });
 
     const responseText = (rawResponse.result || rawResponse || '').toString().trim();

--- a/src/lib/services/email-monitor.js
+++ b/src/lib/services/email-monitor.js
@@ -381,7 +381,7 @@ Respond with JSON only:
         task: 'email_analyze',
         content: prompt,
         requirements: { role: 'free' },
-        context: { trigger: 'heartbeat_email' }
+        context: { trigger: 'heartbeat_email', internal: true }
       });
 
       let response = result.result || result.response || result;

--- a/test/unit/integrations/cockpit-self-measurement.test.js
+++ b/test/unit/integrations/cockpit-self-measurement.test.js
@@ -292,6 +292,201 @@ test('Internal calls are still buffered in CostTracker audit log', () => {
 
   assert.strictEqual(tracker._buffer.length, 1, 'audit entry still buffered');
   assert.strictEqual(tracker._buffer[0].job, 'heartbeat_garden');
+  assert.strictEqual(tracker._buffer[0].internal, true, 'internal flag persisted');
+});
+
+// ============================================================
+// displayCost / displayByJob split
+//
+// Internal calls still accumulate into `cost` and `byJob` (budget truth)
+// but are excluded from `displayCost` and `displayByJob` (card truth).
+// Without this split the Costs card flapped on every heartbeat as tiny
+// internal synthesis costs pushed the rounded EUR display up by €0.01.
+// ============================================================
+
+console.log('\n--- displayCost split ---\n');
+
+test('Internal cloud call: cost tracked, displayCost NOT tracked', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'synthesis',
+    trigger: 'heartbeat_digest',
+    inputTokens: 1000,
+    outputTokens: 500,
+    internal: true,
+  });
+
+  assert.ok(tracker.daily.cost > 0, 'total cost incremented (budget truth)');
+  assert.strictEqual(tracker.daily.displayCost, 0, 'displayCost NOT incremented');
+  assert.ok(tracker.monthly.cost > 0, 'total monthly cost incremented');
+  assert.strictEqual(tracker.monthly.displayCost, 0, 'displayCost monthly NOT incremented');
+});
+
+test('Normal cloud call: both cost and displayCost tracked', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'tools',
+    trigger: 'user_message',
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  assert.ok(tracker.daily.cost > 0);
+  assert.ok(tracker.daily.displayCost > 0);
+  assert.strictEqual(tracker.daily.cost, tracker.daily.displayCost,
+    'non-internal: cost === displayCost');
+});
+
+test('getTotals exposes both cost views', () => {
+  const tracker = new CostTracker();
+
+  // 1 external user call
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'tools',
+    trigger: 'user_message',
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  // 3 internal heartbeat calls
+  for (let i = 0; i < 3; i++) {
+    tracker.record({
+      model: 'claude-haiku-4-5-20251001',
+      job: 'synthesis',
+      trigger: 'heartbeat_digest',
+      inputTokens: 1000,
+      outputTokens: 500,
+      internal: true,
+    });
+  }
+
+  const totals = tracker.getTotals();
+
+  // Budget view includes all 4 calls
+  assert.ok(totals.daily.costUsd > 0);
+  assert.ok(totals.monthly.costUsd > 0);
+
+  // Display view only includes the 1 external call
+  assert.ok(totals.daily.displayCostUsd > 0);
+  assert.ok(totals.daily.displayCostEur > 0);
+  assert.ok(totals.monthly.displayCostUsd > 0);
+  assert.ok(totals.monthly.displayCostEur > 0);
+
+  // Budget total must be exactly 4x the display total (same per-call cost)
+  assert.strictEqual(
+    totals.daily.costUsd.toFixed(6),
+    (totals.daily.displayCostUsd * 4).toFixed(6),
+    'total cost = 4x display cost (1 external + 3 internal at same price)'
+  );
+});
+
+test('topSpending excludes internal jobs', () => {
+  const tracker = new CostTracker();
+
+  // 5 expensive internal synthesis calls
+  for (let i = 0; i < 5; i++) {
+    tracker.record({
+      model: 'claude-haiku-4-5-20251001',
+      job: 'synthesis',
+      trigger: 'heartbeat_digest',
+      inputTokens: 10000,
+      outputTokens: 5000,
+      internal: true,
+    });
+  }
+
+  // 1 cheap external tools call
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'tools',
+    trigger: 'user_message',
+    inputTokens: 100,
+    outputTokens: 50,
+  });
+
+  const totals = tracker.getTotals();
+
+  // Internal synthesis was 100x more expensive in total, but topSpending
+  // reads from displayByJob so it should rank `tools` (the only external job)
+  assert.strictEqual(totals.topSpending.length, 1,
+    'only the external job appears in topSpending');
+  assert.strictEqual(totals.topSpending[0].job, 'tools');
+});
+
+test('Idle pulse stability: displayCost frozen across internal calls', () => {
+  const tracker = new CostTracker();
+
+  // Baseline: 1 external call sets display state
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'tools',
+    trigger: 'user_message',
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  const baseline = {
+    displayCost: tracker.daily.displayCost,
+    cloudCalls: tracker.daily.cloudCalls,
+    displayByJob: { ...tracker.daily.displayByJob },
+  };
+
+  // Simulate 10 idle heartbeat pulses, each making an internal synthesis call
+  for (let i = 0; i < 10; i++) {
+    tracker.record({
+      model: 'claude-haiku-4-5-20251001',
+      job: 'synthesis',
+      trigger: 'heartbeat_digest',
+      inputTokens: 1142,
+      outputTokens: 140,
+      internal: true,
+    });
+  }
+
+  // Display state must be byte-for-byte identical to baseline —
+  // this is the property that keeps the Cockpit Costs card hash stable.
+  assert.strictEqual(tracker.daily.displayCost, baseline.displayCost,
+    'displayCost frozen across 10 idle pulses');
+  assert.strictEqual(tracker.daily.cloudCalls, baseline.cloudCalls);
+  assert.deepStrictEqual(tracker.daily.displayByJob, baseline.displayByJob,
+    'displayByJob frozen across 10 idle pulses');
+
+  // But the budget total MUST have moved (otherwise runaway internal usage
+  // would never trip the budget limit).
+  assert.ok(tracker.daily.cost > baseline.displayCost,
+    'total cost advanced past baseline (budget tracking preserved)');
+});
+
+test('Audit buffer persists internal flag for restore()', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'synthesis',
+    trigger: 'heartbeat_digest',
+    inputTokens: 1142,
+    outputTokens: 140,
+    internal: true,
+  });
+
+  tracker.record({
+    model: 'claude-haiku-4-5-20251001',
+    job: 'tools',
+    trigger: 'user_message',
+    inputTokens: 500,
+    outputTokens: 200,
+  });
+
+  assert.strictEqual(tracker._buffer.length, 2);
+  assert.strictEqual(tracker._buffer[0].internal, true,
+    'heartbeat call marked internal in audit buffer');
+  assert.strictEqual(tracker._buffer[1].internal, false,
+    'user call marked non-internal in audit buffer');
 });
 
 // ============================================================

--- a/test/unit/integrations/cockpit-self-measurement.test.js
+++ b/test/unit/integrations/cockpit-self-measurement.test.js
@@ -1,0 +1,299 @@
+/**
+ * Cockpit Self-Measurement Loop — Issue #19
+ *
+ * Verifies that internal heartbeat LLM calls do not increment the counters
+ * that feed Status cards (Health, Model Usage, Costs). The observer must
+ * not change the observed.
+ *
+ * Run: node test/unit/integrations/cockpit-self-measurement.test.js
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Moltagent
+ */
+
+const assert = require('assert');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const LLMRouter = require('../../../src/lib/llm/router');
+const CostTracker = require('../../../src/lib/llm/cost-tracker');
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function createMockProvider(overrides = {}) {
+  return {
+    type: overrides.type || 'remote',
+    id: overrides.id || 'mock-provider',
+    generate: overrides.generate || (async () => ({
+      result: 'Mock response',
+      model: 'mock-model',
+      tokens: 150,
+      inputTokens: 50,
+      outputTokens: 100,
+      cost: 0.001,
+      duration: 500,
+      headers: {}
+    })),
+    estimateTokens: () => 100,
+    estimateCost: () => 0.001,
+    testConnection: async () => ({ connected: true })
+  };
+}
+
+function createWiredRouter() {
+  const costTracker = new CostTracker();
+  const router = new LLMRouter({
+    roles: { value: ['mock-provider'] }
+  });
+  router.providers.set('mock-provider', createMockProvider());
+  router.costTracker = costTracker;
+  return { router, costTracker };
+}
+
+console.log('\n=== Cockpit Self-Measurement Loop Tests ===\n');
+
+// ============================================================
+// Router: internal flag excludes from stats
+// ============================================================
+
+console.log('\n--- Router internal flag ---\n');
+
+asyncTest('Internal route call does NOT increment totalCalls', async () => {
+  const { router } = createWiredRouter();
+
+  await router.route({
+    task: 'test',
+    content: 'heartbeat housekeeping',
+    context: { trigger: 'heartbeat_extract', internal: true }
+  });
+
+  assert.strictEqual(router.stats.totalCalls, 0);
+  assert.strictEqual(router.stats.successfulCalls, 0);
+  assert.deepStrictEqual(router.stats.byProvider, {});
+});
+
+asyncTest('Normal route call still increments totalCalls', async () => {
+  const { router } = createWiredRouter();
+
+  await router.route({
+    task: 'test',
+    content: 'user message',
+    context: { trigger: 'user_message' }
+  });
+
+  assert.strictEqual(router.stats.totalCalls, 1);
+  assert.strictEqual(router.stats.successfulCalls, 1);
+  assert.strictEqual(router.stats.byProvider['mock-provider'], 1);
+});
+
+asyncTest('Mixed internal + normal calls: only normal counted', async () => {
+  const { router } = createWiredRouter();
+
+  // 2 internal calls
+  await router.route({ task: 'a', content: 'x', context: { internal: true } });
+  await router.route({ task: 'b', content: 'y', context: { internal: true } });
+
+  // 1 normal call
+  await router.route({ task: 'c', content: 'z' });
+
+  assert.strictEqual(router.stats.totalCalls, 1);
+  assert.strictEqual(router.stats.successfulCalls, 1);
+  assert.strictEqual(router.stats.byProvider['mock-provider'], 1);
+});
+
+// ============================================================
+// CostTracker: internal flag excludes call counts, keeps cost
+// ============================================================
+
+console.log('\n--- CostTracker internal flag ---\n');
+
+test('Internal cloud call excluded from call count but cost still tracked', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'claude-sonnet-4-20250514',
+    job: 'heartbeat_extract',
+    trigger: 'heartbeat_extract',
+    inputTokens: 1000,
+    outputTokens: 500,
+    internal: true,
+  });
+
+  const totals = tracker.getTotals();
+  assert.strictEqual(totals.daily.cloudCalls, 0, 'cloud call count should be 0');
+  assert.strictEqual(totals.monthly.cloudCalls, 0, 'monthly cloud call count should be 0');
+  assert.ok(totals.daily.costUsd > 0, 'cost should still be tracked');
+});
+
+test('Internal local call excluded from call count', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'qwen2.5:3b',
+    job: 'heartbeat_garden',
+    trigger: 'heartbeat_garden',
+    inputTokens: 500,
+    outputTokens: 200,
+    isLocal: true,
+    internal: true,
+  });
+
+  const totals = tracker.getTotals();
+  assert.strictEqual(totals.daily.localCalls, 0, 'local call count should be 0');
+  assert.strictEqual(totals.monthly.localCalls, 0, 'monthly local call count should be 0');
+});
+
+test('Normal call still counted in CostTracker', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'claude-sonnet-4-20250514',
+    job: 'thinking',
+    trigger: 'user_message',
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  const totals = tracker.getTotals();
+  assert.strictEqual(totals.daily.cloudCalls, 1);
+  assert.strictEqual(totals.monthly.cloudCalls, 1);
+});
+
+test('Mixed internal + normal: only normal counted in CostTracker', () => {
+  const tracker = new CostTracker();
+
+  // 3 internal calls (simulating 3 heartbeat pulses)
+  for (let i = 0; i < 3; i++) {
+    tracker.record({
+      model: 'qwen2.5:3b',
+      job: 'heartbeat_garden',
+      trigger: 'heartbeat_garden',
+      inputTokens: 500,
+      outputTokens: 200,
+      isLocal: true,
+      internal: true,
+    });
+  }
+
+  // 1 normal call
+  tracker.record({
+    model: 'claude-sonnet-4-20250514',
+    job: 'thinking',
+    trigger: 'user_message',
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  const totals = tracker.getTotals();
+  assert.strictEqual(totals.daily.localCalls, 0, 'internal local calls not counted');
+  assert.strictEqual(totals.daily.cloudCalls, 1, 'only the user call counted');
+});
+
+// ============================================================
+// End-to-end: internal flag flows from router to CostTracker
+// ============================================================
+
+console.log('\n--- End-to-end: router → CostTracker propagation ---\n');
+
+asyncTest('Internal flag propagates from router context to CostTracker', async () => {
+  const { router, costTracker } = createWiredRouter();
+
+  // Internal call
+  await router.route({
+    task: 'extract',
+    content: 'heartbeat housekeeping',
+    context: { trigger: 'heartbeat_extract', internal: true }
+  });
+
+  const totals = costTracker.getTotals();
+  assert.strictEqual(totals.daily.cloudCalls, 0, 'internal call not counted in CostTracker');
+  assert.strictEqual(router.stats.totalCalls, 0, 'internal call not counted in router');
+});
+
+asyncTest('Consecutive idle pulses produce stable counter values', async () => {
+  const { router, costTracker } = createWiredRouter();
+
+  // Simulate one real user message first
+  await router.route({ task: 'chat', content: 'Hello', context: { trigger: 'user_message' } });
+
+  // Snapshot counters
+  const snapshot = {
+    totalCalls: router.stats.totalCalls,
+    successfulCalls: router.stats.successfulCalls,
+    byProvider: { ...router.stats.byProvider },
+    cloudCalls: costTracker.getTotals().daily.cloudCalls,
+  };
+
+  // Simulate 3 idle heartbeat pulses, each making an internal LLM call
+  for (let pulse = 0; pulse < 3; pulse++) {
+    await router.route({
+      task: 'heartbeat_work',
+      content: `pulse ${pulse}`,
+      context: { trigger: 'heartbeat_extract', internal: true }
+    });
+  }
+
+  // Counters must be unchanged
+  assert.strictEqual(router.stats.totalCalls, snapshot.totalCalls,
+    'totalCalls unchanged after 3 idle pulses');
+  assert.strictEqual(router.stats.successfulCalls, snapshot.successfulCalls,
+    'successfulCalls unchanged after 3 idle pulses');
+  assert.strictEqual(router.stats.byProvider['mock-provider'], snapshot.byProvider['mock-provider'],
+    'byProvider unchanged after 3 idle pulses');
+  assert.strictEqual(costTracker.getTotals().daily.cloudCalls, snapshot.cloudCalls,
+    'CostTracker cloudCalls unchanged after 3 idle pulses');
+});
+
+// ============================================================
+// recordOutcome: internal flag support
+// ============================================================
+
+console.log('\n--- recordOutcome internal flag ---\n');
+
+test('recordOutcome with internal flag skips stats', () => {
+  const router = new LLMRouter();
+  router.providers.set('mock-provider', createMockProvider());
+
+  router.recordOutcome('mock-provider', { success: true, internal: true });
+
+  assert.strictEqual(router.stats.successfulCalls, 0);
+  assert.deepStrictEqual(router.stats.byProvider, {});
+});
+
+test('recordOutcome without internal flag tracks stats', () => {
+  const router = new LLMRouter();
+  router.providers.set('mock-provider', createMockProvider());
+
+  router.recordOutcome('mock-provider', { success: true });
+
+  assert.strictEqual(router.stats.successfulCalls, 1);
+  assert.strictEqual(router.stats.byProvider['mock-provider'], 1);
+});
+
+// ============================================================
+// Audit buffer: internal calls still logged for traceability
+// ============================================================
+
+console.log('\n--- Audit buffer ---\n');
+
+test('Internal calls are still buffered in CostTracker audit log', () => {
+  const tracker = new CostTracker();
+
+  tracker.record({
+    model: 'qwen2.5:3b',
+    job: 'heartbeat_garden',
+    trigger: 'heartbeat_garden',
+    inputTokens: 500,
+    outputTokens: 200,
+    isLocal: true,
+    internal: true,
+  });
+
+  assert.strictEqual(tracker._buffer.length, 1, 'audit entry still buffered');
+  assert.strictEqual(tracker._buffer[0].job, 'heartbeat_garden');
+});
+
+// ============================================================
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Summary

Rolls up three sessions of fixes and hardening across Deck workflow safety, cockpit observability, and cost tracking.

### Issues fixed

- **#13** — PAUSED fail-safe: unresolvable rules card → treat board as PAUSED (not silently skip)
- **#14** — Board map injection: `<deck_boards>` block in enricher context so the LLM resolves board names — zero string matching
- **#17** — PAUSED structural guard: `DeckClient._isStackPaused()` blocks card creation in PAUSED stacks across ALL codepaths, ToolRegistry routed through `createCardOnBoard()`
- **#18** — Cockpit hash cache: SHA-256 content hash before card PUTs — skip unchanged writes. Health latency rounded to 50 ms buckets, Costs timestamp to 15 min buckets
- **#19** — CostTracker split into `displayCostEur` (card truth) vs `budgetCostEur` (budget truth); DailyDigest retry storm fixed (288 → 1 call/day, ~€12/month Haiku savings); heartbeat-internal LLM calls excluded from cockpit counters

### Other changes

- `CollectivesClient.ensureDirectory()` generic helper for wiki parent-dir creation
- Branding rename MoltAgent → Moltagent across codebase
- Models card config section newline accumulation fix
- Cockpit status writes throttled to every 3rd heartbeat
- Architecture hero image + README polish
- 6 new tests for cockpit self-measurement (18/18 total), test mock updates
- `.gitignore` cleanup (runtime data, pycache)

### Stats

- 230 files changed, +2 413 / −1 977 lines
- 19 commits

## Test plan

- [x] `node scripts/run-all-tests.js` — 222 tests pass
- [x] Verify cockpit cards stabilize (no flapping Costs timestamp)
- [x] Confirm DailyDigest writes Episode page on first attempt
- [x] PAUSED board blocks card creation across all entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: moltagent github@moltagent.cloud