### PR TITLE
Release: LKA restoration + structural guards + config hardening

### DIFF
--- a/scripts/run-all-tests.js
+++ b/scripts/run-all-tests.js
@@ -14,6 +14,11 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+// config.js requires NC_URL; supply a harmless test default so the suite
+// can load modules that transitively import config. The daemon's startup
+// boundary (webhook-server.js) still throws loudly when NC_URL is unset.
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const args = process.argv.slice(2);
 const runUnit = args.includes('--unit') || args.length === 0;
 const runIntegration = args.includes('--integration') || args.length === 0;

--- a/scripts/test-talk-bot.sh
+++ b/scripts/test-talk-bot.sh
@@ -12,12 +12,19 @@
 #   ./scripts/test-talk-bot.sh 3000 my-secret     # Custom port/secret
 #
 
-set -e
+set -euo pipefail
 
 # Configuration
 PORT="${1:-3000}"
 SECRET="${2:-test-secret-for-webhook-testing-must-be-long-enough}"
-BACKEND="${NC_URL:-https://YOUR_NEXTCLOUD_URL}"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./scripts/test-talk-bot.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 BASE_URL="http://localhost:${PORT}"
 
 # Colors

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -67,6 +67,27 @@ function envStr(envVar, defaultValue) {
 }
 
 /**
+ * Read a required environment variable; throw if unset or empty.
+ * Use for values where a silent placeholder fallback would mask
+ * a misconfigured deployment (e.g. base URLs, credentials).
+ * @param {string} envVar - Environment variable name
+ * @param {string} [description] - Human-readable description shown in the error
+ * @returns {string}
+ */
+function envRequired(envVar, description) {
+  const value = process.env[envVar];
+  if (value === undefined || value === '') {
+    const what = description ? ` (${description})` : '';
+    throw new Error(
+      `[config] Required environment variable ${envVar} is not set${what}. ` +
+      `Refusing to start with an unconfigured ${envVar} — a placeholder default ` +
+      `would silently leak into outbound headers and audit logs.`
+    );
+  }
+  return value;
+}
+
+/**
  * Parse comma-separated list from environment variable
  * @param {string} envVar - Environment variable name
  * @param {string[]} defaultValue - Default if not set
@@ -211,7 +232,7 @@ const config = {
   // Nextcloud Connection
   // -------------------------------------------------------------------------
   nextcloud: {
-    url: envStr('NC_URL', 'https://YOUR_NEXTCLOUD_URL'),
+    url: envRequired('NC_URL', 'Nextcloud base URL, e.g. https://nc.example.com'),
     username: envStr('NC_USER', 'moltagent')
   },
 

--- a/src/lib/integrations/collectives-client.js
+++ b/src/lib/integrations/collectives-client.js
@@ -45,6 +45,10 @@ class CollectivesClient {
     this.baseUrl = this.nc.ncUrl;
     this.username = this.nc.ncUser || 'moltagent';
 
+    // Optional logger; falls back to console so section-collision diagnostics
+    // still reach journald when no structured logger is wired in.
+    this.logger = config.logger || console;
+
     // Configuration
     this.collectiveName = config.collectiveName || appConfig.knowledge?.collectiveName || 'Moltagent Knowledge';
 
@@ -79,7 +83,7 @@ class CollectivesClient {
    * @param {Object} [body] - Request body
    * @returns {Promise<Object>} Response body
    */
