### PR TITLE
feat: Claude Code foundation + verification hook

### DIFF
--- a/.claude/hooks/verify-built.sh
+++ b/.claude/hooks/verify-built.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# .claude/hooks/verify-built.sh
+# Enforces Moltagent principle: BUILT ≠ VERIFIED.
+# Blocks Stop if no [VERIFIED: ...] tag is present in the final assistant message.
+# See moltagent-dev-rules.md § Verification Gate.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Loop prevention: if we've already blocked once this session, allow stop
+# to avoid thrashing. Fu can re-invoke manually if verification is still missing.
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# Extract the final assistant message. Try a direct field first; fall back to
+# the session transcript if the direct field is empty or absent.
+LAST_MESSAGE=$(echo "$INPUT" | jq -r '.last_assistant_message // ""')
+
+if [ -z "$LAST_MESSAGE" ]; then
+  TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
+  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    # Transcript is JSONL. Slurp it, take the last assistant message, extract text.
+    # Handles both top-level .role and nested .message.role; handles content as
+    # string or as an array of {type:"text", text:"..."} blocks.
+    LAST_MESSAGE=$(jq -rs '
+      [.[] | select((.role // .message.role // "") == "assistant")]
+      | if length == 0 then "" else .[-1] end
+      | (.message.content // .content // "")
+      | if type == "string" then .
+        elif type == "array" then [.[] | select(.type == "text") | .text] | join(" ")
+        else "" end
+    ' "$TRANSCRIPT_PATH" 2>/dev/null || echo "")
+  fi
+fi
+
+# If we still have no message to check, fail open rather than blocking on an
+# environment issue. A session that never produced an assistant message has
+# nothing meaningful to verify anyway.
+if [ -z "$LAST_MESSAGE" ]; then
+  exit 0
+fi
+
+# Check for the marker
+if echo "$LAST_MESSAGE" | grep -q '\[VERIFIED:'; then
+  exit 0
+fi
+
+# No marker — block Stop with specific counter-action guidance
+cat >&2 <<'EOF'
+STOP BLOCKED: BUILT ≠ VERIFIED
+
+Your final message does not contain a [VERIFIED: ...] tag.
+
+Per moltagent-dev-rules.md § Verification Gate:
+- A feature is only complete after confirmed production behavior.
+- Green tests can mask silent runtime failures (demonstrated twice with
+  WikiSteward: 220/220 passing, constructor path null at runtime).
+- Live verification queries are mandatory, not optional.
+
+Required before Stop:
+  1. Run each command listed in the briefing's "Verification Gate" section.
+  2. Capture the real output (not assumed output).
+  3. Include a [VERIFIED: <one-line summary of what you ran + key observed result>]
+     line somewhere in your response.
+
+Example:
+  [VERIFIED: npm run lint -> exit 0, no warnings. npm test -> 47/47 passed.
+   Branch feat/cc-foundation pushed to origin. PR #NN opened against next.
+   Hook script tested with all three input cases: block, allow, loop-prevent.]
+
+If verification reveals the fix does not work in production, say so explicitly
+and return to systematic debugging — do not declare done.
+
+For a session with no code changes (pure discussion, planning, reading):
+  [VERIFIED: no code changes in this session]
+
+Continue the session with verification now.
+EOF
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,30 +21,6 @@
           }
         ]
       }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node .claude/hooks/check-anti-patterns.js $FILE_PATH",
-            "description": "Check for natural language anti-patterns in code"
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash(rm *)|Bash(sudo rm *)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '⚠️ Destructive command detected. Confirm intent.'",
-            "description": "Warn before destructive bash commands"
-          }
-        ]
-      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,10 +4,24 @@
       "Bash(git push * main)",
       "Bash(git push origin main)",
       "Bash(git push --force *)",
