### PR TITLE
fix(noise-floor): eliminate recurring 403/404/500 from expected operations

### DIFF
--- a/src/lib/clients/self-heal-client.js
+++ b/src/lib/clients/self-heal-client.js
@@ -23,17 +23,37 @@ class SelfHealClient {
     this.timeoutMs = timeoutMs || 15000;
     this.credentialBroker = credentialBroker;
     this._token = null;
+    /** @type {Error|null} Permanent failure (e.g. credential never existed) — once set, further work is refused. See #26. */
+    this._permanentFailure = null;
+  }
+
+  /**
+   * False once a permanent failure has been latched (e.g. credential not
+   * found in NC Passwords). InfraMonitor and other callers should check
+   * this before attempting restart() so they do not log a failed-restart
+   * warning on every probe cycle.
+   * @returns {boolean}
+   */
+  get isAvailable() {
+    return !this._permanentFailure;
   }
 
   /**
    * Fetch bearer token from credential broker (cached after first call).
+   * If the credential is missing, the failure is latched on this.
    * @returns {Promise<string>}
    * @private
    */
   async _getToken() {
+    if (this._permanentFailure) throw this._permanentFailure;
     if (this._token) return this._token;
     const token = await this.credentialBroker.get(this.tokenCredential);
-    if (!token) throw new Error(`Credential "${this.tokenCredential}" not found in broker`);
+    if (!token) {
+      const err = new Error(`Credential "${this.tokenCredential}" not found in broker`);
+      this._permanentFailure = err;
+      console.warn(`[SelfHealClient] Disabled: ${err.message}. Remote self-heal will not be attempted this session.`);
+      throw err;
+    }
     this._token = token;
     return this._token;
   }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -560,7 +560,12 @@ const config = {
     selfHealEnabled: envBool('INFRA_SELF_HEAL', true),
     notifyOnFailure: envBool('INFRA_NOTIFY_ON_FAILURE', true),
     heald: {
+      // Default is the placeholder sentinel. Downstream (webhook-server.js)
+      // treats this sentinel as "heald not deployed" and skips SelfHealClient
+      // construction so we don't log a credential-missing error every probe.
+      // See #26.
       url: envStr('HEALD_URL', 'http://YOUR_OLLAMA_IP:7867'),
+      urlPlaceholder: 'http://YOUR_OLLAMA_IP:7867',
       tokenCredential: envStr('HEALD_TOKEN_CREDENTIAL', 'heald-token'),
       timeoutMs: envInt('HEALD_TIMEOUT', 15000),
     },

--- a/src/lib/integrations/bot-enroller.js
+++ b/src/lib/integrations/bot-enroller.js
@@ -52,7 +52,7 @@ class BotEnroller {
     this.botName = opts.botName || opts.config?.botName || 'Moltagent';
     this.auditLog = opts.auditLog || null;
 
-    /** @type {number|null} Resolved on first run via admin or per-room discovery */
+    /** @type {number|null} Resolved on first run via per-room discovery */
     this._botId = null;
 
     /** @type {Set<string>} Room tokens we have already enrolled (this session) */
@@ -104,7 +104,7 @@ class BotEnroller {
    * @returns {Promise<Object>} Results object with checked, enrolled, skipped, errors
    */
   async enrollAll() {
-    // 1. Resolve our bot ID (once per session)
+    // 1. Resolve our bot ID (once per session, or keep retrying if still null)
     if (!this._botId) {
       try {
         await this._resolveBotId();
@@ -175,35 +175,17 @@ class BotEnroller {
   }
 
   /**
-   * Resolve our bot's numeric ID from the admin endpoint.
-   * Falls back to per-room discovery if admin access is unavailable.
+   * Resolve our bot's numeric ID via per-room discovery.
+   *
+   * The admin endpoint (`/bot/admin`) is deliberately NOT attempted — the
+   * moltagent NC user is not in the admin group by design (the agent should
+   * not have site-admin rights). The admin attempt produced a 403 on every
+   * heartbeat, ~282/day of noise. See issue #26.
    *
    * @returns {Promise<void>}
    * @private
    */
   async _resolveBotId() {
-    // Try admin endpoint first
-    try {
-      const response = await this.nc.request(
-        '/ocs/v2.php/apps/spreed/api/v1/bot/admin',
-        {
-          method: 'GET',
-          headers: { 'OCS-APIRequest': 'true', 'Accept': 'application/json' }
-        }
-      );
-      const data = response.body?.ocs?.data || [];
-      const bot = data.find(b => b.name === this.botName);
-      if (bot) {
-        this._botId = bot.id;
-        console.log(`[BotEnroller] Resolved bot ID: ${this._botId} (${this.botName})`);
-        return;
-      }
-    } catch (err) {
-      // Not admin -- expected; fall through to per-room discovery
-      console.warn(`[BotEnroller] Admin bot list unavailable: ${err.message}`);
-    }
-
-    // Fallback: try to discover bot ID from rooms we are in
     try {
       const rooms = await this._listRooms();
       for (const room of rooms) {
@@ -211,10 +193,10 @@ class BotEnroller {
         if (discovered) return;
       }
     } catch {
-      // Could not list rooms either
+      // Could not list rooms
     }
 
-    console.warn('[BotEnroller] Could not resolve bot ID -- enrollment disabled');
+    console.warn('[BotEnroller] Could not resolve bot ID -- enrollment disabled for this session');
   }
 
   /**

--- a/src/lib/integrations/bot-enroller.js
+++ b/src/lib/integrations/bot-enroller.js
@@ -55,6 +55,9 @@ class BotEnroller {
     /** @type {number|null} Resolved on first run via per-room discovery */
     this._botId = null;
 
+    /** @type {boolean} Have we already logged the "unresolved" warn? Prevents repeating it every heartbeat. Cleared if resolution later succeeds. See #26. */
+    this._warnedUnresolved = false;
+
     /** @type {Set<string>} Room tokens we have already enrolled (this session) */
     this._enrolledRooms = new Set();
 
@@ -104,16 +107,27 @@ class BotEnroller {
    * @returns {Promise<Object>} Results object with checked, enrolled, skipped, errors
    */
   async enrollAll() {
-    // 1. Resolve our bot ID (once per session, or keep retrying if still null)
+    // 1. Resolve our bot ID. Retry every heartbeat until successful — moltagent
+    //    may not be in any room yet, in which case we want to auto-recover as
+    //    soon as it is added — but log the "unresolved" warn only once per
+    //    session so we do not spam the journal.
     if (!this._botId) {
       try {
         await this._resolveBotId();
       } catch (err) {
-        console.warn(`[BotEnroller] Bot ID resolution failed: ${err.message}`);
+        if (!this._warnedUnresolved) {
+          console.warn(`[BotEnroller] Bot ID resolution failed: ${err.message}`);
+          this._warnedUnresolved = true;
+        }
       }
       if (!this._botId) {
+        if (!this._warnedUnresolved) {
+          console.warn('[BotEnroller] Could not resolve bot ID — enrollment disabled until bot is visible in a room we participate in.');
+          this._warnedUnresolved = true;
+        }
         return { checked: 0, enrolled: 0, skipped: 0, errors: [] };
       }
+      this._warnedUnresolved = false;
     }
 
     // 2. List rooms we are in
@@ -193,10 +207,8 @@ class BotEnroller {
         if (discovered) return;
       }
     } catch {
-      // Could not list rooms
+      // Could not list rooms — enrollAll() logs once-per-session via _warnedUnresolved
     }
-
-    console.warn('[BotEnroller] Could not resolve bot ID -- enrollment disabled for this session');
   }
 
   /**

--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -292,6 +292,16 @@ class CockpitManager {
     this._descriptionHashes = new Map();
   }
 
+  /**
+   * Whether initialize() has completed successfully at least once. Read by
+   * the heartbeat pulse to decide whether to retry initialization before
+   * calling readConfig(). See issue #26.
+   * @returns {boolean}
+   */
+  get isInitialized() {
+    return this._initialized;
+  }
+
   // ===========================================================================
   // Lifecycle
   // ===========================================================================

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -519,12 +519,31 @@ class DeckClient {
   /**
    * Share a board with a user granting full permissions (edit, share, manage).
    * Convenience wrapper over shareBoard() for admin-level sharing.
+   *
+   * Idempotent: if the user is already in the board's ACL, the existing
+   * entry is returned without a second POST. NC Deck returns HTTP 500
+   * (not 409) on a duplicate ACL POST — see nextcloud/deck#7874 — so the
+   * pre-check is required to avoid ~7 500-response payloads per service
+   * restart in our journal. See #26.
+   *
    * @param {number} boardId
    * @param {string} username - NC username to share with
-   * @returns {Promise<Object>} ACL entry object
+   * @returns {Promise<Object>} ACL entry object (existing or newly created)
    */
   async shareBoardWithUser(boardId, username) {
     if (!boardId || !username) throw new DeckApiError('boardId and username are required');
+    try {
+      const board = await this.getBoard(boardId);
+      const existing = (board.acl || []).find(
+        entry => entry.type === 0 &&
+          (entry.participant?.uid === username ||
+            entry.participant?.primaryKey === username)
+      );
+      if (existing) return existing;
+    } catch {
+      // If pre-check fails (e.g. transient network error), fall through and
+      // attempt the POST. We prefer a failed POST over silently doing nothing.
+    }
     return await this.shareBoard(boardId, username, 0, true, true, true);
   }
 

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -234,6 +234,11 @@ class HeartbeatManager {
     this._cockpitWorkingHours = null;   // "HH:MM-HH:MM" string from cockpit
     this._cockpitDailyDigest = null;    // "HH:MM" or "off" from cockpit
 
+    // Rate limit for cockpit init-failure logs. If initialize() fails (e.g. DNS
+    // flakiness at startup), we keep retrying on every pulse — but log the
+    // failure at most once per hour so we don't spam the journal. See #26.
+    this._cockpitInitErrorLastLog = 0;
+
     // Shared ObservationLog — produced by enrichment pipeline, consumed by WikiSteward.
     // Created here so callers can access it via heartbeatManager.observationLog before
     // WikiSteward is ready (deps like knowledgeGraph arrive post-construction).
@@ -647,7 +652,7 @@ class HeartbeatManager {
       // NC Flow events already processed above (before quiet hours gate)
 
       // Cockpit: Read config and update status cards (all levels)
-      if (this.cockpitManager) {
+      if (this.cockpitManager && await this._ensureCockpitInitialized(results)) {
         try {
           // Invalidate cache so card edits are picked up within one heartbeat
           this.cockpitManager.invalidateCache();
@@ -1514,6 +1519,36 @@ class HeartbeatManager {
       types[id] = (typeof provider.isLocal === 'function' ? provider.isLocal() : provider.isLocal) ? 'local' : 'cloud';
     }
     return types;
+  }
+
+  /**
+   * Ensure CockpitManager is initialized before each pulse. If startup init
+   * failed (e.g. DNS flakiness before NC is reachable), retry here and log
+   * the failure at most once per hour. Returns true if usable, false if
+   * caller should skip the cockpit block this pulse.
+   *
+   * Without this retry, a single startup failure produced ~280/day of
+   * "CockpitManager not initialized" errors until service restart. See #26.
+   *
+   * @private
+   * @param {Object} results - Pulse results object to annotate on skip
+   * @returns {Promise<boolean>} true if initialized, false if skip
+   */
+  async _ensureCockpitInitialized(results) {
+    if (this.cockpitManager.isInitialized) return true;
+    try {
+      await this.cockpitManager.initialize();
+      console.log('[Heartbeat] Cockpit manager initialized (on pulse)');
+      return true;
+    } catch (err) {
+      const now = Date.now();
+      if (now - this._cockpitInitErrorLastLog >= 3600000) {
+        console.warn(`[Heartbeat] Cockpit initialization retry failed: ${err.message}`);
+        this._cockpitInitErrorLastLog = now;
+      }
+      results.cockpit = { read: false, updated: false, reason: 'not-initialized' };
+      return false;
+    }
   }
 
   /**

--- a/src/lib/integrations/infra-monitor.js
+++ b/src/lib/integrations/infra-monitor.js
@@ -262,8 +262,11 @@ class InfraMonitor {
       });
     }
 
-    // Self-heal: remote restart via heald (after 2+ consecutive failures)
-    if (this.selfHealClient && this.selfHealEnabled) {
+    // Self-heal: remote restart via heald (after 2+ consecutive failures).
+    // Skip if the client has latched a permanent failure (e.g. credential
+    // missing) — otherwise we log a "remote restart failed" warning on
+    // every probe cycle, which produced ~90/day before #26.
+    if (this.selfHealClient && this.selfHealEnabled && this.selfHealClient.isAvailable !== false) {
       const serviceMap = { ollama: 'ollama', whisper: 'whisper-server' };
       for (const probe of this.probes) {
         const state = this.state.get(probe.id);

--- a/src/lib/workflows/workflow-board-detector.js
+++ b/src/lib/workflows/workflow-board-detector.js
@@ -41,6 +41,9 @@ class WorkflowBoardDetector {
     this._cache = null;
     this._cacheTime = 0;
     this._cacheTTL = 300000; // 5 min — refresh once per pulse
+
+    /** @type {Set<number>} boardIds we have already warned about missing labels — once-per-session */
+    this._warnedMissingLabels = new Set();
   }
 
   /**
@@ -112,10 +115,32 @@ class WorkflowBoardDetector {
     const existing = new Set(
       (fullBoard.labels || []).map(l => (l.title || '').toUpperCase())
     );
+    const missing = WORKFLOW_LABELS.filter(
+      l => !existing.has(l.title.toUpperCase())
+    );
+    if (missing.length === 0) return;
 
-    for (const labelDef of WORKFLOW_LABELS) {
-      if (existing.has(labelDef.title.toUpperCase())) continue;
+    // Creating Deck labels requires PERMISSION_MANAGE. On boards we only have
+    // EDIT on (e.g. boards owned by a user who shared them with us), silent-skip
+    // creation — attempting it just produces 403 noise on every heartbeat.
+    // Emit a single one-shot WARN per board listing what is missing so the
+    // functional gap stays visible in the startup log.
+    const canManage = fullBoard.permissions?.PERMISSION_MANAGE === true;
+    if (!canManage) {
+      if (!this._warnedMissingLabels.has(boardId)) {
+        this._warnedMissingLabels.add(boardId);
+        const names = missing.map(l => l.title).join(', ');
+        const ownerName = fullBoard.owner?.displayname || fullBoard.owner?.uid || 'the board owner';
+        console.warn(
+          `[WorkflowDetector] Board ${boardId} "${fullBoard.title || ''}" is missing workflow labels [${names}], ` +
+          `and we lack PERMISSION_MANAGE to create them. Ask ${ownerName} to create these labels manually ` +
+          `or grant us MANAGE. See moltagent/moltagent#44.`
+        );
+      }
+      return;
+    }
 
+    for (const labelDef of missing) {
       try {
         await this.deck.createLabel(boardId, labelDef.title, labelDef.color);
         console.log(`[WorkflowDetector] Created label "${labelDef.title}" on board ${boardId}`);

--- a/test/unit/integrations/bot-enroller.test.js
+++ b/test/unit/integrations/bot-enroller.test.js
@@ -134,12 +134,12 @@ test('constructor uses botName shortcut over config', () => {
   assert.strictEqual(enroller.botName, 'ShortcutBot');
 });
 
-// --- enrollAll() resolves bot ID from admin endpoint ---
+// --- enrollAll() resolves bot ID via per-room discovery (admin endpoint removed per #26) ---
 
-asyncTest('enrollAll() resolves bot ID from admin endpoint', async () => {
+asyncTest('enrollAll() resolves bot ID via per-room discovery', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse(SAMPLE_ROOMS),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/abc123': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 201, body: {}, headers: {} }
   });
 
@@ -150,14 +150,21 @@ asyncTest('enrollAll() resolves bot ID from admin endpoint', async () => {
   assert.strictEqual(result.checked, 2); // Only group + public rooms
   assert.strictEqual(result.enrolled, 2);
   assert.strictEqual(result.errors.length, 0);
+
+  // Admin endpoint must not be called — that call produced 282/day of 403 noise
+  // before #26 and is now removed.
+  const adminCalls = nc._calls.filter(c =>
+    c.path === '/ocs/v2.php/apps/spreed/api/v1/bot/admin'
+  );
+  assert.strictEqual(adminCalls.length, 0);
 });
 
 // --- enrollAll() enables bot in rooms where user is member ---
 
 asyncTest('enrollAll() enables bot in group and public rooms', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse(SAMPLE_ROOMS),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/abc123': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 201, body: {}, headers: {} }
   });
 
@@ -179,8 +186,8 @@ asyncTest('enrollAll() enables bot in group and public rooms', async () => {
 
 asyncTest('enrollAll() skips already-enrolled rooms on second call', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse(SAMPLE_ROOMS),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/abc123': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 201, body: {}, headers: {} }
   });
 
@@ -200,11 +207,11 @@ asyncTest('enrollAll() skips already-enrolled rooms on second call', async () =>
 
 asyncTest('enrollAll() handles 403 not-moderator gracefully', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
       { token: 'room1', type: 2, name: 'Room 1' },
       { token: 'room2', type: 2, name: 'Room 2' }
     ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': (path) => {
       if (path.includes('room1')) {
         throw new Error('Authentication error: 403');
@@ -229,10 +236,10 @@ asyncTest('enrollAll() handles 403 not-moderator gracefully', async () => {
 
 asyncTest('enrollAll() handles 400 already-enabled gracefully', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
       { token: 'room1', type: 2, name: 'Room 1' }
     ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': new Error('HTTP 400: Bad Request')
   });
 
@@ -286,10 +293,10 @@ asyncTest('_discoverBotIdFromRoom() discovers bot ID from room bot list', async 
 
 asyncTest('resetCache() clears enrolled set so rooms are re-checked', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
       { token: 'room1', type: 2, name: 'Room 1' }
     ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 201, body: {}, headers: {} }
   });
 
@@ -335,11 +342,11 @@ asyncTest('enrollAll() returns gracefully when bot cannot be found', async () =>
 asyncTest('enrollAll() calls auditLog when rooms are enrolled', async () => {
   const auditLog = createMockAuditLog();
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
       { token: 'room1', type: 2, name: 'Room 1' },
       { token: 'room2', type: 3, name: 'Room 2' }
     ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 201, body: {}, headers: {} }
   });
 
@@ -371,8 +378,10 @@ asyncTest('enrollAll() does not audit when no new rooms are enrolled', async () 
 // --- enrollAll() handles room list failure gracefully ---
 
 asyncTest('enrollAll() handles room list failure gracefully', async () => {
+  // Since #26 removed the admin-endpoint shortcut, a failing /room list
+  // prevents bot-id resolution entirely — enrollment is skipped this pulse
+  // and retried next heartbeat.
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': new Error('Network error: timeout')
   });
 
@@ -381,18 +390,18 @@ asyncTest('enrollAll() handles room list failure gracefully', async () => {
 
   assert.strictEqual(result.checked, 0);
   assert.strictEqual(result.enrolled, 0);
-  assert.strictEqual(result.errors.length, 1);
-  assert.ok(result.errors[0].error.includes('timeout'));
+  assert.strictEqual(result.errors.length, 0);
+  assert.strictEqual(enroller.botId, null);
 });
 
 // --- enrollAll() handles 200 (already enabled) from POST ---
 
 asyncTest('enrollAll() treats POST 200 as already-enabled (skip not enroll)', async () => {
   const nc = createMockNC({
-    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/admin': ocsResponse(SAMPLE_ADMIN_BOTS),
     'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
       { token: 'room1', type: 2, name: 'Room 1' }
     ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': { status: 200, body: {}, headers: {} }
   });
 

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -2049,15 +2049,23 @@ async function initialize() {
     botNames = ['Molti', 'moltagent', 'molti'];
   }
 
-  // Create SelfHealClient (heald daemon on Ollama VM)
-  if (SelfHealClient && appConfig.infra?.heald?.url && credentialBroker) {
+  // Create SelfHealClient (heald daemon on Ollama VM). Skip when HEALD_URL is
+  // unset / still the placeholder sentinel — otherwise InfraMonitor calls
+  // restart() on the first service outage, the credential broker fails to
+  // resolve heald-token (never created), and we log ~90/day of warnings
+  // against a daemon that was never deployed. See #26.
+  const healdUrl = appConfig.infra?.heald?.url;
+  const healdIsConfigured = healdUrl && healdUrl !== appConfig.infra?.heald?.urlPlaceholder;
+  if (SelfHealClient && healdIsConfigured && credentialBroker) {
     selfHealClient = new SelfHealClient({
-      url: appConfig.infra.heald.url,
+      url: healdUrl,
       tokenCredential: appConfig.infra.heald.tokenCredential,
       timeoutMs: appConfig.infra.heald.timeoutMs,
       credentialBroker
     });
-    console.log(`[INIT] SelfHealClient ready → ${appConfig.infra.heald.url}`);
+    console.log(`[INIT] SelfHealClient ready → ${healdUrl}`);
+  } else if (SelfHealClient && healdUrl && !healdIsConfigured) {
+    console.log('[INIT] SelfHealClient disabled — HEALD_URL is unset (placeholder value). Set HEALD_URL to enable remote self-heal.');
   }
 
   serverComponents = createServerComponents({


### PR DESCRIPTION
## Summary

Resolves the noise-floor portion of #26. The agent was emitting ~956/day of recurring error/warn log lines across five distinct failure modes plus one NC Deck server error — nothing user-visible, but enough that signal disappeared when a real bug appeared (see #22 retrospective). Five commits (four resolutions + one polish from live verification), each independently revertible.

## Observed pre-fix counts (during discovery, 2026-04-22)

Noise has drifted upward since the issue's 2026-04-15 retrospective (830/day then, **956/day at discovery**). Biggest mover: the Cockpit init-race doubled from 146 → 280/day. Using *discovery* counts here rather than the issue's retrospective counts; they're the actual baseline the verification compares against.

## Two framings — the issue's symptom map and the generator-level view

Both are useful. The symptom map is what you check to confirm the fix shipped. The generator view is what a future reader needs to understand *why* the fix took the shape it did.

### By the issue's six-row table (symptom map)

| # | Symptom | Pre-fix/day | Resolution |
|---|---|---|---|
| 1 | BotEnroller admin 403 | 282 | Removed admin call; per-room discovery was already the fallback. Polish commit latches the "unresolved" WARN to once-per-session. |
| 2 | WorkflowDetector "Could not create label APPROVED" on board 144 | 146 | Silent-skip when board lacks MANAGE; one-shot WARN per boardId |
| 3 | WorkflowDetector "Could not create label REJECTED" on board 144 | 146 | Same as row 2 |
| 4 | Cockpit "CockpitManager not initialized" | 280 | Retry init on pulse; rate-limit failure log to once/hour |
| 5 | InfraMonitor "Credential heald-token not found" | 90 | Don't construct SelfHealClient when HEALD_URL is placeholder; latch credential-missing failure as safety net |
| 6 | NC Deck HTTP 500 on POST /boards/5/acl | ~9 | Pre-check ACL; skip POST when participant already present. Upstream filed as nextcloud/deck#7874. |

### By generator (class of problem)

**Group A — "operation the moltagent NC user is not authorised for" (577/day across three symptoms).** One generator, three surfaces. `3ca775d` + polish `7e91ea6`.

- BotEnroller called an admin-only endpoint; per-room discovery was already its fallback path. Drop the admin attempt.
- WorkflowDetector called label-create on board 144; moltagent has EDIT but not MANAGE. Guard creation with a permission check; one-shot WARN per board listing what is missing so the functional gap stays visible. Filed as moltagent/moltagent#44 — APPROVED/REJECTED are consumed by the live GATE workflow, so their absence on board 144 is a real feature gap, not just a cosmetic issue.

**Group B — "caller fires before its prerequisite exists" (370/day across two symptoms).** Two commits because the generators differ on closer inspection: one is timing, one is data.

- `0d2571f` (row 4, timing): Cockpit init failed once at startup (DNS transient), was never retried. Retry on each pulse; rate-limit the failure log.
- `13af2ed` (row 5, data): HEALD daemon isn't deployed; HEALD_URL is the placeholder sentinel. Skip SelfHealClient construction when HEALD_URL matches the sentinel, so no probe call site ever exists. Safety latch in the client for the case where URL is set but credential is still missing.

**Group C — "upstream server bug in a call we make idempotently" (9/day).** `b1a673b`.

- NC Deck returns 500 (not 409) on duplicate ACL POST. Our `shareBoardWithUser` helper is called idempotently on startup. Pre-check ACL; POST only if participant missing. Raw `shareBoard` stays as-is for callers that explicitly want the lower-level semantics (e.g. tool-registry's user-initiated share).
- Upstream filed at nextcloud/deck#7874 — *Deck should return 409, not 500*. Our pre-check isn't purely a workaround — even when the upstream is fixed, it saves a round-trip on idempotent startup shares.

## Follow-ups (surfaced during discovery or verification)

- **moltagent/moltagent#44** — board 144 is missing APPROVED/REJECTED labels, which the GATE workflow actively consumes. Functional gap: Funana should create the labels manually, or grant moltagent MANAGE.
- **moltagent/moltagent#45** — cockpit board registry mismatch. Masked by the old init-race noise; surfaced once #26's retry-on-pulse let the real error through. `data/deck-board-registry.json` missing the `cockpit` entry; actual board is id 14. One-line operator fix.
- **nextcloud/deck#7874** — upstream fix for the 500-on-duplicate-ACL.
- Observed during discovery but deliberately **not fixed here** per the briefing's out-of-scope rule: NC DNS flakiness at startup; SkillForge yaml parse errors for brave-search and google-calendar; MKCOL 405 "resource already exists" from DailyDigest/Logs paths (probably related to the CollectivesClient.ensureDirectory work in Session 48 but covers a different set of paths).

## Verification — cadence-aware, two restart cycles

First restart at 2026-04-22 14:46:51 (after the four main commits). Live verification at 13m40s post-restart, 3 heartbeat pulses elapsed:

| Error string | Natural cadence | Post-deploy count | Status |
|---|---|---|---|
| `Admin bot list unavailable` | ~5 min | 0 | ✓ |
| `Could not create label` | ~5 min | 0 | ✓ |
| `CockpitManager not initialized — call initialize` | ~5 min | 0 | ✓ (path replaced by rate-limited retry) |
| `heald-token` | ~16 min | 0 | ✓ (no call site exists) |
| `HTTP 500 on POST .../boards/5/acl` | once per restart | 0 | ✓ |
| `Board 144 is missing workflow labels …` (new one-shot WARN) | once per session | 1 | ✓ (designed) |
| `SelfHealClient disabled — HEALD_URL is unset` (new INIT log) | once per startup | 1 | ✓ (designed) |

Live verification revealed that the Group A "Could not resolve bot ID" fallback log was firing on every heartbeat (~100/day), not once per session as intended. Polish commit `7e91ea6` added a `_warnedUnresolved` latch. Second restart at 15:02:32; re-verification at 12m16s post-restart, 3 pulses elapsed:

- `Could not resolve bot ID`: **1** (was 4 pre-polish — latch confirmed)
- All other target patterns: still 0

## Test plan

- [x] `npm run lint` — 0 errors (2764 pre-existing warnings)
- [x] `npm test` — 220/220 test files pass
- [x] Service restart successful (twice — primary + polish)
- [x] Per-row error-string counts = 0 (or designed one-shot value) after 2× cadence
- [x] Polish commit re-verified at 2× cadence post-second-restart
- [ ] 24h background sweep — will post as a PR comment on merge day + 1

Closes #26.
