### PR TITLE
fix(config): require NC_URL, remove placeholder fallback

### DIFF
--- a/scripts/run-all-tests.js
+++ b/scripts/run-all-tests.js
@@ -14,6 +14,11 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+// config.js requires NC_URL; supply a harmless test default so the suite
+// can load modules that transitively import config. The daemon's startup
+// boundary (webhook-server.js) still throws loudly when NC_URL is unset.
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const args = process.argv.slice(2);
 const runUnit = args.includes('--unit') || args.length === 0;
 const runIntegration = args.includes('--integration') || args.length === 0;

--- a/scripts/test-talk-bot.sh
+++ b/scripts/test-talk-bot.sh
@@ -12,12 +12,19 @@
 #   ./scripts/test-talk-bot.sh 3000 my-secret     # Custom port/secret
 #
 
-set -e
+set -euo pipefail
 
 # Configuration
 PORT="${1:-3000}"
 SECRET="${2:-test-secret-for-webhook-testing-must-be-long-enough}"
-BACKEND="${NC_URL:-https://YOUR_NEXTCLOUD_URL}"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./scripts/test-talk-bot.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 BASE_URL="http://localhost:${PORT}"
 
 # Colors

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -67,6 +67,27 @@ function envStr(envVar, defaultValue) {
 }
 
 /**
+ * Read a required environment variable; throw if unset or empty.
+ * Use for values where a silent placeholder fallback would mask
+ * a misconfigured deployment (e.g. base URLs, credentials).
+ * @param {string} envVar - Environment variable name
+ * @param {string} [description] - Human-readable description shown in the error
+ * @returns {string}
+ */
+function envRequired(envVar, description) {
+  const value = process.env[envVar];
+  if (value === undefined || value === '') {
+    const what = description ? ` (${description})` : '';
+    throw new Error(
+      `[config] Required environment variable ${envVar} is not set${what}. ` +
+      `Refusing to start with an unconfigured ${envVar} — a placeholder default ` +
+      `would silently leak into outbound headers and audit logs.`
+    );
+  }
+  return value;
+}
+
+/**
  * Parse comma-separated list from environment variable
  * @param {string} envVar - Environment variable name
  * @param {string[]} defaultValue - Default if not set
@@ -211,7 +232,7 @@ const config = {
   // Nextcloud Connection
   // -------------------------------------------------------------------------
   nextcloud: {
-    url: envStr('NC_URL', 'https://YOUR_NEXTCLOUD_URL'),
+    url: envRequired('NC_URL', 'Nextcloud base URL, e.g. https://nc.example.com'),
     username: envStr('NC_USER', 'moltagent')
   },
 

--- a/test/manual/knowledge-pipeline-tests.sh
+++ b/test/manual/knowledge-pipeline-tests.sh
@@ -2,8 +2,17 @@
 # Knowledge Pipeline Test Suite — 5 probes to diagnose knowledge quality
 # Sends signed webhook requests to localhost:3000 and captures pipeline logs
 
+set -euo pipefail
+
 SECRET="7d02a6d8a79d17636424b73013900ed6ad8054a610843a905ae2b42a8834023039e256db2204056680c9bf438f821eb27dc6eabc875c6768c5ee7754bda51aaf"
-BACKEND="https://YOUR_NEXTCLOUD_URL"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./test/manual/knowledge-pipeline-tests.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 ROOM="strte9d4"
 PORT=3000
 LOG_DIR="/tmp/knowledge-tests-$(date +%Y%m%d-%H%M%S)"

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -48,8 +48,14 @@ function loadConfigWithEnv(envOverrides = {}) {
     }
   }
 
+  // NC_URL is required by config.js; supply a test default unless the
+  // caller explicitly overrides it (including to '').
+  const envWithDefaults = Object.prototype.hasOwnProperty.call(envOverrides, 'NC_URL')
+    ? envOverrides
+    : { NC_URL: 'https://test.example.com', ...envOverrides };
+
   // Apply overrides
-  Object.assign(process.env, envOverrides);
+  Object.assign(process.env, envWithDefaults);
 
   // Clear require cache and reload
   delete require.cache[require.resolve('../../src/lib/config')];
@@ -64,10 +70,31 @@ console.log('\n=== Config Module Tests ===\n');
 
 // --- Default Values ---
 
-test('TC-CFG-001: Default nextcloud.url is set', () => {
-  const config = loadConfigWithEnv({});
-  assert.strictEqual(typeof config.nextcloud.url, 'string');
-  assert.ok(config.nextcloud.url.startsWith('https://'));
+test('TC-CFG-001: Missing NC_URL throws on config load', () => {
+  // Drop NC_URL out of env (loadConfigWithEnv would otherwise supply a test default).
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must refuse to load when NC_URL is not set'
+  );
+});
+
+test('TC-CFG-001a: Empty NC_URL throws on config load', () => {
+  const envOverrides = { NC_URL: '' };
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must reject NC_URL=""'
+  );
 });
 
 test('TC-CFG-002: Default nextcloud.username is moltagent', () => {

--- a/test/unit/integrations/talk-multi-room.test.js
+++ b/test/unit/integrations/talk-multi-room.test.js
@@ -14,6 +14,10 @@
  * Run: node test/unit/integrations/talk-multi-room.test.js
  */
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const assert = require('assert');
 
 let testsPassed = 0;

