### PR TITLE
fix(wikisteward): prevent Related section overflow from cross-steward interference

### DIFF
--- a/src/lib/integrations/collectives-client.js
+++ b/src/lib/integrations/collectives-client.js
@@ -45,6 +45,10 @@ class CollectivesClient {
     this.baseUrl = this.nc.ncUrl;
     this.username = this.nc.ncUser || 'moltagent';
 
+    // Optional logger; falls back to console so section-collision diagnostics
+    // still reach journald when no structured logger is wired in.
+    this.logger = config.logger || console;
+
     // Configuration
     this.collectiveName = config.collectiveName || appConfig.knowledge?.collectiveName || 'Moltagent Knowledge';
 
@@ -79,7 +83,7 @@ class CollectivesClient {
    * @param {Object} [body] - Request body
    * @returns {Promise<Object>} Response body
    */
-  async _ocsRequest(method, path, body = null) {
+  async _ocsRequest(method, path, body = null, { skipCache = false } = {}) {
     const url = `${this.ocsBase}${path}`;
     const options = {
       method,
@@ -88,6 +92,10 @@ class CollectivesClient {
         'Accept': 'application/json'
       }
     };
+
+    // Force a fresh read past the NCRequestManager response cache. Used by
+    // ensureSection so its existence check never decides on a stale page list.
+    if (skipCache) options.skipCache = true;
 
     if (body && (method === 'POST' || method === 'PUT')) {
       options.headers['Content-Type'] = 'application/json';
@@ -235,10 +243,12 @@ class CollectivesClient {
   /**
    * List all pages in a collective
    * @param {number} collectiveId - Collective ID
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Array>} List of pages
    */
-  async listPages(collectiveId) {
-    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`);
+  async listPages(collectiveId, { skipCache = false } = {}) {
+    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`, null, { skipCache });
     return data?.pages || data || [];
   }
 
@@ -301,8 +311,10 @@ class CollectivesClient {
     this._sectionLocks.set(lockKey, lock);
 
     try {
-      // Re-check after acquiring lock in case a previous run just created it.
-      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId);
+      // Re-check after acquiring the lock in case a previous run just created
+      // it. skipCache: this existence check is the gate that decides whether to
+      // create — a stale page list here is exactly what produces "(2)" sections.
+      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
       if (existing) {
         this._sectionCache.set(lockKey, existing);
         return existing;
@@ -318,6 +330,39 @@ class CollectivesClient {
       }
 
       const created = await this.createPage(collectiveId, actualParentId, sectionName);
+
+      // Post-creation collision guard. If the existence check still raced a
+      // stale listing, Collectives appends "(N)" to disambiguate. Detect that
+      // suffix, trash the artifact, and return the real section instead —
+      // otherwise the duplicate accumulates on every heartbeat (issue #25).
+      const wanted = (sectionName || '').toLowerCase().trim();
+      const suffixMatch = (created?.title || '').match(/^(.*?)\s*\(\d+\)\s*$/);
+      if (suffixMatch && suffixMatch[1].toLowerCase().trim() === wanted) {
+        const real = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
+        if (real && real.id !== created.id) {
+          this.logger.warn(
+            `[Collectives] ensureSection collision: requested "${sectionName}", ` +
+            `got "${created.title}". Trashing duplicate and returning existing.`
+          );
+          try {
+            await this.trashPage(collectiveId, created.id);
+          } catch (err) {
+            this.logger.warn(
+              `[Collectives] Failed to trash collision artifact "${created.title}" ` +
+              `(id ${created.id}): ${err.message}`
+            );
+          }
+          this._sectionCache.set(lockKey, real);
+          return real;
+        }
+        // No un-suffixed section to fall back to — keep the suffixed page rather
+        // than lose the section entirely. Log so it is visible for manual cleanup.
+        this.logger.warn(
+          `[Collectives] ensureSection got "${created.title}" for "${sectionName}" ` +
+          'but found no un-suffixed section to fall back to — keeping it.'
+        );
+      }
+
       this._sectionCache.set(lockKey, created);
       return created;
     } finally {
@@ -336,11 +381,14 @@ class CollectivesClient {
    *
    * @param {number} collectiveId - Collective ID
    * @param {string} sectionName  - Target section title
+   * @param {number|null} [parentPageId] - Restrict search to children of this page
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Object|null>} Page object or null if not found
    * @private
    */
-  async _findSectionPage(collectiveId, sectionName, parentPageId = null) {
-    const pages = await this.listPages(collectiveId);
+  async _findSectionPage(collectiveId, sectionName, parentPageId = null, { skipCache = false } = {}) {
+    const pages = await this.listPages(collectiveId, { skipCache });
     const pageList = Array.isArray(pages) ? pages : [];
     const target = (sectionName || '').toLowerCase().trim();
 

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -743,7 +743,18 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
    * @returns {string} Prompt text.
    */
   _connectionAssessmentPrompt(neighborhood) {
-    const pageLinks = neighborhood.pages.map(p =>
+    // Structural guard: section index / navigation pages are not knowledge
+    // entities and must never be link targets. Drop them from the data the LLM
+    // sees so it cannot suggest links to "Documents", "People", etc. Index
+    // pages carry `type: index`; structural pages carry the `compost: never`
+    // pin. The prompt EXCLUSION instruction below is the intelligence-layer
+    // counterpart — belt and suspenders.
+    const contentPages = neighborhood.pages.filter(p => {
+      const fm = p.frontmatter || {};
+      return fm.type !== 'index' && fm.compost !== 'never';
+    });
+
+    const pageLinks = contentPages.map(p =>
       `### ${p.title}\n` +
       `Graph connections: ${p.graphConnections.map(e => `${e.predicate} → ${e.object}`).join(', ') || 'none'}\n` +
       `Wikilinks in content: ${p.wikilinks.join(', ') || 'none'}`
@@ -767,6 +778,12 @@ Near-duplicate (EN): Pages "ManeraMedia GmbH" and "Manera Media GmbH" likely des
 Near-duplicate (DE): Die Seiten "ManeraMedia GmbH" und "Manera Media GmbH" beschreiben wahrscheinlich dieselbe Organisation.
 Near-duplicate (PT): As páginas "ManeraMedia GmbH" e "Manera Media GmbH" provavelmente descrevem a mesma organização.
 ---
+
+EXCLUSION: Do NOT suggest links to section index pages. Pages whose type is "index"
+or whose title matches a top-level section name (Documents, People, Projects,
+Organizations, Research, Procedures, Images, Meta, emails) are structural navigation,
+not knowledge entities. They must never appear in missingLinks or orphan suggestions.
+Only suggest links between actual knowledge entities (people, projects, documents, concepts).
 
 Here are the pages with their graph connections and wikilinks:
 
@@ -1121,8 +1138,15 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
     const body = result.body || '';
 
-    // Idempotency: skip if [[target]] already appears anywhere in the body
+    // Idempotency: skip if the link to `target` already appears in the body,
+    // in EITHER form. writePageWithFrontmatter() runs resolveWikilinks() before
+    // every write, transforming [[target]] into [target](url). On the next
+    // heartbeat read only the resolved form remains — so a check for the
+    // unresolved form alone passes and appends a duplicate every cycle.
+    // Matching `[target](` is structural markdown-link syntax, not natural
+    // language, so it is allowed under the language policy.
     if (body.includes(`[[${target}]]`)) return false;
+    if (body.includes(`[${target}](`)) return false;
 
     // Append a Related section entry
     const relLine = `\n- [[${target}]] (${relationship || 'related'})\n`;
@@ -1260,13 +1284,11 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
     fm.compost_reason = reason || 'Marked by Memory Steward';
     fm.compost_marked_at = new Date().toISOString();
 
-    let body = result.body || '';
-    const markerSignature = 'Archived by Memory Steward';
-    if (!body.includes(markerSignature)) {
-      body = `${body}\n\n---\n_${markerSignature}: ${reason || 'Marked by Memory Steward'}_\n`;
-    }
-
-    await this.collectivesClient.writePageWithFrontmatter(page, fm, body);
+    // Frontmatter carries the compost state. No inline body annotation:
+    // it was redundant with compost_ready/compost_reason/compost_marked_at and
+    // disrupted the Connection Steward's `## Related` section regex by inserting
+    // content between the heading and EOF. The body holds knowledge only.
+    await this.collectivesClient.writePageWithFrontmatter(page, fm, result.body || '');
     this.logger.info(`[WikiSteward:memory] Marked "${page}" for composting: ${reason}`);
     return true;
   }

--- a/test/unit/integrations/collectives-client.test.js
+++ b/test/unit/integrations/collectives-client.test.js
@@ -487,6 +487,71 @@ asyncTest('writePageWithFrontmatter resolves wikilinks before writing', async ()
   assert.ok(!writtenContent.includes('[['), 'Should not contain raw wikilinks');
 });
 
+// -- ensureSection — collision dedup (Fix D) --
+
+const silentLogger = { warn() {}, info() {}, error() {}, debug() {} };
+
+asyncTest('ensureSection returns the existing section without creating', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createCalls = 0;
+  client.createPage = async () => { createCalls++; return { id: 999, title: 'WRONG' }; };
+  client.listPages = async () => ([
+    { id: 1, title: 'Landing page', parentId: 0 },
+    { id: 2, title: 'Documents', parentId: 1 },
+  ]);
+
+  const result = await client.ensureSection(10, 'Documents');
+  assert.strictEqual(result.id, 2, 'should return the existing Documents section');
+  assert.strictEqual(createCalls, 0, 'createPage must not be called when the section exists');
+});
+
+asyncTest('ensureSection creates the section when it does not exist', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createArgs = null;
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async (cid, parentId, title) => {
+    createArgs = { cid, parentId, title };
+    return { id: 50, title, parentId };
+  };
+
+  const result = await client.ensureSection(10, 'Research');
+  assert.strictEqual(result.id, 50, 'should return the newly created section');
+  assert.deepStrictEqual(createArgs, { cid: 10, parentId: 1, title: 'Research' });
+});
+
+asyncTest('ensureSection detects a (N) collision and trashes the artifact', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  let listCalls = 0;
+  // The pre-create check races a stale list (no Documents). After createPage
+  // collides, the fresh skipCache re-find sees the real Documents section.
+  client.listPages = async () => {
+    listCalls++;
+    const pages = [{ id: 1, title: 'Landing page', parentId: 0 }];
+    if (listCalls >= 2) pages.push({ id: 7, title: 'Documents', parentId: 1 });
+    return pages;
+  };
+  client.createPage = async () => ({ id: 99, title: 'Documents (2)', parentId: 1 });
+  let trashedId = null;
+  client.trashPage = async (cid, pid) => { trashedId = pid; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashedId, 99, 'the (2) collision artifact should be trashed');
+  assert.strictEqual(result.id, 7, 'should return the real Documents section, not the artifact');
+});
+
+asyncTest('ensureSection keeps the suffixed page when no real section can be found', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  // Both the pre-check and the post-collision re-find see no un-suffixed section.
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async () => ({ id: 88, title: 'Documents (2)', parentId: 1 });
+  let trashed = false;
+  client.trashPage = async () => { trashed = true; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashed, false, 'must not trash when there is no section to fall back to');
+  assert.strictEqual(result.id, 88, 'should keep the suffixed page rather than lose the section');
+});
+
 // ============================================================
 // Summary
 // ============================================================

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -532,6 +532,153 @@ asyncTest('_markForComposting honors compost: never pin — does not mark pinned
 });
 
 // ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix A: wikilink idempotency survives resolution
+// ---------------------------------------------------------------------------
+
+// Fix A.1: _addWikilink returns false when the unresolved [[target]] is present.
+asyncTest('_addWikilink skips when unresolved [[target]] already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [[ManeraMedia GmbH]] (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — unresolved form already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.2: _addWikilink returns false when the RESOLVED [target](url) is present.
+// This is the new behavior — writePageWithFrontmatter resolves [[X]] to [X](url),
+// so on the next heartbeat only the resolved form remains in the body.
+asyncTest('_addWikilink skips when resolved [target](url) already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [ManeraMedia GmbH](https://nc.example/f/12345) (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — resolved markdown link already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.3: _addWikilink adds the link when neither form is present.
+asyncTest('_addWikilink adds the link when neither form is present', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: {}, body: 'Carlos works somewhere.', path: 'People/Carlos.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, true, 'should add — neither form present');
+  const written = collectivesClient._writtenPages['Carlos'];
+  assert.ok(written && written.body.includes('[[ManeraMedia GmbH]]'), 'body should carry the new link');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix B: Connection Steward excludes index pages
+// ---------------------------------------------------------------------------
+
+function makeConnectionNeighborhood(pages) {
+  return {
+    cluster: 'Documents',
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: 'Documents',
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set(['Documents']),
+    deckCards: [],
+  };
+}
+
+// Fix B.1: pages with `type: index` are excluded from the assessment data.
+test('_connectionAssessmentPrompt excludes type:index pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Documents'), 'index page must not appear as a link target');
+});
+
+// Fix B.2: pages with `compost: never` (structural pin) are excluded.
+test('_connectionAssessmentPrompt excludes compost:never pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Structural Nav Page', frontmatter: { compost: 'never' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Structural Nav Page'), 'pinned structural page must not appear');
+});
+
+// Fix B.3: the EXCLUSION instruction is present in the prompt.
+test('_connectionAssessmentPrompt carries the EXCLUSION instruction', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const prompt = steward._connectionAssessmentPrompt(makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+  ]));
+  assert.ok(prompt.includes('EXCLUSION:'), 'prompt should instruct the LLM to exclude index pages');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix C: _markForComposting writes frontmatter only
+// ---------------------------------------------------------------------------
+
+// Fix C.1: _markForComposting sets the compost frontmatter fields.
+asyncTest('_markForComposting sets compost_ready/compost_reason/compost_marked_at', async () => {
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: '# Stale Doc\n\nbody', path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const ok = await steward._markForComposting('Stale Doc', 'Never accessed, past decay');
+  assert.strictEqual(ok, true);
+  const fm = collectivesClient._writtenPages['Stale Doc'].frontmatter;
+  assert.strictEqual(fm.compost_ready, true, 'compost_ready should be true');
+  assert.strictEqual(fm.compost_reason, 'Never accessed, past decay', 'compost_reason should be set');
+  assert.ok(fm.compost_marked_at, 'compost_marked_at should be set');
+});
+
+// Fix C.2: _markForComposting does NOT modify the page body — no inline marker.
+asyncTest('_markForComposting leaves the page body unchanged (no inline archive marker)', async () => {
+  const originalBody = '# Stale Doc\n\nReal content.\n\n## Related\n- [Eelco](https://nc.example/f/9) (related)\n';
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: originalBody, path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  await steward._markForComposting('Stale Doc', 'Never accessed');
+  const writtenBody = collectivesClient._writtenPages['Stale Doc'].body;
+  assert.strictEqual(writtenBody, originalBody, 'body must be byte-identical — no inline annotation');
+  assert.ok(!writtenBody.includes('Archived by Memory Steward'), 'no inline archive marker in body');
+});
+
+// ---------------------------------------------------------------------------
 // INTEGRATION WITH tend()
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes visible Collectives wiki corruption caused by **cross-write interference** — three WikiSteward lenses (knowledge, connection, memory) writing the same page body without accounting for the state previous writes left behind. One generating function, four fixes.

Two symptoms, one root cause:
1. **Unbounded `## Related` overflow** on document-reference pages — dozens of duplicate link entries appended over successive heartbeat cycles.
2. **Duplicate "(N)" sections** — Nextcloud Collectives collision artifacts (`Documents (2)`, `Projects (2)`) created when section creation raced a stale page list.

## Fixes

**A — Wikilink idempotency survives resolution** (`wiki-steward.js` `_addWikilink`)
`writePageWithFrontmatter()` resolves `[[target]]` → `[target](url)` before every write, so the next heartbeat's `body.includes('[[target]]')` check missed the already-present link and appended a duplicate. The check now matches both the unresolved and resolved forms.

**B — Connection Steward excludes index pages** (`wiki-steward.js` `_connectionAssessmentPrompt`)
Section index / structural navigation pages (`type: index`, or the `compost: never` pin) are filtered out of the neighborhood data sent to the LLM, and an `EXCLUSION` instruction is added to the prompt — belt (filter) and suspenders (prompt).

**C — No inline body annotation on compost** (`wiki-steward.js` `_markForComposting`)
Dropped the inline `Archived by Memory Steward` marker. The frontmatter fields (`compost_ready`, `compost_reason`, `compost_marked_at`) already carry that state; the body annotation was redundant and disrupted the Connection Steward's `## Related` section regex. Frontmatter carries state, the body carries knowledge.

**D — `ensureSection` collision dedup** (`collectives-client.js`)
The existence check that gates section creation now reads past the response cache (`skipCache`), and a post-creation guard detects the `(N)` collision suffix, trashes the artifact, and returns the real section. A `skipCache` option is threaded through `listPages`/`_ocsRequest`.

## Tests

12 new unit tests (8 in `wiki-steward.test.js`, 4 in `collectives-client.test.js`). Full suite: **215/215 test files pass**, lint 0 errors.

## Live cleanup (commit 3)

Applied to the production wiki after the code deployed and verified:
- Deduplicated the `## Related` section on 7 document-reference pages (entry counts `134/93/123/71/56/124/93` → `7/5/4/5/4/8/6`).
- Removed inline archive markers from page bodies.
- Re-resolved Related links so entries that pointed at the deleted orphan pages now resolve to the real entity pages.
- Deleted the `Documents (2)` and `Projects (2)` collision sections and their empty 0-byte child pages. (`Projects (2)` was an identical artifact found during live inspection — cleanup scope extended to cover it.)

Page-head content (summaries, entity sections) and frontmatter were verified byte-faithful across the cleanup.

## Verification

- **Fix D** — `ensureSection("Documents")` on the live collective returns the real section; a repeated `ensureSection` on a fresh name is idempotent (no `(2)`); test section trashed.
- **Fix A** — `_addWikilink` against a live page whose Related section already holds the resolved link returns `false` with the body unchanged (pre-fix it appended a duplicate).
- **Fix C** — `_markForComposting` on a live compost-ready page sets the frontmatter fields and leaves the body with no archive marker.
- **Fix B** — covered by 3 unit tests; the `EXCLUSION` instruction is confirmed present in the live-generated prompt. The end-to-end "Connection Steward omits index pages from `missingLinks`" log check is currently unobservable (see note below).

## Out of scope — follow-up

During verification the steward's `_readNeighborhood` cluster filter was found to expect `filePath` to include the page filename, while the Collectives API now returns folder-only paths — so the stewards currently read empty neighborhoods for nested sections. This is a separate pre-existing bug (it also explains why the Related overflow stopped accumulating in late April). Filed as #51; not addressed here.

Related: #42 (structural page restoration), #25 (DAV MKCOL / log hygiene)