-      "Bash(rm -rf *)"
+      "Bash(rm -rf:*)",
+      "Write(.env)",
+      "Write(.env.*)",
+      "Read(.env)",
+      "Read(.env.*)"
     ]
   },
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-built.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/skills/moltagent-dev-rules/SKILL.md
+++ b/.claude/skills/moltagent-dev-rules/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: moltagent-dev-rules
+description: Moltagent's non-negotiable development rules and Verification Gate convention. This project is LLM-native; conventional coding instincts produce the wrong solutions. Apply whenever touching code that handles natural language, classification, intent detection, keyword extraction, multilingual behavior, trust boundaries, LLM routing, or when adding new features. Load PROACTIVELY at the start of any coding task. The 8-rule checklist and the Verification Gate at the end together form the final gate before committing code or declaring a session done.
+---
+
 # Moltagent Development Rules
 
 **Read this before writing ANY code. These rules are non-negotiable.**

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: systematic-debugging
+description: Systemic-before-reductionist diagnosis. Apply whenever a bug is reported, a test fails, a log line looks wrong, or code is being added in response to something breaking. The first question is always what CLASS of problem this is, not how to make this specific instance work. Two instances of the same pattern = stop patching, find the generating function. Load PROACTIVELY at the start of any bug investigation, failure analysis, or debugging session.
+---
+
+# Systematic Debugging
+
+## The first question is never "how do I fix this"
+
+It is: **what class of problem is this, and what generates that class?**
+
+When a failure appears, resist the immediate pull toward "change this line." The right fix at the right altitude replaces five fixes at the wrong altitude. "Less code, not more" is not an aesthetic preference — it is a signal that the fix is structural rather than incidental.
+
+## The diagnostic sequence
+
+1. **Gather evidence before hypothesis.** Read the actual log lines. Read the actual failing test. Read the actual file involved. Do not synthesize an explanation from partial reads — the pattern-matching instinct will fabricate a plausible story that is not what is happening.
+
+2. **State the observed behavior as behavior, not judgment.** Not "the code is wrong" — "the function returns X when inputs are Y." Behavior is falsifiable. Judgment is not.
+
+3. **Ask: is this an instance, or a generator?**
+   - *Instance:* this specific call, this specific input, this specific edge case.
+   - *Generator:* the structural reason this class of failure is possible at all.
+   - If two bugs in different places turned out to share a root cause, the generator is that shared root.
+
+4. **Is this regex for intelligence?** A failure often leads to "just add a check for X." If X is natural language, keyword detection, or post-classifier override, the fix is at the wrong altitude. Strengthen the LLM component instead — better prompt, better examples, better model. See moltagent-dev-rules skill.
+
+5. **BUILT ≠ VERIFIED.** Green tests can mask silent runtime failures. After any fix, produce evidence from real production behavior — a log line showing the new path executed, a query against the live system, an observable state change. Tests confirm the fix doesn't regress. Production evidence confirms it actually runs. The Verification Gate in moltagent-dev-rules.md and the Stop hook that enforces it exist precisely to prevent green-test rationalization.
+
+6. **Commit size is a signal.** If a fix adds more lines than it removes, question the altitude. Sometimes additive is correct. Often it is patching an instance while the generator continues to produce new instances.
+
+## Generator-level fixes — examples from the issue tracker
+
+- **Two independent PAUSED readers returning different results** → consolidate to one canonical reader. (Issue #23 closed the generator that produced #22.)
+- **Stop-word list growing to handle German and Portuguese** → replace the stop-word approach with LLM-based keyword extraction.
+- **Post-classify guard overriding the LLM** → fix the classifier prompt, remove the guard.
+- **DEEP_READ Meta filter running before the observation generator** → reorder so the generator sees everything; the filter applies only to the user-facing response. (Issue #29.)
+- **WikiSteward conflating "no retrieval traffic" with "not useful"** → disambiguate the signal, either by type-aware logic, explicit pinning, or an additional write site. (Issue #30 captures all three options in-situ.)
+
+## The anti-pattern: instance patching
+
+Symptoms:
+- Each new language, edge case, or input class requires a new code change.
+- The function grows branches instead of responsibility shrinking.
+- The fix works on the reported case but you can list five others that would trigger the same class.
+
+If any of these hold, stop. Write down what the generator is. Propose the generator-level fix. Compare scope. Decide explicitly whether to fix the generator now, fix the instance now with a generator-level follow-up issue filed, or revise scope.
+
+## Zoom sequence: 50% analysis, 50% synthesis
+
+- **Zoom in:** what exactly happens in this case? Get the evidence from logs, tests, live queries.
+- **Zoom out:** what other cases would produce the same symptom? What is the shared structure?
+- **Synthesize:** where does the fix belong — at the symptom site, or upstream at the generator?
+
+Both modes matter. Neither alone is sufficient. Reductionist thinking produces instance patches; holistic thinking without evidence produces architectural astronautics. The target is the interplay, not either pole.
+
+## When an instance patch is genuinely correct
+
+Sometimes the generator-level fix is out of scope for the session, or the structural work is too large for the current window. That is fine. But in that case:
+
+- Document the generator in the commit message or in a linked GitHub issue.
+- Label the instance patch explicitly ("instance patch for #NN; generator-level fix tracked as #MM").
+- Do not let the instance patch pretend to be a resolution. It closes the symptom, not the class.
+
+## The final diagnostic gate
+
+Before declaring a diagnostic done:
+
+1. Is the evidence from real production, not just from tests?
+2. Have I named the generating function, not just the instance?
+3. If I fix only this instance, will three more instances appear from the same generator within the next week?
+4. Is my fix at the altitude of the generator, or at the altitude of the instance? Was that choice explicit?
+5. Is my `[VERIFIED: ...]` marker concrete — naming the command I ran and the observed result — rather than vague?
+
+If any answer is uncertain, the diagnostic is not done.
+
+## Cross-reference
+
+- The eight-rule checklist in the moltagent-dev-rules skill is the final gate *before committing code*.
+- The Verification Gate in the same skill is the final gate *before declaring a session done*.
+- This skill is the diagnostic gate *before deciding what code to write*.
+- All three apply, in that order.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,67 +1,63 @@
-# CLAUDE.md — Moltagent
+# Moltagent — Claude Code Context
 
-# CRITICAL — Read These First
-- No regex for intelligence. LLM is the language layer.
-- Run production verification before marking complete.
-- Push to `next` branch only. Never `main`.
+**Project:** Moltagent — sovereign AI agent platform on Nextcloud.  
+**Language:** Node.js (>= 18), JavaScript. Multilingual by default: DE / EN / PT.  
+**License:** AGPL-3.0.
 
-## Project
+## Repo layout
 
-Moltagent (lowercase 'a', never "MoltAgent") is a sovereign AI agent platform built on Nextcloud. Node.js codebase, AGPL-3.0. Entry point: `webhook-server.js`. ~35 modules, ~27,000 lines.
-
-## Architecture in One Sentence
-
-The LLM handles understanding. Code handles plumbing. When in doubt, it's understanding → use the LLM.
+- `src/` — product code
+- `test/` — unit and integration tests
+- `scripts/` — ops and setup
+- `config/` — runtime configuration, including `SOUL.md` and `system-prompt.md` (the agent's behavioral layer)
+- `ansible/`, `deploy/` — infrastructure
+- `webhook-server.js` — entry point (large; a split is overdue, out of scope for most sessions)
 
 ## Commands
 
-    sudo systemctl start moltagent
-    journalctl -u moltagent -f --no-pager
-    npm test
-    npm run lint
-    sudo systemctl status moltagent
+- `npm run lint` — ESLint (`--fix` to auto-correct)
+- `npm test` — all tests
+- `npm run test:unit` | `test:integration` | `test:llm` | `test:deck` — narrower scopes
+- `npm run setup` — Deck board setup (one-off)
 
-## Git Workflow
+After every substantial edit, run `npm run lint`. Before declaring a task done, run the appropriate test scope. Before declaring a session done, produce a `[VERIFIED: ...]` marker per the Verification Gate (see moltagent-dev-rules.md).
 
-- Work on `next`. PRs: `next → main`. (Pushes to `main` blocked by deny list.)
-- SSH commit signing with `~/.ssh/id_ed25519_signing`.
-- Co-authored-by: `moltagent <github@moltagent.cloud>`.
-- Commit messages: imperative, descriptive — describe what changed and why.
+## Git workflow
 
-## The Three Non-Negotiable Rules
+- All work lands on feature branches off `next`.
+- PRs merge into `next`. `next` periodically promotes to `main`.
+- Commit email: `github@moltagent.cloud`
+- Signing key: SSH, `~/.ssh/id_ed25519_signing`
+- Co-authored-by: `moltagent <github@moltagent.cloud>`
 
-**1. LLM is the language layer.** Never write Sets, Arrays, or Maps of natural language words. No stop word lists. No keyword matching on user input. No regex on natural language. If the code would need to change when adding a new language → use the LLM instead. qwen2.5:3b runs locally in 100ms for free.
+## The two behavioral layers — know which one applies
 
-**2. Fix the prompt, not the code around it.** When the LLM produces wrong output: fix the prompt, add multilingual examples, use a better model. Do NOT add post-classify guards that override the LLM in code. The only acceptable post-classify guard is structural validation (invalid gate name → fallback to default).
+This repo contains two parallel behavioral-instruction documents. They serve different systems and are often confused. Choose correctly before editing.
 
-**3. Multilingual from day one.** Every feature must work in German, English, and Portuguese. All LLM prompts include DE + PT examples. No language-specific code paths. No hardcoded day/month names.
+1. **This file (`CLAUDE.md`)** — instructions for Claude Code (the developer tool). How to work on the codebase: commands, rules, conventions, workflow.
+2. **`config/SOUL.md`** and **`config/system-prompt.md`** — instructions for the *Moltagent agent itself* (the product). How the agent responds to users, how it handles knowledge gaps, how it reports tool results, how it integrates memory.
 
-## Before Every Commit
+When the user reports that the agent is behaving incorrectly — hallucinating roles, overconfident under sparse data, misusing tools, wrong tone — the fix almost always belongs in SOUL.md, not in code. This is Rule 7 (Prompt Updates, Not Code Guards) applied to the agent's own behavior: when an LLM-based system produces wrong output, fix the prompt before reaching for a code guard. Read SOUL.md first when a behavior bug is reported. Most of the time the answer is already there or belongs there.
 
-- Did I create a Set/Array of natural language words? → Use LLM
-- Does this only work in English? → Add DE/PT or use LLM
-- Does this commit add more lines than it removes? → Question the altitude
-- Am I compensating for an LLM weakness with code? → Strengthen the LLM
+## Non-negotiable rules (short form — full rules auto-load via skill)
 
-## Key Architecture
+1. **The LLM is the language layer.** Never write code containing word lists, stop words, or regex matching natural language. If code would need to change when we add a new language, it's wrong.
+2. **Analysis before fix.** What class of problem is this? What generates it? Fix the generator, not the instance. Two instances of the same pattern = stop patching.
+3. **Trust boundary is the single control.** `trust: local-only` vs `cloud-ok` governs every cloud-touching decision. No per-component overrides.
+4. **BUILT ≠ VERIFIED.** Features are only complete after confirmed production behavior. Green tests are necessary but not sufficient. The Stop hook enforces this — every session must end with a `[VERIFIED: ...]` marker. See moltagent-dev-rules.md § Verification Gate.
+5. **PAUSED always wins.** State-enforcing labels override scheduled actions. Guards belong where the pipe narrows.
 
-- **Trust boundary:** `trust: local-only` or `trust: cloud-ok` — one setting, respected everywhere. Never hardcode `role: 'sovereign'` or `forceLocal: true`.
-- **Four-gate classifier:** KNOWLEDGE (default), ACTION, COMPOUND, THINKING. Knowledge is default. Thinking is the rare exception.
-- **Model routing:** Jobs & Players v3. Each job has a roster chain per trust level. Synthesis: Haiku → qwen3:8b. Thinking: Opus. Credentials: always local.
+The full rule set — with examples, counterexamples, the architecture table, the Verification Gate convention, and the pre-commit anti-pattern checklist — is at `moltagent-dev-rules.md`. The same content is exposed as a skill at `.claude/skills/moltagent-dev-rules/SKILL.md` and auto-loads whenever you touch code that handles natural language, classification, intent detection, LLM routing, trust boundaries, or when adding new features. When the skill loads, read it. It is authoritative.
 
-## Compaction
+## Operating discipline
 
-When compacting, always preserve:
-- The current briefing objectives
-- All file paths modified in this session
-- Board/config facts (board IDs, stack names, config paths)
-- Any "generating function" or systemic analysis from this session
+- **Search the codebase before assuming structure.** Never guess file paths, function names, or API shapes. Read before writing.
+- **Run the pre-commit checklist** (Rule 8 in the dev-rules skill) before any commit.
+- **Run the Verification Gate** (section in moltagent-dev-rules.md) before declaring a session done. The Stop hook will block you if you forget the marker.
+- **Use GitHub issues** for anything not in scope for the current briefing. Don't silently expand scope.
+- **Zoom out before patching.** Two instances of the same pattern = find the generator.
+- **Small commits over large ones.** If a commit adds more lines than it removes, question whether the altitude is right.
 
-## Dev Rules
+## Architecture partnership
 
-Read `.moltagent-dev-rules.md` at repo root before coding. Full anti-pattern checklist and decision tables. This file is the condensed version.
-
-# CRITICAL — Read These Last
-- No regex for intelligence. LLM is the language layer.
-- Run production verification before marking complete.
-- Push to `next` branch only. Never `main`.
+Claude (claude.ai, Opus 4.7) operates as the architectural and strategic reasoning layer above CC. CC implements from structured briefings (typically 15–25 KB). Claude synthesizes, diagnoses, and plans at the generator level; CC executes at the instance level with skills loaded for domain grounding. This is the division of labor. Don't try to do both at once in one session.


### PR DESCRIPTION
## Summary

- Adds ambient `CLAUDE.md` at repo root with project context, commands, non-negotiable rules, and operating discipline for every CC session
- Creates two skills: `moltagent-dev-rules` (full rule set auto-loads on code tasks) and `systematic-debugging` (diagnostic discipline for bug investigations)
- Adds Stop hook (`.claude/hooks/verify-built.sh`) that mechanically enforces the BUILT ≠ VERIFIED principle — blocks session end without a `[VERIFIED: ...]` marker
- Updates `.claude/settings.json` with deny list (.env protection, rm -rf, force push, push to main) and Stop hook registration
- Amends `moltagent-dev-rules.md` with the Verification Gate convention section

## Motivation

Closes the rationalization loophole demonstrated twice with WikiSteward, where 220/220 tests passed while the constructor path was null in production. The Stop hook makes verification mechanical at the single chokepoint rather than depending on soft guidance under context pressure.

## Test plan

- [x] Hook executable: `-rwxr-xr-x`
- [x] Hook blocks when `[VERIFIED:]` marker absent (exit=2, block message on stderr)
- [x] Hook allows when marker present (exit=0, no output)
- [x] Hook loop-prevention: allows when `stop_hook_active=true`
- [x] Hook fail-open: exits 0 when no message available
- [x] `settings.json` Stop hook registration present
- [x] Deny list includes `.env` protection
- [x] Dev-rules amendment contains "Verification Gate" (4 occurrences)
- [x] Skill file mirrors amended dev-rules (zero diff)
- [x] `npm run lint` → 0 errors
- [x] `npm test` → 220/220 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope note

This PR's briefing scoped the session to Phase 1 only: the Stop hook (BUILT ≠ VERIFIED) and the foundational CLAUDE.md + skills + deny list. PreToolUse and PostToolUse hooks were declared anti-goals.

The initial implementation exceeded that scope — adding a PostToolUse anti-pattern detector (`check-anti-patterns.js`), a PreToolUse destructive-command warning, and three additional deny entries protecting `main`. The script was unbriefed and untested end-to-end. Additionally, the detector's heuristic uses a hardcoded Latin+DE+PT character class to identify "natural language words," which is itself the Rule 1 anti-pattern the script is meant to enforce — tooling that enforces an LLM-native architecture must itself respect LLM-native constraints.

Corrections applied before merge:

- Stripped PostToolUse and PreToolUse hook blocks from `.claude/settings.json` (registration out of scope for this PR)
- Retained `check-anti-patterns.js` in tree as Phase 2 specimen/prior art (see #32)
- Retained the three git-push deny entries (within the spirit of the deny list, caught a real gap)

The scope violation is the reason for this note. The Stop hook in this PR exists to mechanically enforce BUILT ≠ VERIFIED, closing the rationalization loophole demonstrated twice with WikiSteward. Letting silent scope expansion land in the same PR as that hook would normalize the pattern the hook was built to close. The correction keeps the principle consistent with the mechanism.