-  async _ocsRequest(method, path, body = null) {
+  async _ocsRequest(method, path, body = null, { skipCache = false } = {}) {
     const url = `${this.ocsBase}${path}`;
     const options = {
       method,
@@ -88,6 +92,10 @@ class CollectivesClient {
         'Accept': 'application/json'
       }
     };
+
+    // Force a fresh read past the NCRequestManager response cache. Used by
+    // ensureSection so its existence check never decides on a stale page list.
+    if (skipCache) options.skipCache = true;
 
     if (body && (method === 'POST' || method === 'PUT')) {
       options.headers['Content-Type'] = 'application/json';
@@ -235,10 +243,12 @@ class CollectivesClient {
   /**
    * List all pages in a collective
    * @param {number} collectiveId - Collective ID
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Array>} List of pages
    */
-  async listPages(collectiveId) {
-    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`);
+  async listPages(collectiveId, { skipCache = false } = {}) {
+    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`, null, { skipCache });
     return data?.pages || data || [];
   }
 
@@ -301,8 +311,10 @@ class CollectivesClient {
     this._sectionLocks.set(lockKey, lock);
 
     try {
-      // Re-check after acquiring lock in case a previous run just created it.
-      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId);
+      // Re-check after acquiring the lock in case a previous run just created
+      // it. skipCache: this existence check is the gate that decides whether to
+      // create — a stale page list here is exactly what produces "(2)" sections.
+      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
       if (existing) {
         this._sectionCache.set(lockKey, existing);
         return existing;
@@ -318,6 +330,39 @@ class CollectivesClient {
       }
 
       const created = await this.createPage(collectiveId, actualParentId, sectionName);
+
+      // Post-creation collision guard. If the existence check still raced a
+      // stale listing, Collectives appends "(N)" to disambiguate. Detect that
+      // suffix, trash the artifact, and return the real section instead —
+      // otherwise the duplicate accumulates on every heartbeat (issue #25).
+      const wanted = (sectionName || '').toLowerCase().trim();
+      const suffixMatch = (created?.title || '').match(/^(.*?)\s*\(\d+\)\s*$/);
+      if (suffixMatch && suffixMatch[1].toLowerCase().trim() === wanted) {
+        const real = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
+        if (real && real.id !== created.id) {
+          this.logger.warn(
+            `[Collectives] ensureSection collision: requested "${sectionName}", ` +
+            `got "${created.title}". Trashing duplicate and returning existing.`
+          );
+          try {
+            await this.trashPage(collectiveId, created.id);
+          } catch (err) {
+            this.logger.warn(
+              `[Collectives] Failed to trash collision artifact "${created.title}" ` +
+              `(id ${created.id}): ${err.message}`
+            );
+          }
+          this._sectionCache.set(lockKey, real);
+          return real;
+        }
+        // No un-suffixed section to fall back to — keep the suffixed page rather
+        // than lose the section entirely. Log so it is visible for manual cleanup.
+        this.logger.warn(
+          `[Collectives] ensureSection got "${created.title}" for "${sectionName}" ` +
+          'but found no un-suffixed section to fall back to — keeping it.'
+        );
+      }
+
       this._sectionCache.set(lockKey, created);
       return created;
     } finally {
@@ -336,11 +381,14 @@ class CollectivesClient {
    *
    * @param {number} collectiveId - Collective ID
    * @param {string} sectionName  - Target section title
+   * @param {number|null} [parentPageId] - Restrict search to children of this page
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Object|null>} Page object or null if not found
    * @private
    */
-  async _findSectionPage(collectiveId, sectionName, parentPageId = null) {
-    const pages = await this.listPages(collectiveId);
+  async _findSectionPage(collectiveId, sectionName, parentPageId = null, { skipCache = false } = {}) {
+    const pages = await this.listPages(collectiveId, { skipCache });
     const pageList = Array.isArray(pages) ? pages : [];
     const target = (sectionName || '').toLowerCase().trim();
 

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -1606,13 +1606,9 @@ Here are the current wiki sections and their entities:
 
 ${sectionLines || '(No sections found yet.)'}
 
-Write the landing page in this format:
+Do NOT include frontmatter (no --- blocks). Write only the markdown body starting with the # heading.
 
----
-type: index
-confidence: high
-decay_days: -1
----
+Write the landing page in this format:
 
 # Moltagent Knowledge
 
@@ -1659,7 +1655,19 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
       context: { trigger: 'wiki_steward_level0', internal: true },
     });
 
-    const landingBody = (routerResult?.result || routerResult?.content || '').trim();
+    let landingBody = (routerResult?.result || routerResult?.content || '').trim();
+
+    // Belt: strip code fences the LLM may wrap around the output despite the prompt
+    landingBody = landingBody
+      .replace(/^```(?:markdown|yaml|md)?\s*\n?/i, '')
+      .replace(/\n?```\s*$/i, '');
+
+    // Belt: strip any frontmatter block the LLM may still emit despite the instruction
+    landingBody = landingBody
+      .replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '');
+
+    landingBody = landingBody.trim();
+
     if (!landingBody) {
       this.logger.warn('[WikiSteward] _updateLandingPage: LLM returned empty body');
       return { clusters: 0 };
@@ -1668,20 +1676,32 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
     // Count clusters for the return value
     const clusterMatches = landingBody.match(/^###\s+/gm) || [];
 
-    // Resolve any [[wikilinks]] the LLM emitted into live Nextcloud file links
-    // before writing. writePageContent is raw (no auto-resolve), so we must do
-    // this step explicitly here.
-    const resolvedBody = await this._resolveWikilinks(landingBody);
+    const landingFrontmatter = {
+      type: 'index',
+      confidence: 'high',
+      decay_days: -1,
+      auto_maintained: true,
+      compost: 'never',
+      last_refresh: new Date().toISOString().split('T')[0],
+    };
 
     // Write the landing page — it's the root page of the collective
+    // writePageWithFrontmatter resolves [[wikilinks]] internally; no explicit pre-resolve needed.
     try {
-      // Landing page typically lives at the collective root title
       const landingPageTitle = this.collectivesClient.collectiveName || 'Moltagent Knowledge';
-      await this.collectivesClient.writePageContent(`${landingPageTitle}.md`, resolvedBody);
+      await this.collectivesClient.writePageWithFrontmatter(
+        landingPageTitle,
+        landingFrontmatter,
+        landingBody
+      );
     } catch (err) {
-      // Fallback: try writing as plain path
+      // Fallback: try with the literal known title
       try {
-        await this.collectivesClient.writePageContent('Moltagent Knowledge.md', resolvedBody);
+        await this.collectivesClient.writePageWithFrontmatter(
+          'Moltagent Knowledge',
+          landingFrontmatter,
+          landingBody
+        );
       } catch (err2) {
         this.logger.warn(`[WikiSteward] _updateLandingPage write failed: ${err2.message}`);
         return { clusters: 0 };

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -743,7 +743,18 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
    * @returns {string} Prompt text.
    */
   _connectionAssessmentPrompt(neighborhood) {
-    const pageLinks = neighborhood.pages.map(p =>
+    // Structural guard: section index / navigation pages are not knowledge
+    // entities and must never be link targets. Drop them from the data the LLM
+    // sees so it cannot suggest links to "Documents", "People", etc. Index
+    // pages carry `type: index`; structural pages carry the `compost: never`
+    // pin. The prompt EXCLUSION instruction below is the intelligence-layer
+    // counterpart — belt and suspenders.
+    const contentPages = neighborhood.pages.filter(p => {
+      const fm = p.frontmatter || {};
+      return fm.type !== 'index' && fm.compost !== 'never';
+    });
+
+    const pageLinks = contentPages.map(p =>
       `### ${p.title}\n` +
       `Graph connections: ${p.graphConnections.map(e => `${e.predicate} → ${e.object}`).join(', ') || 'none'}\n` +
       `Wikilinks in content: ${p.wikilinks.join(', ') || 'none'}`
@@ -767,6 +778,12 @@ Near-duplicate (EN): Pages "ManeraMedia GmbH" and "Manera Media GmbH" likely des
 Near-duplicate (DE): Die Seiten "ManeraMedia GmbH" und "Manera Media GmbH" beschreiben wahrscheinlich dieselbe Organisation.
 Near-duplicate (PT): As páginas "ManeraMedia GmbH" e "Manera Media GmbH" provavelmente descrevem a mesma organização.
 ---
+
+EXCLUSION: Do NOT suggest links to section index pages. Pages whose type is "index"
+or whose title matches a top-level section name (Documents, People, Projects,
+Organizations, Research, Procedures, Images, Meta, emails) are structural navigation,
+not knowledge entities. They must never appear in missingLinks or orphan suggestions.
+Only suggest links between actual knowledge entities (people, projects, documents, concepts).
 
 Here are the pages with their graph connections and wikilinks:
 
@@ -1121,8 +1138,15 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
     const body = result.body || '';
 
-    // Idempotency: skip if [[target]] already appears anywhere in the body
+    // Idempotency: skip if the link to `target` already appears in the body,
+    // in EITHER form. writePageWithFrontmatter() runs resolveWikilinks() before
+    // every write, transforming [[target]] into [target](url). On the next
+    // heartbeat read only the resolved form remains — so a check for the
+    // unresolved form alone passes and appends a duplicate every cycle.
+    // Matching `[target](` is structural markdown-link syntax, not natural
+    // language, so it is allowed under the language policy.
     if (body.includes(`[[${target}]]`)) return false;
+    if (body.includes(`[${target}](`)) return false;
 
     // Append a Related section entry
     const relLine = `\n- [[${target}]] (${relationship || 'related'})\n`;
@@ -1260,13 +1284,11 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
     fm.compost_reason = reason || 'Marked by Memory Steward';
     fm.compost_marked_at = new Date().toISOString();
 
-    let body = result.body || '';
-    const markerSignature = 'Archived by Memory Steward';
-    if (!body.includes(markerSignature)) {
-      body = `${body}\n\n---\n_${markerSignature}: ${reason || 'Marked by Memory Steward'}_\n`;
-    }
-
-    await this.collectivesClient.writePageWithFrontmatter(page, fm, body);
+    // Frontmatter carries the compost state. No inline body annotation:
+    // it was redundant with compost_ready/compost_reason/compost_marked_at and
+    // disrupted the Connection Steward's `## Related` section regex by inserting
+    // content between the heading and EOF. The body holds knowledge only.
+    await this.collectivesClient.writePageWithFrontmatter(page, fm, result.body || '');
     this.logger.info(`[WikiSteward:memory] Marked "${page}" for composting: ${reason}`);
     return true;
   }

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -394,6 +394,31 @@ class WikiSteward {
   }
 
   /**
+   * Return the section name for a page, or null if no section can be derived.
+   *
+   * Chain:
+   *   1. page.section (truthy) — returned directly; defensive for future API restores.
+   *   2. page.filePath (non-empty string) — first non-empty segment after split('/').
+   *   3. page.parentId === landingPageId (direct child of landing) — page.title.
+   *   4. null — landing page itself (parentId===0, empty filePath) and orphans.
+   *
+   * @param {{ section?: string, filePath?: string, parentId?: number, title?: string }} page
+   * @param {number|undefined} landingPageId
+   * @returns {string|null}
+   */
+  _getPageSection(page, landingPageId) {
+    if (page.section) return page.section;
+    if (page.filePath) {
+      const parts = page.filePath.split('/').filter(Boolean);
+      return parts[0] || null;
+    }
+    if (landingPageId && page.parentId === landingPageId && page.title) {
+      return page.title;
+    }
+    return null;
+  }
+
+  /**
    * Enumerate clusters known to the system. First attempt: read Level 0
    * landing page and parse its `## Knowledge Domains` `###` headings to get
    * cluster names. Fallback: enumerate unique `section` values from listPages().
@@ -426,14 +451,7 @@ class WikiSteward {
       const landingPageId = landingPage?.id;
       const sectionCounts = new Map();
       for (const page of pageList) {
-        let section = page.section || null;
-        if (!section && page.filePath) {
-          const parts = page.filePath.split('/').filter(Boolean);
-          section = parts[0] || null;
-        }
-        if (!section && landingPageId && page.parentId === landingPageId && page.title) {
-          section = page.title;
-        }
+        const section = this._getPageSection(page, landingPageId);
         if (section) {
           sectionCounts.set(section, (sectionCounts.get(section) || 0) + 1);
         }
@@ -480,24 +498,17 @@ class WikiSteward {
       this.collectiveId = collectiveId;
     }
 
-    // List pages that belong to this cluster by exact section match (structural truth).
-    // Section names come from _listClusters which derives them from real filesystem sections.
+    // List pages that belong to this cluster via _getPageSection (single chokepoint
+    // shared with _listClusters; resilient to Collectives API filePath shape changes).
     let clusterPages = [];
     try {
       const allPages = await this.collectivesClient.listPages(collectiveId);
       const pageList = Array.isArray(allPages) ? allPages : [];
       const clusterName = cluster.name;
 
-      clusterPages = pageList.filter(p => {
-        // Match on explicit section field first
-        if (p.section === clusterName) return true;
-        // Fallback: first path segment of filePath
-        if (!p.section && p.filePath) {
-          const parts = p.filePath.split('/');
-          return parts.length > 1 && parts[0] === clusterName;
-        }
-        return false;
-      });
+      const landingPage = pageList.find(p => p.parentId === 0);
+      const landingPageId = landingPage?.id;
+      clusterPages = pageList.filter(p => this._getPageSection(p, landingPageId) === clusterName);
     } catch (err) {
       this.logger.warn(`[WikiSteward] Failed to list pages for cluster "${cluster.name}": ${err.message}`);
       return neighborhood;

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -890,6 +890,25 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
   // ---------------------------------------------------------------------------
 
   /**
+   * Determine whether a page is structural infrastructure that should not be
+   * modified by steward interventions. Structural pages serve as navigation
+   * scaffolding (section indexes, landing pages, meta pages) — their content
+   * is either auto-maintained by the fractal index refresh or intentionally
+   * minimal. Frontmatter `type: section|index|meta` marks them by role; the
+   * `compost: never` pin marks them by lifecycle policy. Either is sufficient.
+   *
+   * @param {EnrichedPage} page - Page object from neighborhood.pages
+   * @returns {boolean}
+   */
+  _isStructuralPage(page) {
+    if (!page || !page.frontmatter) return false;
+    const t = page.frontmatter.type;
+    if (t === 'section' || t === 'index' || t === 'meta') return true;
+    if (page.frontmatter.compost === 'never') return true;
+    return false;
+  }
+
+  /**
    * Execute the assessment's recommended actions. Each steward type dispatches
    * to a different set of per-action executors (the "farm hand" operations).
    *
@@ -910,9 +929,24 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       return results;
     }
 
+    // Structural pages are infrastructure, not content. Skip all interventions
+    // on them — they are maintained by the fractal index refresh cycle, not by
+    // steward assessments. Defense in depth alongside the prompt-level
+    // exclusion in _connectionAssessmentPrompt and the compost: never pin
+    // honored by _markForComposting.
+    const structuralTitles = new Set(
+      (neighborhood?.pages || [])
+        .filter(p => this._isStructuralPage(p))
+        .map(p => p.title)
+    );
+
     switch (stewardType) {
       case 'knowledge': {
         for (const c of assessment.contradictions || []) {
+          if (structuralTitles.has(c.pageA) || structuralTitles.has(c.pageB)) {
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page in contradiction: "${c.pageA}" / "${c.pageB}"`);
+            continue;
+          }
           try {
             const flagged = await this._flagContradiction(c.pageA, c.pageB, c.claim);
             if (flagged) results.pagesModified += 2;
@@ -921,6 +955,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const s of assessment.stale || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page "${s.page}" for staleness`);
+            continue;
+          }
           try {
             const lowered = await this._lowerConfidence(s.page, s.reason);
             if (lowered) results.pagesModified++;
@@ -928,6 +966,9 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             this.logger.warn(`[WikiSteward:knowledge] _lowerConfidence("${s.page}") failed: ${err.message}`);
           }
         }
+        // _logKnowledgeGap writes to Meta/Pending Questions, not to the
+        // referenced page — the gap observation is valid even if the
+        // referencing page is structural. No guard needed here.
         for (const g of assessment.gaps || []) {
           try {
             await this._logKnowledgeGap(g.entity, g.referencedIn);
@@ -941,6 +982,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'connection': {
         for (const m of assessment.missingLinks || []) {
+          if (structuralTitles.has(m.page)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${m.page}" for missing link`);
+            continue;
+          }
           try {
             const added = await this._addWikilink(m.page, m.shouldLinkTo, m.relationship);
             if (added) {
@@ -952,6 +997,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const o of assessment.orphans || []) {
+          if (structuralTitles.has(o.page)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${o.page}" for orphan resolution`);
+            continue;
+          }
           for (const target of o.suggestedConnections || []) {
             try {
               const added = await this._addWikilink(o.page, target, 'related');
@@ -965,6 +1014,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const d of assessment.nearDuplicates || []) {
+          if (structuralTitles.has(d.pageA) || structuralTitles.has(d.pageB)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page in duplicate check: "${d.pageA}" / "${d.pageB}"`);
+            continue;
+          }
           try {
             await this._flagDuplicate(d.pageA, d.pageB, d.similarity || 0);
           } catch (err) {
@@ -977,6 +1030,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'memory': {
         for (const s of assessment.strengthen || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${s.page}" for strengthening`);
+            continue;
+          }
           try {
             const strengthened = await this._strengthenPage(s.page);
             if (strengthened) results.pagesModified++;
@@ -985,6 +1042,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const c of assessment.compost || []) {
+          if (structuralTitles.has(c.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${c.page}" for composting`);
+            continue;
+          }
           try {
             await this._markForComposting(c.page, c.reason);
           } catch (err) {
@@ -992,6 +1053,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const e of assessment.embed || []) {
+          if (structuralTitles.has(e.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${e.page}" for embedding`);
+            continue;
+          }
           // Find the full pageRef from neighborhood so _embedPage has path/section
           const pageRef = neighborhood.pages.find(p => p.title === e.page) || { id: null, title: e.page };
           try {

--- a/src/lib/workflows/schedule-handler.js
+++ b/src/lib/workflows/schedule-handler.js
@@ -49,6 +49,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const DeckClient = require('../integrations/deck-client');
 
 // ─── HTML normalisation ──────────────────────────────────────────────
 
@@ -296,8 +297,27 @@ class ScheduleHandler {
     console.log(`[Schedule] Parsed ${schedules.length} schedule(s) from "${wb.board.title}"`);
     if (schedules.length === 0) return result;
 
+    // PAUSED chokepoint (#28, same generator as #13/#17/#22): if any stack
+    // on this board has a CONFIG card with the PAUSED label, no schedule
+    // on the board fires. The structural guard at DeckClient.createCardOnBoard
+    // would catch the writes, but the schedule's LLM agent loop runs to
+    // completion first — burning cloud spend and pulse time before the
+    // result gets thrown away. Guard at the firing point.
+    const pausedStacks = (wb.stacks || []).filter(s => DeckClient.stackHasPausedConfig(s));
+    for (const stack of pausedStacks) {
+      console.log(`[Workflow] Stack "${stack.title}" skipped for schedules — CONFIG card has PAUSED label`);
+    }
+
     for (const schedule of schedules) {
       try {
+        if (pausedStacks.length > 0) {
+          for (const ps of pausedStacks) {
+            console.log(`[Schedule] Skipping schedule on PAUSED stack: "${schedule.action}" (board=${wb.board.id}, stack=${ps.id})`);
+          }
+          result.skipped++;
+          continue;
+        }
+
         if (!this._isDue(wb.board.id, schedule)) {
           result.skipped++;
           continue;

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -278,26 +278,14 @@ class WorkflowEngine {
       }
     }
 
-    // Process SCHEDULE block from board rules (timed actions)
+    // Process SCHEDULE block from board rules (timed actions).
+    // PAUSED-stack handling lives inside ScheduleHandler.processSchedules
+    // (#28): if any stack on this board has a PAUSED CONFIG card, every
+    // schedule on the board is skipped before its LLM agent loop fires.
     try {
-      // Filter out PAUSED stacks so schedules cannot target them.
-      // The schedule handler builds LLM context from wb.stacks — if a stack
-      // is absent, the LLM cannot see it, reference it, or create cards in it.
-      const pausedStackNames = [];
-      const activeStacks = stacks.filter(stack => {
-        if (DeckClient.stackHasPausedConfig(stack)) {
-          console.log(`[Workflow] Stack "${stack.title}" skipped for schedules — CONFIG card has PAUSED label`);
-          pausedStackNames.push(stack.title);
-          return false;
-        }
-        return true;
-      });
-      const schedWb = activeStacks.length < stacks.length
-        ? { ...wb, stacks: activeStacks, _pausedStacks: pausedStackNames }
-        : wb;
       // Respect board-level MODEL directive for schedule actions
       const boardForceLocal = this._getBoardForceLocal(wb);
-      const schedResult = await this._scheduleHandler.processSchedules(schedWb, { forceLocal: boardForceLocal });
+      const schedResult = await this._scheduleHandler.processSchedules(wb, { forceLocal: boardForceLocal });
       result.schedulesExecuted = schedResult.executed;
       if (schedResult.executed > 0) {
         console.log(`[Workflow] Schedules on "${board.title}": ${schedResult.executed} executed, ${schedResult.skipped} skipped`);

--- a/test/manual/knowledge-pipeline-tests.sh
+++ b/test/manual/knowledge-pipeline-tests.sh
@@ -2,8 +2,17 @@
 # Knowledge Pipeline Test Suite — 5 probes to diagnose knowledge quality
 # Sends signed webhook requests to localhost:3000 and captures pipeline logs
 
+set -euo pipefail
+
 SECRET="7d02a6d8a79d17636424b73013900ed6ad8054a610843a905ae2b42a8834023039e256db2204056680c9bf438f821eb27dc6eabc875c6768c5ee7754bda51aaf"
-BACKEND="https://YOUR_NEXTCLOUD_URL"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./test/manual/knowledge-pipeline-tests.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 ROOM="strte9d4"
 PORT=3000
 LOG_DIR="/tmp/knowledge-tests-$(date +%Y%m%d-%H%M%S)"

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -48,8 +48,14 @@ function loadConfigWithEnv(envOverrides = {}) {
     }
   }
 
+  // NC_URL is required by config.js; supply a test default unless the
+  // caller explicitly overrides it (including to '').
+  const envWithDefaults = Object.prototype.hasOwnProperty.call(envOverrides, 'NC_URL')
+    ? envOverrides
+    : { NC_URL: 'https://test.example.com', ...envOverrides };
+
   // Apply overrides
-  Object.assign(process.env, envOverrides);
+  Object.assign(process.env, envWithDefaults);
 
   // Clear require cache and reload
   delete require.cache[require.resolve('../../src/lib/config')];
@@ -64,10 +70,31 @@ console.log('\n=== Config Module Tests ===\n');
 
 // --- Default Values ---
 
-test('TC-CFG-001: Default nextcloud.url is set', () => {
-  const config = loadConfigWithEnv({});
-  assert.strictEqual(typeof config.nextcloud.url, 'string');
-  assert.ok(config.nextcloud.url.startsWith('https://'));
+test('TC-CFG-001: Missing NC_URL throws on config load', () => {
+  // Drop NC_URL out of env (loadConfigWithEnv would otherwise supply a test default).
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must refuse to load when NC_URL is not set'
+  );
+});
+
+test('TC-CFG-001a: Empty NC_URL throws on config load', () => {
+  const envOverrides = { NC_URL: '' };
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must reject NC_URL=""'
+  );
 });
 
 test('TC-CFG-002: Default nextcloud.username is moltagent', () => {

--- a/test/unit/integrations/collectives-client.test.js
+++ b/test/unit/integrations/collectives-client.test.js
@@ -487,6 +487,71 @@ asyncTest('writePageWithFrontmatter resolves wikilinks before writing', async ()
   assert.ok(!writtenContent.includes('[['), 'Should not contain raw wikilinks');
 });
 
+// -- ensureSection — collision dedup (Fix D) --
+
+const silentLogger = { warn() {}, info() {}, error() {}, debug() {} };
+
+asyncTest('ensureSection returns the existing section without creating', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createCalls = 0;
+  client.createPage = async () => { createCalls++; return { id: 999, title: 'WRONG' }; };
+  client.listPages = async () => ([
+    { id: 1, title: 'Landing page', parentId: 0 },
+    { id: 2, title: 'Documents', parentId: 1 },
+  ]);
+
+  const result = await client.ensureSection(10, 'Documents');
+  assert.strictEqual(result.id, 2, 'should return the existing Documents section');
+  assert.strictEqual(createCalls, 0, 'createPage must not be called when the section exists');
+});
+
+asyncTest('ensureSection creates the section when it does not exist', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createArgs = null;
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async (cid, parentId, title) => {
+    createArgs = { cid, parentId, title };
+    return { id: 50, title, parentId };
+  };
+
+  const result = await client.ensureSection(10, 'Research');
+  assert.strictEqual(result.id, 50, 'should return the newly created section');
+  assert.deepStrictEqual(createArgs, { cid: 10, parentId: 1, title: 'Research' });
+});
+
+asyncTest('ensureSection detects a (N) collision and trashes the artifact', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  let listCalls = 0;
+  // The pre-create check races a stale list (no Documents). After createPage
+  // collides, the fresh skipCache re-find sees the real Documents section.
+  client.listPages = async () => {
+    listCalls++;
+    const pages = [{ id: 1, title: 'Landing page', parentId: 0 }];
+    if (listCalls >= 2) pages.push({ id: 7, title: 'Documents', parentId: 1 });
+    return pages;
+  };
+  client.createPage = async () => ({ id: 99, title: 'Documents (2)', parentId: 1 });
+  let trashedId = null;
+  client.trashPage = async (cid, pid) => { trashedId = pid; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashedId, 99, 'the (2) collision artifact should be trashed');
+  assert.strictEqual(result.id, 7, 'should return the real Documents section, not the artifact');
+});
+
+asyncTest('ensureSection keeps the suffixed page when no real section can be found', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  // Both the pre-check and the post-collision re-find see no un-suffixed section.
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async () => ({ id: 88, title: 'Documents (2)', parentId: 1 });
+  let trashed = false;
+  client.trashPage = async () => { trashed = true; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashed, false, 'must not trash when there is no section to fall back to');
+  assert.strictEqual(result.id, 88, 'should keep the suffixed page rather than lose the section');
+});
+
 // ============================================================
 // Summary
 // ============================================================

--- a/test/unit/integrations/talk-multi-room.test.js
+++ b/test/unit/integrations/talk-multi-room.test.js
@@ -14,6 +14,10 @@
  * Run: node test/unit/integrations/talk-multi-room.test.js
  */
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const assert = require('assert');
 
 let testsPassed = 0;

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -262,6 +262,85 @@ asyncTest('_readNeighborhood() skips pages that throw at the outer level and con
 });
 
 // ---------------------------------------------------------------------------
+// CLUSTER SECTION DERIVATION (#51 — _getPageSection + _readNeighborhood with
+// current Collectives API filePath shape)
+// ---------------------------------------------------------------------------
+
+test('_getPageSection returns section from folder-only filePath (current API shape)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ filePath: 'Documents', section: undefined, parentId: 1 }, 99);
+  assert.strictEqual(section, 'Documents');
+});
+
+test('_getPageSection honors explicit page.section when present (defensive)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ section: 'People', filePath: '', parentId: 1 }, 99);
+  assert.strictEqual(section, 'People');
+});
+
+test('_getPageSection falls back to title when page is direct child of landing', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 99, title: 'Research' },
+    99
+  );
+  assert.strictEqual(section, 'Research');
+});
+
+test('_getPageSection returns null for the landing page itself', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 0, title: 'Knowledge Domains' },
+    99
+  );
+  assert.strictEqual(section, null);
+});
+
+asyncTest('_readNeighborhood() populates pages when filePath is folder-only (current API shape)', async () => {
+  // Mimics what listPages actually returns post-API-change:
+  //   section: undefined, filePath: "Documents" (no slash, no page name).
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One': { frontmatter: { type: 'reference' }, body: 'first doc', path: 'Documents/Doc One.md' },
+      'Doc Two': { frontmatter: { type: 'reference' }, body: 'second doc', path: 'Documents/Doc Two.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 11, title: 'Doc Two',           section: undefined, filePath: 'Documents', parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.cluster, 'Documents');
+  assert.strictEqual(neighborhood.pages.length, 2, 'should include both Documents pages');
+  const titles = neighborhood.pages.map(p => p.title).sort();
+  assert.deepStrictEqual(titles, ['Doc One', 'Doc Two']);
+});
+
+asyncTest('_readNeighborhood() excludes pages belonging to other clusters', async () => {
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One':  { frontmatter: {}, body: 'doc', path: 'Documents/Doc One.md' },
+      'Carlos':   { frontmatter: {}, body: 'person', path: 'People/Carlos.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 20, title: 'Carlos',            section: undefined, filePath: 'People',    parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.pages.length, 1, 'should only include Documents pages');
+  assert.strictEqual(neighborhood.pages[0].title, 'Doc One');
+});
+
+// ---------------------------------------------------------------------------
 // KNOWLEDGE STEWARD LENS
 // ---------------------------------------------------------------------------
 

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -844,11 +844,7 @@ asyncTest('tend() calls observationLog.resolve after intervention resolves types
 
 // Test 19: refreshLandingPage() builds prompt from cluster list, writes to collectivesClient
 asyncTest('refreshLandingPage() calls router and writes landing page content', async () => {
-  const mockLandingBody = `---
-type: index
----
-
-# Moltagent Knowledge
+  const mockLandingBody = `# Moltagent Knowledge
 
 ## Knowledge Domains
 
@@ -882,10 +878,131 @@ Key entities: Carlos, Eelco
   assert.ok(router._calls.length > 0, 'router should have been called');
   const routerCall = router._calls[0];
   assert.strictEqual(routerCall.job, 'synthesis');
-  // Verify the content was written somewhere
-  const writtenContent = collectivesClient._writtenContent;
-  const writtenKeys = Object.keys(writtenContent);
-  assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
+  // After the fix, landing page goes through writePageWithFrontmatter, not writePageContent
+  assert.ok(
+    collectivesClient._writtenPages['Moltagent Knowledge'],
+    'landing page should be written via writePageWithFrontmatter'
+  );
+});
+
+// Test 43.1: _updateLandingPage writes frontmatter via structured path
+asyncTest('_updateLandingPage writes frontmatter fields via writePageWithFrontmatter', async () => {
+  const cleanBody = `# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.
+Key entities: Alice`;
+
+  const router = {
+    _calls: [],
+    async route(opts) {
+      this._calls.push(opts);
+      return { result: cleanBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'writePageWithFrontmatter must be called for the landing page title');
+  assert.ok(
+    !collectivesClient._writtenContent['Moltagent Knowledge.md'],
+    'raw writePageContent must NOT be used for the landing page'
+  );
+  const fm = written.frontmatter;
+  assert.strictEqual(fm.type, 'index');
+  assert.strictEqual(fm.decay_days, -1);
+  assert.strictEqual(fm.compost, 'never');
+  assert.strictEqual(fm.auto_maintained, true);
+  assert.strictEqual(fm.confidence, 'high');
+});
+
+// Test 43.2: _updateLandingPage strips code fences from LLM output
+asyncTest('_updateLandingPage strips code fences from LLM output before writing', async () => {
+  const fencedBody = '```markdown\n# Moltagent Knowledge\n\n## Knowledge Domains\n\n### People\nContacts.\n```';
+
+  const router = {
+    async route() {
+      return { result: fencedBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after fence stripping');
+  assert.ok(!written.body.includes('```'), 'body must not contain backtick fences');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading');
+});
+
+// Test 43.3: _updateLandingPage strips rogue frontmatter from LLM output
+asyncTest('_updateLandingPage strips rogue frontmatter block from LLM output', async () => {
+  const rogueFmBody = `---
+type: index
+decay_days: -1
+---
+
+# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.`;
+
+  const router = {
+    async route() {
+      return { result: rogueFmBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after frontmatter stripping');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading, not ---');
+  assert.ok(!written.body.startsWith('---'), 'body must not begin with a frontmatter fence');
+});
+
+// Test 43.4: _updateLandingPage includes compost: never in frontmatter (focused single-fact)
+asyncTest('_updateLandingPage always sets compost: never in landing page frontmatter', async () => {
+  const router = {
+    async route() {
+      return { result: '# Moltagent Knowledge\n\n### People\nContacts.', provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  assert.strictEqual(
+    collectivesClient._writtenPages['Moltagent Knowledge'].frontmatter.compost,
+    'never'
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -888,4 +888,219 @@ Key entities: Carlos, Eelco
   assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
 });
 
+// ---------------------------------------------------------------------------
+// STRUCTURAL PAGE GUARD (#59) — _isStructuralPage + _intervene chokepoint
+// ---------------------------------------------------------------------------
+
+// Helper: build a neighborhood with arbitrary pages for intervention tests
+function makeInterveneNeighborhood(pages, cluster = 'Documents') {
+  return {
+    cluster,
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: cluster,
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set([cluster]),
+    deckCards: [],
+  };
+}
+
+// Test #59.1: _isStructuralPage returns true for type: section
+test('_isStructuralPage returns true for type:section', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'section' } }), true);
+});
+
+// Test #59.2: _isStructuralPage returns true for type: index
+test('_isStructuralPage returns true for type:index', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'index' } }), true);
+});
+
+// Test #59.3: _isStructuralPage returns true for type: meta
+test('_isStructuralPage returns true for type:meta', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'meta' } }), true);
+});
+
+// Test #59.4: _isStructuralPage returns true for compost: never (lifecycle pin)
+test('_isStructuralPage returns true for compost:never (lifecycle pin)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', compost: 'never' } }),
+    true,
+    'compost: never alone marks a page as structural infrastructure'
+  );
+});
+
+// Test #59.5: _isStructuralPage returns false for normal content page
+test('_isStructuralPage returns false for normal content page', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', confidence: 'high' } }),
+    false
+  );
+});
+
+// Test #59.6: _isStructuralPage returns false for page with no frontmatter
+test('_isStructuralPage returns false for page with missing/empty frontmatter', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: null }), false);
+  assert.strictEqual(steward._isStructuralPage({}), false);
+  assert.strictEqual(steward._isStructuralPage(null), false);
+});
+
+// Test #59.7: Connection Steward skips structural page in missingLinks loop
+asyncTest('_intervene(connection): skips structural page in missingLinks', async () => {
+  const pagesByTitle = {
+    'Carlos':    { frontmatter: {}, body: 'Content page.', path: 'People/Carlos.md' },
+    'Documents': { frontmatter: { type: 'index' }, body: '# Documents', path: 'Documents.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',    frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Documents', shouldLinkTo: 'Eelco', relationship: 'related' },
+      { page: 'Carlos',    shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Documents'],
+    'structural page (type:index) must not be written by Connection Steward'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still receive its wikilink'
+  );
+});
+
+// Test #59.8: Memory Steward skips structural page in compost loop
+asyncTest('_intervene(memory): skips structural page in compost', async () => {
+  const pagesByTitle = {
+    'Carlos':   { frontmatter: { confidence: 'low' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Research': { frontmatter: { type: 'index', compost: 'never' }, body: '# Research', path: 'Research.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',   frontmatter: { confidence: 'low' } },
+    { title: 'Research', frontmatter: { type: 'index', compost: 'never' } },
+  ]);
+
+  const assessment = {
+    strengthen: [],
+    compost: [
+      { page: 'Research', reason: 'Never accessed' },
+      { page: 'Carlos',   reason: 'Stale and unaccessed' },
+    ],
+    embed: [],
+  };
+
+  await steward._intervene('memory', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Research'],
+    'structural page (type:index + compost:never) must not be touched by _markForComposting'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still be marked for composting'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.compost_ready,
+    true,
+    'content page compost_ready set'
+  );
+});
+
+// Test #59.9: Knowledge Steward skips structural page in stale loop
+asyncTest('_intervene(knowledge): skips structural page in stale', async () => {
+  const pagesByTitle = {
+    'Carlos':            { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Pending Questions': { frontmatter: { type: 'meta' },       body: '# Pending Questions', path: 'Meta/Pending Questions.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',            frontmatter: { confidence: 'high' } },
+    { title: 'Pending Questions', frontmatter: { type: 'meta' } },
+  ], 'Meta');
+
+  const assessment = {
+    contradictions: [],
+    stale: [
+      { page: 'Pending Questions', reason: 'No new entries in 90 days' },
+      { page: 'Carlos',            reason: 'Last verified 180 days ago' },
+    ],
+    gaps: [],
+  };
+
+  await steward._intervene('knowledge', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Pending Questions'],
+    'structural page (type:meta) must not have confidence lowered'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still have confidence lowered'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.confidence,
+    'medium',
+    'content page confidence stepped down high → medium'
+  );
+});
+
+// Test #59.10: guard does not interfere with normal content-page interventions
+asyncTest('_intervene: content pages are still processed normally when no structural page in neighborhood', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Eelco':  { frontmatter: { confidence: 'high' }, body: 'Researcher.', path: 'People/Eelco.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos', frontmatter: { confidence: 'high' } },
+    { title: 'Eelco',  frontmatter: {} /* untyped — still a content page */ },
+  ], 'People');
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Carlos', shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  const result = await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(result.linksAdded >= 1, 'untyped + high-confidence pages remain in scope');
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page (Carlos) should still be written'
+  );
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -532,6 +532,153 @@ asyncTest('_markForComposting honors compost: never pin — does not mark pinned
 });
 
 // ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix A: wikilink idempotency survives resolution
