### PR TITLE
fix(wikisteward): structural-page intervention guard (closes #59)

### DIFF
--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -944,7 +944,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       case 'knowledge': {
         for (const c of assessment.contradictions || []) {
           if (structuralTitles.has(c.pageA) || structuralTitles.has(c.pageB)) {
-            this.logger.debug(`[WikiSteward:knowledge] Skipping structural page in contradiction: "${c.pageA}" / "${c.pageB}"`);
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page in contradiction: "${c.pageA}" / "${c.pageB}"`);
             continue;
           }
           try {
@@ -956,7 +956,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         }
         for (const s of assessment.stale || []) {
           if (structuralTitles.has(s.page)) {
-            this.logger.debug(`[WikiSteward:knowledge] Skipping structural page "${s.page}" for staleness`);
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page "${s.page}" for staleness`);
             continue;
           }
           try {
@@ -983,7 +983,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       case 'connection': {
         for (const m of assessment.missingLinks || []) {
           if (structuralTitles.has(m.page)) {
-            this.logger.debug(`[WikiSteward:connection] Skipping structural page "${m.page}" for missing link`);
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${m.page}" for missing link`);
             continue;
           }
           try {
@@ -998,7 +998,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         }
         for (const o of assessment.orphans || []) {
           if (structuralTitles.has(o.page)) {
-            this.logger.debug(`[WikiSteward:connection] Skipping structural page "${o.page}" for orphan resolution`);
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${o.page}" for orphan resolution`);
             continue;
           }
           for (const target of o.suggestedConnections || []) {
@@ -1015,7 +1015,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         }
         for (const d of assessment.nearDuplicates || []) {
           if (structuralTitles.has(d.pageA) || structuralTitles.has(d.pageB)) {
-            this.logger.debug(`[WikiSteward:connection] Skipping structural page in duplicate check: "${d.pageA}" / "${d.pageB}"`);
+            this.logger.info(`[WikiSteward:connection] Skipping structural page in duplicate check: "${d.pageA}" / "${d.pageB}"`);
             continue;
           }
           try {
@@ -1031,7 +1031,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       case 'memory': {
         for (const s of assessment.strengthen || []) {
           if (structuralTitles.has(s.page)) {
-            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${s.page}" for strengthening`);
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${s.page}" for strengthening`);
             continue;
           }
           try {
@@ -1043,7 +1043,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         }
         for (const c of assessment.compost || []) {
           if (structuralTitles.has(c.page)) {
-            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${c.page}" for composting`);
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${c.page}" for composting`);
             continue;
           }
           try {
@@ -1054,7 +1054,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         }
         for (const e of assessment.embed || []) {
           if (structuralTitles.has(e.page)) {
-            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${e.page}" for embedding`);
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${e.page}" for embedding`);
             continue;
           }
           // Find the full pageRef from neighborhood so _embedPage has path/section

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -890,6 +890,25 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
   // ---------------------------------------------------------------------------
 
   /**
+   * Determine whether a page is structural infrastructure that should not be
+   * modified by steward interventions. Structural pages serve as navigation
+   * scaffolding (section indexes, landing pages, meta pages) — their content
+   * is either auto-maintained by the fractal index refresh or intentionally
+   * minimal. Frontmatter `type: section|index|meta` marks them by role; the
+   * `compost: never` pin marks them by lifecycle policy. Either is sufficient.
+   *
+   * @param {EnrichedPage} page - Page object from neighborhood.pages
+   * @returns {boolean}
+   */
+  _isStructuralPage(page) {
+    if (!page || !page.frontmatter) return false;
+    const t = page.frontmatter.type;
+    if (t === 'section' || t === 'index' || t === 'meta') return true;
+    if (page.frontmatter.compost === 'never') return true;
+    return false;
+  }
+
+  /**
    * Execute the assessment's recommended actions. Each steward type dispatches
    * to a different set of per-action executors (the "farm hand" operations).
    *
@@ -910,9 +929,24 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       return results;
     }
 
+    // Structural pages are infrastructure, not content. Skip all interventions
+    // on them — they are maintained by the fractal index refresh cycle, not by
+    // steward assessments. Defense in depth alongside the prompt-level
+    // exclusion in _connectionAssessmentPrompt and the compost: never pin
+    // honored by _markForComposting.
+    const structuralTitles = new Set(
+      (neighborhood?.pages || [])
+        .filter(p => this._isStructuralPage(p))
+        .map(p => p.title)
+    );
+
     switch (stewardType) {
       case 'knowledge': {
         for (const c of assessment.contradictions || []) {
+          if (structuralTitles.has(c.pageA) || structuralTitles.has(c.pageB)) {
+            this.logger.debug(`[WikiSteward:knowledge] Skipping structural page in contradiction: "${c.pageA}" / "${c.pageB}"`);
+            continue;
+          }
           try {
             const flagged = await this._flagContradiction(c.pageA, c.pageB, c.claim);
             if (flagged) results.pagesModified += 2;
@@ -921,6 +955,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const s of assessment.stale || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.debug(`[WikiSteward:knowledge] Skipping structural page "${s.page}" for staleness`);
+            continue;
+          }
           try {
             const lowered = await this._lowerConfidence(s.page, s.reason);
             if (lowered) results.pagesModified++;
@@ -928,6 +966,9 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             this.logger.warn(`[WikiSteward:knowledge] _lowerConfidence("${s.page}") failed: ${err.message}`);
           }
         }
+        // _logKnowledgeGap writes to Meta/Pending Questions, not to the
+        // referenced page — the gap observation is valid even if the
+        // referencing page is structural. No guard needed here.
         for (const g of assessment.gaps || []) {
           try {
             await this._logKnowledgeGap(g.entity, g.referencedIn);
@@ -941,6 +982,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'connection': {
         for (const m of assessment.missingLinks || []) {
+          if (structuralTitles.has(m.page)) {
+            this.logger.debug(`[WikiSteward:connection] Skipping structural page "${m.page}" for missing link`);
+            continue;
+          }
           try {
             const added = await this._addWikilink(m.page, m.shouldLinkTo, m.relationship);
             if (added) {
@@ -952,6 +997,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const o of assessment.orphans || []) {
+          if (structuralTitles.has(o.page)) {
+            this.logger.debug(`[WikiSteward:connection] Skipping structural page "${o.page}" for orphan resolution`);
+            continue;
+          }
           for (const target of o.suggestedConnections || []) {
             try {
               const added = await this._addWikilink(o.page, target, 'related');
@@ -965,6 +1014,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const d of assessment.nearDuplicates || []) {
+          if (structuralTitles.has(d.pageA) || structuralTitles.has(d.pageB)) {
+            this.logger.debug(`[WikiSteward:connection] Skipping structural page in duplicate check: "${d.pageA}" / "${d.pageB}"`);
+            continue;
+          }
           try {
             await this._flagDuplicate(d.pageA, d.pageB, d.similarity || 0);
           } catch (err) {
@@ -977,6 +1030,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'memory': {
         for (const s of assessment.strengthen || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${s.page}" for strengthening`);
+            continue;
+          }
           try {
             const strengthened = await this._strengthenPage(s.page);
             if (strengthened) results.pagesModified++;
@@ -985,6 +1042,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const c of assessment.compost || []) {
+          if (structuralTitles.has(c.page)) {
+            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${c.page}" for composting`);
+            continue;
+          }
           try {
             await this._markForComposting(c.page, c.reason);
           } catch (err) {
@@ -992,6 +1053,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const e of assessment.embed || []) {
+          if (structuralTitles.has(e.page)) {
+            this.logger.debug(`[WikiSteward:memory] Skipping structural page "${e.page}" for embedding`);
+            continue;
+          }
           // Find the full pageRef from neighborhood so _embedPage has path/section
           const pageRef = neighborhood.pages.find(p => p.title === e.page) || { id: null, title: e.page };
           try {

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -888,4 +888,219 @@ Key entities: Carlos, Eelco
   assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
 });
 
+// ---------------------------------------------------------------------------
+// STRUCTURAL PAGE GUARD (#59) — _isStructuralPage + _intervene chokepoint
+// ---------------------------------------------------------------------------
+
+// Helper: build a neighborhood with arbitrary pages for intervention tests
+function makeInterveneNeighborhood(pages, cluster = 'Documents') {
+  return {
+    cluster,
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: cluster,
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set([cluster]),
+    deckCards: [],
+  };
+}
+
+// Test #59.1: _isStructuralPage returns true for type: section
+test('_isStructuralPage returns true for type:section', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'section' } }), true);
+});
+
+// Test #59.2: _isStructuralPage returns true for type: index
+test('_isStructuralPage returns true for type:index', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'index' } }), true);
+});
+
+// Test #59.3: _isStructuralPage returns true for type: meta
+test('_isStructuralPage returns true for type:meta', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'meta' } }), true);
+});
+
+// Test #59.4: _isStructuralPage returns true for compost: never (lifecycle pin)
+test('_isStructuralPage returns true for compost:never (lifecycle pin)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', compost: 'never' } }),
+    true,
+    'compost: never alone marks a page as structural infrastructure'
+  );
+});
+
+// Test #59.5: _isStructuralPage returns false for normal content page
+test('_isStructuralPage returns false for normal content page', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', confidence: 'high' } }),
+    false
+  );
+});
+
+// Test #59.6: _isStructuralPage returns false for page with no frontmatter
+test('_isStructuralPage returns false for page with missing/empty frontmatter', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: null }), false);
+  assert.strictEqual(steward._isStructuralPage({}), false);
+  assert.strictEqual(steward._isStructuralPage(null), false);
+});
+
+// Test #59.7: Connection Steward skips structural page in missingLinks loop
+asyncTest('_intervene(connection): skips structural page in missingLinks', async () => {
+  const pagesByTitle = {
+    'Carlos':    { frontmatter: {}, body: 'Content page.', path: 'People/Carlos.md' },
+    'Documents': { frontmatter: { type: 'index' }, body: '# Documents', path: 'Documents.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',    frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Documents', shouldLinkTo: 'Eelco', relationship: 'related' },
+      { page: 'Carlos',    shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Documents'],
+    'structural page (type:index) must not be written by Connection Steward'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still receive its wikilink'
+  );
+});
+
+// Test #59.8: Memory Steward skips structural page in compost loop
+asyncTest('_intervene(memory): skips structural page in compost', async () => {
+  const pagesByTitle = {
+    'Carlos':   { frontmatter: { confidence: 'low' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Research': { frontmatter: { type: 'index', compost: 'never' }, body: '# Research', path: 'Research.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',   frontmatter: { confidence: 'low' } },
+    { title: 'Research', frontmatter: { type: 'index', compost: 'never' } },
+  ]);
+
+  const assessment = {
+    strengthen: [],
+    compost: [
+      { page: 'Research', reason: 'Never accessed' },
+      { page: 'Carlos',   reason: 'Stale and unaccessed' },
+    ],
+    embed: [],
+  };
+
+  await steward._intervene('memory', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Research'],
+    'structural page (type:index + compost:never) must not be touched by _markForComposting'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still be marked for composting'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.compost_ready,
+    true,
+    'content page compost_ready set'
+  );
+});
+
+// Test #59.9: Knowledge Steward skips structural page in stale loop
+asyncTest('_intervene(knowledge): skips structural page in stale', async () => {
+  const pagesByTitle = {
+    'Carlos':            { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Pending Questions': { frontmatter: { type: 'meta' },       body: '# Pending Questions', path: 'Meta/Pending Questions.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',            frontmatter: { confidence: 'high' } },
+    { title: 'Pending Questions', frontmatter: { type: 'meta' } },
+  ], 'Meta');
+
+  const assessment = {
+    contradictions: [],
+    stale: [
+      { page: 'Pending Questions', reason: 'No new entries in 90 days' },
+      { page: 'Carlos',            reason: 'Last verified 180 days ago' },
+    ],
+    gaps: [],
+  };
+
+  await steward._intervene('knowledge', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Pending Questions'],
+    'structural page (type:meta) must not have confidence lowered'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still have confidence lowered'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.confidence,
+    'medium',
+    'content page confidence stepped down high → medium'
+  );
+});
+
+// Test #59.10: guard does not interfere with normal content-page interventions
+asyncTest('_intervene: content pages are still processed normally when no structural page in neighborhood', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Eelco':  { frontmatter: { confidence: 'high' }, body: 'Researcher.', path: 'People/Eelco.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos', frontmatter: { confidence: 'high' } },
+    { title: 'Eelco',  frontmatter: {} /* untyped — still a content page */ },
+  ], 'People');
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Carlos', shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  const result = await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(result.linksAdded >= 1, 'untyped + high-confidence pages remain in scope');
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page (Carlos) should still be written'
+  );
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
Closes #59.

## Summary

Generator-level guard in `WikiSteward._intervene()` that skips structural infrastructure pages (`type: section|index|meta` or `compost: never`) across all three steward lenses. Defense in depth alongside the prompt-level exclusion (#50 Fix B) and the `compost: never` check in `_markForComposting` (#41 / #30).

- `_isStructuralPage(page)` helper.
- `structuralTitles` Set computed once at the top of `_intervene()`.
- Eight write-bearing intervention loops now guard on `structuralTitles.has(...)`. `_logKnowledgeGap` intentionally retains no guard — it writes to `Meta/Pending Questions`, not the referenced page.
- Skip lines emit at info level so the guard is observable in production logs.

## Tests

- 10 new unit tests in `wiki-steward.test.js` (6 helper, 4 `_intervene` × three lenses + no-regression).
- `node test/unit/maintenance/wiki-steward.test.js` → 45/45 pass.
- `npm test` → 220/220 test files pass.
- `npm run lint` → 0 errors.

## Production verification

Restart at 12:32:44 WEST. Three heartbeat pulses captured (12:33:36, 12:38:55, 12:44:08).

**Bug reproduced pre-restart** (12:20:54, old code):

```
[WikiSteward:knowledge] Lowered confidence for "Images" to medium:
  Index page never verified (last_verified: never), zero access count,
  high confidence but no maintenance history
```

**Same page, post-restart, new code:**

```
12:33:26 [WikiSteward:knowledge] Skipping structural page "Images" for staleness
12:44:01 [WikiSteward:memory]    Skipping structural page "Organizations" for composting
```

Two distinct steward lenses (knowledge, memory) fired the guard on two distinct structural pages across three pulses.

**Content pages still tended normally** — same pulses report `1 pages modified, 4 observations resolved` for non-structural pages in those clusters.

**Structural pages unchanged.** SHA256 of frontmatter + body before restart (11:27:40Z) vs. after three pulses (11:44:46Z):

| page              | pre-restart sha256 | post-restart sha256 | bodyLen |
|-------------------|--------------------|---------------------|---------|
| Procedures        | `b80f28abc6798b98` | `b80f28abc6798b98`  | 12      |
| Research          | `02befb0802490d50` | `02befb0802490d50`  | 10      |
| Pending Questions | `7913bde46116af7f` | `7913bde46116af7f`  | 39427   |

No new errors, no `TypeError`, no `Cannot find module`, no `Unhandled` markers since restart.

## Test plan

- [x] Unit tests pass (45/45 wiki-steward; 220/220 full suite)
- [x] Lint clean (0 errors)
- [x] Branch signed + pushed (commits `9152af7`, `51fb6e2`)
- [x] Live restart + 3 heartbeat pulses observed
- [x] Guard skip-log fired on two distinct structural pages across two lenses
- [x] Three structural pages byte-identical before/after
- [x] Content pages still receiving normal intervention

Co-authored-by: moltagent <github@moltagent.cloud>