### PR TITLE
fix(wikisteward): write landing page frontmatter via structured path (#43)

### DIFF
--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -1606,13 +1606,9 @@ Here are the current wiki sections and their entities:
 
 ${sectionLines || '(No sections found yet.)'}
 
-Write the landing page in this format:
+Do NOT include frontmatter (no --- blocks). Write only the markdown body starting with the # heading.
 
----
-type: index
-confidence: high
-decay_days: -1
----
+Write the landing page in this format:
 
 # Moltagent Knowledge
 
@@ -1659,7 +1655,19 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
       context: { trigger: 'wiki_steward_level0', internal: true },
     });
 
-    const landingBody = (routerResult?.result || routerResult?.content || '').trim();
+    let landingBody = (routerResult?.result || routerResult?.content || '').trim();
+
+    // Belt: strip code fences the LLM may wrap around the output despite the prompt
+    landingBody = landingBody
+      .replace(/^```(?:markdown|yaml|md)?\s*\n?/i, '')
+      .replace(/\n?```\s*$/i, '');
+
+    // Belt: strip any frontmatter block the LLM may still emit despite the instruction
+    landingBody = landingBody
+      .replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '');
+
+    landingBody = landingBody.trim();
+
     if (!landingBody) {
       this.logger.warn('[WikiSteward] _updateLandingPage: LLM returned empty body');
       return { clusters: 0 };
@@ -1668,20 +1676,32 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
     // Count clusters for the return value
     const clusterMatches = landingBody.match(/^###\s+/gm) || [];
 
-    // Resolve any [[wikilinks]] the LLM emitted into live Nextcloud file links
-    // before writing. writePageContent is raw (no auto-resolve), so we must do
-    // this step explicitly here.
-    const resolvedBody = await this._resolveWikilinks(landingBody);
+    const landingFrontmatter = {
+      type: 'index',
+      confidence: 'high',
+      decay_days: -1,
+      auto_maintained: true,
+      compost: 'never',
+      last_refresh: new Date().toISOString().split('T')[0],
+    };
 
     // Write the landing page — it's the root page of the collective
+    // writePageWithFrontmatter resolves [[wikilinks]] internally; no explicit pre-resolve needed.
     try {
-      // Landing page typically lives at the collective root title
       const landingPageTitle = this.collectivesClient.collectiveName || 'Moltagent Knowledge';
-      await this.collectivesClient.writePageContent(`${landingPageTitle}.md`, resolvedBody);
+      await this.collectivesClient.writePageWithFrontmatter(
+        landingPageTitle,
+        landingFrontmatter,
+        landingBody
+      );
     } catch (err) {
-      // Fallback: try writing as plain path
+      // Fallback: try with the literal known title
       try {
-        await this.collectivesClient.writePageContent('Moltagent Knowledge.md', resolvedBody);
+        await this.collectivesClient.writePageWithFrontmatter(
+          'Moltagent Knowledge',
+          landingFrontmatter,
+          landingBody
+        );
       } catch (err2) {
         this.logger.warn(`[WikiSteward] _updateLandingPage write failed: ${err2.message}`);
         return { clusters: 0 };

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -844,11 +844,7 @@ asyncTest('tend() calls observationLog.resolve after intervention resolves types
 
 // Test 19: refreshLandingPage() builds prompt from cluster list, writes to collectivesClient
 asyncTest('refreshLandingPage() calls router and writes landing page content', async () => {
-  const mockLandingBody = `---
-type: index
----
-
-# Moltagent Knowledge
+  const mockLandingBody = `# Moltagent Knowledge
 
 ## Knowledge Domains
 
@@ -882,10 +878,131 @@ Key entities: Carlos, Eelco
   assert.ok(router._calls.length > 0, 'router should have been called');
   const routerCall = router._calls[0];
   assert.strictEqual(routerCall.job, 'synthesis');
-  // Verify the content was written somewhere
-  const writtenContent = collectivesClient._writtenContent;
-  const writtenKeys = Object.keys(writtenContent);
-  assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
+  // After the fix, landing page goes through writePageWithFrontmatter, not writePageContent
+  assert.ok(
+    collectivesClient._writtenPages['Moltagent Knowledge'],
+    'landing page should be written via writePageWithFrontmatter'
+  );
+});
+
+// Test 43.1: _updateLandingPage writes frontmatter via structured path
+asyncTest('_updateLandingPage writes frontmatter fields via writePageWithFrontmatter', async () => {
+  const cleanBody = `# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.
+Key entities: Alice`;
+
+  const router = {
+    _calls: [],
+    async route(opts) {
+      this._calls.push(opts);
+      return { result: cleanBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'writePageWithFrontmatter must be called for the landing page title');
+  assert.ok(
+    !collectivesClient._writtenContent['Moltagent Knowledge.md'],
+    'raw writePageContent must NOT be used for the landing page'
+  );
+  const fm = written.frontmatter;
+  assert.strictEqual(fm.type, 'index');
+  assert.strictEqual(fm.decay_days, -1);
+  assert.strictEqual(fm.compost, 'never');
+  assert.strictEqual(fm.auto_maintained, true);
+  assert.strictEqual(fm.confidence, 'high');
+});
+
+// Test 43.2: _updateLandingPage strips code fences from LLM output
+asyncTest('_updateLandingPage strips code fences from LLM output before writing', async () => {
+  const fencedBody = '```markdown\n# Moltagent Knowledge\n\n## Knowledge Domains\n\n### People\nContacts.\n```';
+
+  const router = {
+    async route() {
+      return { result: fencedBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after fence stripping');
+  assert.ok(!written.body.includes('```'), 'body must not contain backtick fences');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading');
+});
+
+// Test 43.3: _updateLandingPage strips rogue frontmatter from LLM output
+asyncTest('_updateLandingPage strips rogue frontmatter block from LLM output', async () => {
+  const rogueFmBody = `---
+type: index
+decay_days: -1
+---
+
+# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.`;
+
+  const router = {
+    async route() {
+      return { result: rogueFmBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after frontmatter stripping');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading, not ---');
+  assert.ok(!written.body.startsWith('---'), 'body must not begin with a frontmatter fence');
+});
+
+// Test 43.4: _updateLandingPage includes compost: never in frontmatter (focused single-fact)
+asyncTest('_updateLandingPage always sets compost: never in landing page frontmatter', async () => {
+  const router = {
+    async route() {
+      return { result: '# Moltagent Knowledge\n\n### People\nContacts.', provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  assert.strictEqual(
+    collectivesClient._writtenPages['Moltagent Knowledge'].frontmatter.compost,
+    'never'
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `WikiSteward._updateLandingPage()` asked the LLM to emit YAML frontmatter inside the page body. The LLM reliably wraps YAML in code fences, so the raw `writePageContent()` write produced unparseable frontmatter on the Level 0 landing page. `type: index`, `decay_days: -1`, and `compost: never` were invisible to every consumer.
- Separated concerns: the prompt now explicitly forbids frontmatter and emits body only. Static frontmatter is injected via `writePageWithFrontmatter`. A structural belt strips any residual code fences or rogue `---` blocks before write — markdown plumbing, not regex on natural language.
- The `last_refresh` field is recomputed per call. `compost: never` is set for the first time (couldn't be earlier — broken frontmatter blocked the pin). The explicit `_resolveWikilinks` pre-resolve was dropped because `writePageWithFrontmatter` resolves internally.

Closes #43.

## Why this matters

- The structural-page guard from PR #60 keys off `type: index` in frontmatter. With broken frontmatter the guard could not fire for the landing page — belt without trousers. This restores the trousers.
- Memory steward decay treated the landing page as default-90-day instead of `decay_days: -1`. Long-lived structural infrastructure could have been composted on a slow drift.

## Test plan

- [x] 4 new unit tests in `test/unit/maintenance/wiki-steward.test.js`: structured-path write, fence stripping, rogue-frontmatter stripping, `compost: never` present.
- [x] Existing Test 19 updated to inspect `_writtenPages` (structured) instead of `_writtenContent` (raw).
- [x] `npm run lint` — 0 errors.
- [x] `npm run test:unit` — 215/215 test files pass, 0 regressions.
- [ ] Live verification on bot VM: `refreshLandingPage()` → WebDAV read-back → frontmatter parseable → `type: index` / `decay_days: -1` / `compost: never` present → structural guard skips the landing page on next steward tend.

Co-authored-by: moltagent <github@moltagent.cloud>