+// ---------------------------------------------------------------------------
+
+// Fix A.1: _addWikilink returns false when the unresolved [[target]] is present.
+asyncTest('_addWikilink skips when unresolved [[target]] already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [[ManeraMedia GmbH]] (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — unresolved form already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.2: _addWikilink returns false when the RESOLVED [target](url) is present.
+// This is the new behavior — writePageWithFrontmatter resolves [[X]] to [X](url),
+// so on the next heartbeat only the resolved form remains in the body.
+asyncTest('_addWikilink skips when resolved [target](url) already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [ManeraMedia GmbH](https://nc.example/f/12345) (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — resolved markdown link already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.3: _addWikilink adds the link when neither form is present.
+asyncTest('_addWikilink adds the link when neither form is present', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: {}, body: 'Carlos works somewhere.', path: 'People/Carlos.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, true, 'should add — neither form present');
+  const written = collectivesClient._writtenPages['Carlos'];
+  assert.ok(written && written.body.includes('[[ManeraMedia GmbH]]'), 'body should carry the new link');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix B: Connection Steward excludes index pages
+// ---------------------------------------------------------------------------
+
+function makeConnectionNeighborhood(pages) {
+  return {
+    cluster: 'Documents',
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: 'Documents',
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set(['Documents']),
+    deckCards: [],
+  };
+}
+
+// Fix B.1: pages with `type: index` are excluded from the assessment data.
+test('_connectionAssessmentPrompt excludes type:index pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Documents'), 'index page must not appear as a link target');
+});
+
+// Fix B.2: pages with `compost: never` (structural pin) are excluded.
+test('_connectionAssessmentPrompt excludes compost:never pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Structural Nav Page', frontmatter: { compost: 'never' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Structural Nav Page'), 'pinned structural page must not appear');
+});
+
+// Fix B.3: the EXCLUSION instruction is present in the prompt.
+test('_connectionAssessmentPrompt carries the EXCLUSION instruction', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const prompt = steward._connectionAssessmentPrompt(makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+  ]));
+  assert.ok(prompt.includes('EXCLUSION:'), 'prompt should instruct the LLM to exclude index pages');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix C: _markForComposting writes frontmatter only
+// ---------------------------------------------------------------------------
+
+// Fix C.1: _markForComposting sets the compost frontmatter fields.
+asyncTest('_markForComposting sets compost_ready/compost_reason/compost_marked_at', async () => {
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: '# Stale Doc\n\nbody', path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const ok = await steward._markForComposting('Stale Doc', 'Never accessed, past decay');
+  assert.strictEqual(ok, true);
+  const fm = collectivesClient._writtenPages['Stale Doc'].frontmatter;
+  assert.strictEqual(fm.compost_ready, true, 'compost_ready should be true');
+  assert.strictEqual(fm.compost_reason, 'Never accessed, past decay', 'compost_reason should be set');
+  assert.ok(fm.compost_marked_at, 'compost_marked_at should be set');
+});
+
+// Fix C.2: _markForComposting does NOT modify the page body — no inline marker.
+asyncTest('_markForComposting leaves the page body unchanged (no inline archive marker)', async () => {
+  const originalBody = '# Stale Doc\n\nReal content.\n\n## Related\n- [Eelco](https://nc.example/f/9) (related)\n';
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: originalBody, path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  await steward._markForComposting('Stale Doc', 'Never accessed');
+  const writtenBody = collectivesClient._writtenPages['Stale Doc'].body;
+  assert.strictEqual(writtenBody, originalBody, 'body must be byte-identical — no inline annotation');
+  assert.ok(!writtenBody.includes('Archived by Memory Steward'), 'no inline archive marker in body');
+});
+
+// ---------------------------------------------------------------------------
 // INTEGRATION WITH tend()
 // ---------------------------------------------------------------------------
 

