### PR TITLE
fix(wikisteward): restore _readNeighborhood cluster filter for current Collectives API shape (#51)

### DIFF
--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -394,6 +394,31 @@ class WikiSteward {
   }
 
   /**
+   * Return the section name for a page, or null if no section can be derived.
+   *
+   * Chain:
+   *   1. page.section (truthy) — returned directly; defensive for future API restores.
+   *   2. page.filePath (non-empty string) — first non-empty segment after split('/').
+   *   3. page.parentId === landingPageId (direct child of landing) — page.title.
+   *   4. null — landing page itself (parentId===0, empty filePath) and orphans.
+   *
+   * @param {{ section?: string, filePath?: string, parentId?: number, title?: string }} page
+   * @param {number|undefined} landingPageId
+   * @returns {string|null}
+   */
+  _getPageSection(page, landingPageId) {
+    if (page.section) return page.section;
+    if (page.filePath) {
+      const parts = page.filePath.split('/').filter(Boolean);
+      return parts[0] || null;
+    }
+    if (landingPageId && page.parentId === landingPageId && page.title) {
+      return page.title;
+    }
+    return null;
+  }
+
+  /**
    * Enumerate clusters known to the system. First attempt: read Level 0
    * landing page and parse its `## Knowledge Domains` `###` headings to get
    * cluster names. Fallback: enumerate unique `section` values from listPages().
@@ -426,14 +451,7 @@ class WikiSteward {
       const landingPageId = landingPage?.id;
       const sectionCounts = new Map();
       for (const page of pageList) {
-        let section = page.section || null;
-        if (!section && page.filePath) {
-          const parts = page.filePath.split('/').filter(Boolean);
-          section = parts[0] || null;
-        }
-        if (!section && landingPageId && page.parentId === landingPageId && page.title) {
-          section = page.title;
-        }
+        const section = this._getPageSection(page, landingPageId);
         if (section) {
           sectionCounts.set(section, (sectionCounts.get(section) || 0) + 1);
         }
@@ -480,24 +498,17 @@ class WikiSteward {
       this.collectiveId = collectiveId;
     }
 
-    // List pages that belong to this cluster by exact section match (structural truth).
-    // Section names come from _listClusters which derives them from real filesystem sections.
+    // List pages that belong to this cluster via _getPageSection (single chokepoint
+    // shared with _listClusters; resilient to Collectives API filePath shape changes).
     let clusterPages = [];
     try {
       const allPages = await this.collectivesClient.listPages(collectiveId);
       const pageList = Array.isArray(allPages) ? allPages : [];
       const clusterName = cluster.name;
 
-      clusterPages = pageList.filter(p => {
-        // Match on explicit section field first
-        if (p.section === clusterName) return true;
-        // Fallback: first path segment of filePath
-        if (!p.section && p.filePath) {
-          const parts = p.filePath.split('/');
-          return parts.length > 1 && parts[0] === clusterName;
-        }
-        return false;
-      });
+      const landingPage = pageList.find(p => p.parentId === 0);
+      const landingPageId = landingPage?.id;
+      clusterPages = pageList.filter(p => this._getPageSection(p, landingPageId) === clusterName);
     } catch (err) {
       this.logger.warn(`[WikiSteward] Failed to list pages for cluster "${cluster.name}": ${err.message}`);
       return neighborhood;

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -262,6 +262,85 @@ asyncTest('_readNeighborhood() skips pages that throw at the outer level and con
 });
 
 // ---------------------------------------------------------------------------
+// CLUSTER SECTION DERIVATION (#51 — _getPageSection + _readNeighborhood with
+// current Collectives API filePath shape)
+// ---------------------------------------------------------------------------
+
+test('_getPageSection returns section from folder-only filePath (current API shape)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ filePath: 'Documents', section: undefined, parentId: 1 }, 99);
+  assert.strictEqual(section, 'Documents');
+});
+
+test('_getPageSection honors explicit page.section when present (defensive)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ section: 'People', filePath: '', parentId: 1 }, 99);
+  assert.strictEqual(section, 'People');
+});
+
+test('_getPageSection falls back to title when page is direct child of landing', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 99, title: 'Research' },
+    99
+  );
+  assert.strictEqual(section, 'Research');
+});
+
+test('_getPageSection returns null for the landing page itself', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 0, title: 'Knowledge Domains' },
+    99
+  );
+  assert.strictEqual(section, null);
+});
+
+asyncTest('_readNeighborhood() populates pages when filePath is folder-only (current API shape)', async () => {
+  // Mimics what listPages actually returns post-API-change:
+  //   section: undefined, filePath: "Documents" (no slash, no page name).
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One': { frontmatter: { type: 'reference' }, body: 'first doc', path: 'Documents/Doc One.md' },
+      'Doc Two': { frontmatter: { type: 'reference' }, body: 'second doc', path: 'Documents/Doc Two.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 11, title: 'Doc Two',           section: undefined, filePath: 'Documents', parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.cluster, 'Documents');
+  assert.strictEqual(neighborhood.pages.length, 2, 'should include both Documents pages');
+  const titles = neighborhood.pages.map(p => p.title).sort();
+  assert.deepStrictEqual(titles, ['Doc One', 'Doc Two']);
+});
+
+asyncTest('_readNeighborhood() excludes pages belonging to other clusters', async () => {
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One':  { frontmatter: {}, body: 'doc', path: 'Documents/Doc One.md' },
+      'Carlos':   { frontmatter: {}, body: 'person', path: 'People/Carlos.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 20, title: 'Carlos',            section: undefined, filePath: 'People',    parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.pages.length, 1, 'should only include Documents pages');
+  assert.strictEqual(neighborhood.pages[0].title, 'Doc One');
+});
+
+// ---------------------------------------------------------------------------
 // KNOWLEDGE STEWARD LENS
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The Collectives OCS listPages endpoint returns filePath as the containing folder only ("Documents"), not "Documents/PageName". The _readNeighborhood filter required parts.length > 1, which is never true for folder-only paths, so every cluster filter returned zero pages and all three stewards ran their tend cycle against empty neighborhoods on every heartbeat.

Extract _getPageSection(page, landingPageId) helper shared by _listClusters and _readNeighborhood. Both methods now route through the same chain: page.section -> filePath first segment -> page.title via parentId fallback -> null. Single chokepoint, structurally resilient to future API shape changes.

Six new unit tests cover the four helper branches plus _readNeighborhood end-to-end under the current folder-only filePath shape and a cross-cluster exclusion case.

## What

<!-- What does this PR change? One or two sentences. -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #000 -->

## How

<!-- Brief description of the approach. Mention any architectural decisions. -->

## Testing

<!-- How did you verify this works? -->

- [ ] Tests pass (`npm test`)
- [ ] Tested manually against a Nextcloud instance
- [ ] No language-specific logic added (multilingual by default)

## Checklist

- [ ] Commit messages are descriptive
- [ ] No credentials, IPs, or client-specific data in the diff
- [ ] Documentation updated if needed