--- a/test/unit/providers/ollama-credential-model.test.js
+++ b/test/unit/providers/ollama-credential-model.test.js
@@ -12,6 +12,10 @@
 const assert = require('assert');
 const { test, summary, exitWithCode } = require('../../helpers/test-runner');
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 // Store original env to restore after tests
 const originalEnv = { ...process.env };
 


### PR DESCRIPTION
## Summary

- `NC_URL` is now required at config load — startup throws with a clear error instead of silently substituting `https://YOUR_NEXTCLOUD_URL` and leaking it into outbound webhook headers.
- The two webhook-test shell scripts (`scripts/test-talk-bot.sh`, `test/manual/knowledge-pipeline-tests.sh`) now use `set -euo pipefail` and require `NC_URL` instead of falling back to the placeholder.
- Systemd unit template at `deploy/moltagent.service:33` is intentionally left as-is — templates exist to be substituted at deploy time.

## Why now

Audit log on 2026-05-26T11:23:59Z caught a localhost webhook carrying `x-nextcloud-talk-backend: https://YOUR_NEXTCLOUD_URL`. The allowlist rejected it correctly, but the *source* of the placeholder string traced back to the `envStr('NC_URL', 'https://YOUR_NEXTCLOUD_URL')` fallback in `src/lib/config.js` plus two test scripts that defaulted to the same sentinel when `NC_URL` was unset in the invoking shell. A production daemon should crash immediately when its primary URL is unconfigured, not silently substitute an unreachable string and let downstream code deal with it. This is Rule 5 applied to the config boundary: narrow the pipe where it's already narrow.

## Test plan

- [x] `npm run lint` — 0 errors, no new warnings.
- [x] `npm test` — 220/220 test files pass.
- [x] `env -i node -e "require('./src/lib/config')"` — throws with `Required environment variable NC_URL is not set …` message.
- [x] `NC_URL='' node -e "require('./src/lib/config')"` — same throw.
- [x] `NC_URL=https://nx89136.your-storageshare.de node -e "require('./src/lib/config')"` — loads, `nextcloud.url` matches.
- [x] `unset NC_URL; ./scripts/test-talk-bot.sh` — exits with explicit `NC_URL is not set` message on stderr.
- [x] `unset NC_URL; ./test/manual/knowledge-pipeline-tests.sh` — same.
- [ ] After merge + deploy: confirm running daemon still starts (it already has `NC_URL=https://nx89136.your-storageshare.de` set via the installed unit, so this is belt-and-suspenders).

## Backwards-compatibility note

The systemd unit template in `deploy/` still ships with the placeholder — that's the template's job. Any deploy that copies the file unmodified and forgets to substitute `NC_URL` will now fail to start with a clear error pointing at the missing variable, rather than running with a broken default.