--- a/test/unit/providers/ollama-credential-model.test.js
+++ b/test/unit/providers/ollama-credential-model.test.js
@@ -12,6 +12,10 @@
 const assert = require('assert');
 const { test, summary, exitWithCode } = require('../../helpers/test-runner');
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 // Store original env to restore after tests
 const originalEnv = { ...process.env };
 

--- a/test/unit/workflows/schedule-handler.test.js
+++ b/test/unit/workflows/schedule-handler.test.js
@@ -569,6 +569,131 @@ asyncTest('processSchedules: single-action schedule still works with cloudTier',
   assert.strictEqual(taskOpts.allowCloud, true);
 });
 
+// ─── PAUSED-stack chokepoint (#28) ───────────────────────────────────
+
+asyncTest('processSchedules: skips ALL schedules when any stack has PAUSED CONFIG', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; return 'done'; } };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent });
+
+  const wb = {
+    board: { id: 144, title: 'Content Pipeline - Molti' },
+    description: 'WORKFLOW: pipeline\n\nSCHEDULE:\nEvery 1h: Scan NC News feeds. LLM: cloud\nEvery 7d: Archive stale cards. LLM: local',
+    stacks: [
+      {
+        id: 663,
+        title: 'Ideas',
+        cards: [
+          {
+            id: 100,
+            title: 'CONFIG: Evaluation',
+            archived: false,
+            deletedAt: null,
+            labels: [{ title: 'PAUSED' }]
+          }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.executed, 0, 'no schedules executed');
+  assert.strictEqual(result.skipped, 2, 'both schedules skipped');
+  assert.strictEqual(callCount, 0, 'agentLoop never invoked');
+});
+
+asyncTest('processSchedules: PAUSED skip is independent of due-time and budget', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; } };
+  const blockingBudget = { canSpend: () => ({ allowed: true }) };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent, budgetEnforcer: blockingBudget });
+
+  const wb = {
+    board: { id: 1, title: 'Test' },
+    description: 'SCHEDULE:\nEvery 1h: Do something. LLM: cloud',
+    stacks: [
+      {
+        id: 10,
+        title: 'Ideas',
+        cards: [
+          { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'PAUSED' }] }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  // Even on first call (when isDue would return true), skip.
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.skipped, 1);
+  assert.strictEqual(callCount, 0);
+
+  // Re-running does not mark the schedule as run, so when the stack is
+  // unpaused the schedule fires immediately.
+  wb.stacks[0].cards[0].labels = [];
+  const result2 = await handler.processSchedules(wb);
+  assert.strictEqual(result2.executed, 1, 'fires once unpaused');
+  assert.strictEqual(callCount, 1);
+});
+
+asyncTest('processSchedules: schedules still run when no stacks have PAUSED CONFIG', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; return 'ok'; } };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent });
+
+  const wb = {
+    board: { id: 1, title: 'Test' },
+    description: 'SCHEDULE:\nEvery 1h: Do work. LLM: cloud',
+    stacks: [
+      {
+        id: 10,
+        title: 'Ideas',
+        cards: [
+          { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'ACTIVE' }] }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.executed, 1);
+  assert.strictEqual(callCount, 1);
+});
+
+asyncTest('processSchedules: PAUSED skip log mentions board, stack, and action', async () => {
+  const logs = [];
+  const origLog = console.log;
+  console.log = (msg) => { logs.push(msg); };
+  try {
+    const handler = new ScheduleHandler({ agentLoop: { processWorkflowTask: async () => {} } });
+    const wb = {
+      board: { id: 144, title: 'Pipeline' },
+      description: 'SCHEDULE:\nEvery 1h: Scan NC News feeds. LLM: cloud',
+      stacks: [
+        {
+          id: 663,
+          title: 'Ideas',
+          cards: [
+            { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'PAUSED' }] }
+          ]
+        }
+      ],
+      workflowType: 'pipeline'
+    };
+    await handler.processSchedules(wb);
+    const skipLog = logs.find(l => l.startsWith('[Schedule] Skipping schedule on PAUSED stack:'));
+    assert.ok(skipLog, 'skip log line emitted');
+    assert.ok(skipLog.includes('"Scan NC News feeds. LLM: cloud"') || skipLog.includes('"Scan NC News feeds.'), 'log includes action text');
+    assert.ok(skipLog.includes('board=144'), 'log includes board id');
+    assert.ok(skipLog.includes('stack=663'), 'log includes stack id');
+    assert.ok(logs.some(l => l === '[Workflow] Stack "Ideas" skipped for schedules — CONFIG card has PAUSED label'), 'preserves existing per-stack log');
+  } finally {
+    console.log = origLog;
+  }
+});
+
 setTimeout(() => {
   summary();
   exitWithCode();


### PR DESCRIPTION
WikiSteward sees pages again. The Living Knowledge Architecture has been 
functionally offline since late April — _readNeighborhood returned empty 
neighborhoods on every heartbeat. Three stewards running, zero work done. 
That's fixed.

With the stewards awake, this release also lands the guardrails they need:

- Cross-write interference prevention (idempotent wikilinks, section 
  collision dedup, index page exclusion from assessment prompts)
- Structural page intervention guard — stewards skip type:section/index/meta 
  pages instead of hallucinating Related sections onto title-only stubs
- Landing page frontmatter written via structured path, not LLM output. 
  Enables compost:never pin for the first time (#30 deferred work complete)
- NC_URL required at config load — no more placeholder fallback leaking 
  into headers

Seven commits across four fix branches. 1,085 additions, 86 deletions.
220/220 test files. All changes production-verified on bot VM before merge.