### PR TITLE
fix(agent): conversational deck tools reach shared boards (closes #65)

### DIFF
--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -471,6 +471,114 @@ class ToolRegistry {
   }
 
   /**
+   * Resolve a card on either the default board (legacy behaviour, preserved
+   * for backward compatibility) or a named/ID-identified board. Returns one
+   * of four shapes so the caller can render an appropriate user-facing
+   * message without a second resolution pass.
+   *
+   * @private
+   * @param {Object} deck - DeckClient instance
+   * @param {string} cardIdentifier - Card title (partial match) or "#ID"
+   * @param {string} [boardParam] - Board name (partial match) or ID. If
+   *   omitted, walks the bot's default task board.
+   * @returns {Promise<
+   *     { found: true, card, boardId, stackId, stackTitle, isDefaultBoard, stackKey? }
+   *   | { found: false, reason: 'no_board', boardQuery }
+   *   | { found: false, reason: 'no_card', boardTitle, cardQuery }
+   *   | { found: false, reason: 'ambiguous', boardTitle, cardQuery, candidates }
+   * >}
+   */
+  async _resolveCardOnBoard(deck, cardIdentifier, boardParam) {
+    if (!boardParam) {
+      const resolved = await this._resolveCard(deck, cardIdentifier);
+      if (!resolved) return { found: false, reason: 'no_card', boardTitle: null, cardQuery: cardIdentifier };
+
+      const stackTitle = (deck.stackNames && deck.stackNames[resolved.stackKey]) || resolved.stackKey;
+      return {
+        found: true,
+        card: resolved.card,
+        boardId: null,
+        stackId: null,
+        stackTitle,
+        isDefaultBoard: true,
+        stackKey: resolved.stackKey
+      };
+    }
+
+    const board = await this._resolveBoard(deck, boardParam);
+    if (!board) return { found: false, reason: 'no_board', boardQuery: boardParam };
+
+    const stacks = await deck.getStacks(board.id);
+    const idStr = String(cardIdentifier).startsWith('#')
+      ? String(cardIdentifier).slice(1)
+      : null;
+    const titleLower = idStr ? null : String(cardIdentifier).toLowerCase();
+
+    const matches = [];
+    for (const stack of stacks || []) {
+      for (const card of stack.cards || []) {
+        const matchById = idStr && String(card.id) === idStr;
+        const matchByTitle = !idStr && card.title && card.title.toLowerCase().includes(titleLower);
+        if (matchById || matchByTitle) {
+          matches.push({ card, stackId: stack.id, stackTitle: stack.title });
+        }
+      }
+    }
+
+    if (matches.length === 0) {
+      return { found: false, reason: 'no_card', boardTitle: board.title, cardQuery: cardIdentifier };
+    }
+    if (matches.length > 1) {
+      return {
+        found: false,
+        reason: 'ambiguous',
+        boardTitle: board.title,
+        cardQuery: cardIdentifier,
+        candidates: matches.map(m => ({
+          id: m.card.id,
+          title: m.card.title,
+          stackTitle: m.stackTitle
+        }))
+      };
+    }
+
+    const m = matches[0];
+    return {
+      found: true,
+      card: m.card,
+      boardId: board.id,
+      stackId: m.stackId,
+      stackTitle: m.stackTitle,
+      isDefaultBoard: false
+    };
+  }
+
+  /**
+   * Render a non-found resolution as a user-facing string. Returns null
+   * if the resolution is `found: true` (caller should not invoke this).
+   * @private
+   */
+  _renderResolutionError(resolution, action = 'operate on') {
+    if (resolution.found) return null;
+    if (resolution.reason === 'no_board') {
+      return `No board found matching "${resolution.boardQuery}".`;
+    }
+    if (resolution.reason === 'no_card') {
+      return resolution.boardTitle
+        ? `No card found matching "${resolution.cardQuery}" on board "${resolution.boardTitle}".`
+        : `No card found matching "${resolution.cardQuery}".`;
+    }
+    if (resolution.reason === 'ambiguous') {
+      const list = resolution.candidates
+        .map(c => `  - #${c.id} "${c.title}" in ${c.stackTitle}`)
+        .join('\n');
+      return `Multiple cards on board "${resolution.boardTitle}" match "${resolution.cardQuery}". ` +
+        `Please specify which card to ${action} by passing the card ID (e.g. "#${resolution.candidates[0].id}"):\n${list}`;
+    }
+    return `Could not resolve card "${resolution.cardQuery}".`;
+  }
+
+  /**
    * Resolve cards across all accessible boards.
    * Returns flat array of { card, stackTitle, boardTitle, boardId }.
    * @private
@@ -607,7 +715,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_move_card',
-      description: 'Move a card to a different stack. Use this when asked to close, finish, start, or queue a task. The card can be identified by title (partial match) or ID.',
+      description: 'Move a card to a different stack. Use this when asked to close, finish, start, or queue a task. The card can be identified by title (partial match) or ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
         type: 'object',
         properties: {
@@ -617,33 +725,51 @@ class ToolRegistry {
           },
           target_stack: {
             type: 'string',
-            description: 'Destination stack',
-            enum: [DECK.stacks.inbox, DECK.stacks.queued, DECK.stacks.working, DECK.stacks.done, DECK.stacks.review]
+            description: 'Destination stack title. On the default task board: Inbox, Queued, Working, Done, Review. On a shared board: the stack title as it appears on that board (use deck_list_stacks to discover).'
+          },
+          board: {
+            type: 'string',
+            description: 'Board name (partial match) or board ID. If omitted, uses the task board.'
           }
         },
         required: ['card', 'target_stack']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-
-          if (!resolved) {
-            const allCards = await deck.getAllCards();
-            const available = Object.entries(allCards)
-              .flatMap(([k, cards]) => cards.map(c => `  - "${c.title}" in ${this._stackDisplayName(k, deck)}`))
-              .join('\n');
-            return `No card found matching "${args.card}".${available ? ` Available cards:\n${available}` : ''}`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) {
+            if (!args.board && resolution.reason === 'no_card') {
+              const allCards = await deck.getAllCards();
+              const available = Object.entries(allCards)
+                .flatMap(([k, cards]) => cards.map(c => `  - "${c.title}" in ${this._stackDisplayName(k, deck)}`))
+                .join('\n');
+              return `No card found matching "${args.card}".${available ? ` Available cards:\n${available}` : ''}`;
+            }
+            return this._renderResolutionError(resolution, 'move');
           }
 
-          const { card: foundCard, stackKey: fromStackKey } = resolved;
-          const toStackKey = this._stackKey(args.target_stack);
+          const { card: foundCard, boardId, stackId: fromStackId, stackTitle: fromStackTitle, isDefaultBoard, stackKey: fromStackKey } = resolution;
 
-          if (fromStackKey === toStackKey) {
-            return `Card "${foundCard.title}" is already in ${args.target_stack}.`;
+          if (isDefaultBoard) {
+            const toStackKey = this._stackKey(args.target_stack);
+            if (fromStackKey === toStackKey) {
+              return `Card "${foundCard.title}" is already in ${args.target_stack}.`;
+            }
+            await deck.moveCard(foundCard.id, fromStackKey, toStackKey);
+            return `Moved "${foundCard.title}" (card #${foundCard.id}) from ${this._stackDisplayName(fromStackKey, deck)} to ${args.target_stack}.`;
           }
 
-          await deck.moveCard(foundCard.id, fromStackKey, toStackKey);
-          return `Moved "${foundCard.title}" (card #${foundCard.id}) from ${this._stackDisplayName(fromStackKey, deck)} to ${args.target_stack}.`;
+          const stacks = await deck.getStacks(boardId);
+          const targetStack = (stacks || []).find(s => s.title.toLowerCase() === args.target_stack.toLowerCase());
+          if (!targetStack) {
+            const available = (stacks || []).map(s => `"${s.title}"`).join(', ');
+            return `No stack "${args.target_stack}" on this board. Available stacks: ${available || '(none)'}`;
+          }
+          if (targetStack.id === fromStackId) {
+            return `Card "${foundCard.title}" is already in "${targetStack.title}".`;
+          }
+          await deck.moveCardById(foundCard.id, targetStack.id, 0);
+          return `Moved "${foundCard.title}" (card #${foundCard.id}) from "${fromStackTitle}" to "${targetStack.title}".`;
         } catch (err) {
           this.logger.error(`[deck_move_card] ${err.message}`);
           return `Failed to move card: ${err.message}`;
@@ -860,24 +986,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_get_card',
-      description: 'Get full details of a card including description, due date, assigned users, labels, and comments. Card identified by title (partial match) or #ID.',
+      description: 'Get full details of a card including description, due date, assigned users, labels, and comments. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read from a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'read');
 
-          const { card: found, stackKey } = resolved;
-          const full = await deck.getCard(found.id, stackKey);
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
+          const full = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
           const comments = await deck.getComments(found.id);
 
-          let result = `Card #${full.id}: "${full.title}" in ${this._stackDisplayName(stackKey, deck)}\n`;
+          let result = `Card #${full.id}: "${full.title}" in ${stackTitle}\n`;
           if (full.description) result += `Description: ${full.description}\n`;
           if (full.duedate) result += `Due: ${full.duedate}\n`;
 
@@ -907,24 +1036,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_update_card',
-      description: 'Update a card\'s title, description, or due date. Card identified by title (partial match) or #ID.',
+      description: 'Update a card\'s title, description, or due date. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
           title: { type: 'string', description: 'New title' },
           description: { type: 'string', description: 'New description' },
-          duedate: { type: 'string', description: 'New due date (ISO format) or "none" to clear' }
+          duedate: { type: 'string', description: 'New due date (ISO format) or "none" to clear' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'update');
 
-          const { card: found, stackKey } = resolved;
-          const current = await deck.getCard(found.id, stackKey);
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          const current = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
 
           const updates = {
             title: args.title || current.title,
@@ -934,7 +1066,11 @@ class ToolRegistry {
             duedate: args.duedate === 'none' ? null : (args.duedate || current.duedate || null)
           };
 
-          await deck.updateCard(found.id, stackKey, updates);
+          if (isDefaultBoard) {
+            await deck.updateCard(found.id, stackKey, updates);
+          } else {
+            await deck.updateCardById(boardId, stackId, found.id, updates);
+          }
 
           const changes = [];
           if (args.title) changes.push(`title: "${args.title}"`);
@@ -951,22 +1087,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_card',
-      description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID.',
+      description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to delete a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'delete');
 
-          const { card: found, stackKey } = resolved;
-          await deck.deleteCard(found.id, stackKey);
-          return `Deleted card #${found.id} "${found.title}" from ${this._stackDisplayName(stackKey, deck)}.`;
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.deleteCard(found.id, stackKey);
+          } else {
+            await deck.deleteCardById(boardId, stackId, found.id);
+          }
+          return `Deleted card #${found.id} "${found.title}" from ${stackTitle}.`;
         } catch (err) {
           this.logger.error(`[deck_delete_card] ${err.message}`);
           return `Failed to delete card: ${err.message}`;
@@ -976,61 +1117,76 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_assign_user',
-      description: 'Assign a user to a card. Card identified by title (partial match) or #ID.',
+      description: 'Assign a user to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to assign on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          user: { type: 'string', description: 'NC username to assign' }
+          user: { type: 'string', description: 'NC username to assign' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'user']
       },
       handler: async (args) => {
-        const resolved = await this._resolveCard(deck, args.card);
-        if (!resolved) return `No card found matching "${args.card}".`;
+        const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+        if (!resolution.found) return this._renderResolutionError(resolution, 'assign on');
 
-        const { card: found, stackKey } = resolved;
+        const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
         if (isStructuralCard(found)) {
           return `Card #${found.id} "${found.title}" is a structural/config card, not a work item. Structural cards should not be assigned to users. If you need to modify this card, do so explicitly.`;
         }
-        const assignResult = await deck.assignUser(found.id, stackKey, args.user);
-        if (assignResult === undefined || assignResult === null) {
-          // assignUser returns undefined when user is not a board member
-          // Re-read card to verify assignment actually took effect
-          try {
-            const updated = await deck.getCard(found.id, stackKey);
-            const isAssigned = (updated.assignedUsers || []).some(
-              a => (a.participant?.uid || '').toLowerCase() === args.user.toLowerCase()
-            );
-            if (!isAssigned) return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
-          } catch {
-            // If re-read fails, we can't confirm — report uncertainty
-            return `Assignment of "${args.user}" to card #${found.id} could not be confirmed. The user may not be a member of this board.`;
+
+        if (isDefaultBoard) {
+          const assignResult = await deck.assignUser(found.id, stackKey, args.user);
+          if (assignResult === undefined || assignResult === null) {
+            try {
+              const updated = await deck.getCard(found.id, stackKey);
+              const isAssigned = (updated.assignedUsers || []).some(
+                a => (a.participant?.uid || '').toLowerCase() === args.user.toLowerCase()
+              );
+              if (!isAssigned) return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
+            } catch {
+              return `Assignment of "${args.user}" to card #${found.id} could not be confirmed. The user may not be a member of this board.`;
+            }
           }
+          return `Assigned "${args.user}" to card #${found.id} "${found.title}".`;
         }
-        return `Assigned "${args.user}" to card #${found.id} "${found.title}".`;
+
+        const matched = await deck.assignUserById(boardId, stackId, found.id, args.user);
+        if (matched === null) {
+          return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
+        }
+        return `Assigned "${matched}" to card #${found.id} "${found.title}".`;
       }
     });
 
     this.register({
       name: 'deck_unassign_user',
-      description: 'Remove a user assignment from a card. Card identified by title (partial match) or #ID.',
+      description: 'Remove a user assignment from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to unassign on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          user: { type: 'string', description: 'NC username to unassign' }
+          user: { type: 'string', description: 'NC username to unassign' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'user']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'unassign on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.unassignUser(found.id, stackKey, args.user);
-          return `Unassigned "${args.user}" from card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.unassignUser(found.id, stackKey, args.user);
+            return `Unassigned "${args.user}" from card #${found.id} "${found.title}".`;
+          }
+          const matched = await deck.unassignUserById(boardId, stackId, found.id, args.user);
+          if (matched === null) {
+            return `Could not unassign "${args.user}" from card #${found.id} — user is not a member of this board.`;
+          }
+          return `Unassigned "${matched}" from card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_unassign_user] ${err.message}`);
           return `Failed to unassign user: ${err.message}`;
@@ -1040,33 +1196,43 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_set_due_date',
-      description: 'Set or clear the due date on a card. Card identified by title (partial match) or #ID.',
+      description: 'Set or clear the due date on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          duedate: { type: 'string', description: 'Due date in ISO format (e.g. 2026-02-15) or "none" to clear' }
+          duedate: { type: 'string', description: 'Due date in ISO format (e.g. 2026-02-15) or "none" to clear' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'duedate']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'update');
 
-          const { card: found, stackKey } = resolved;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
           if (isStructuralCard(found)) {
             return `Card #${found.id} "${found.title}" is a structural/config card, not a work item. Structural cards should not have due dates. If you need to modify this card, do so explicitly.`;
           }
-          const current = await deck.getCard(found.id, stackKey);
+
+          const current = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
 
           const duedate = args.duedate.toLowerCase() === 'none' ? null : args.duedate;
-          await deck.updateCard(found.id, stackKey, {
+          const updates = {
             title: current.title,
             type: current.type || 'plain',
             owner: current.owner?.uid || current.owner || deck.username,
             duedate
-          });
+          };
+
+          if (isDefaultBoard) {
+            await deck.updateCard(found.id, stackKey, updates);
+          } else {
+            await deck.updateCardById(boardId, stackId, found.id, updates);
+          }
 
           return duedate
             ? `Set due date on card #${found.id} "${found.title}" to ${duedate}.`
@@ -1082,23 +1248,35 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_label',
-      description: 'Add a label to a card. Card identified by title (partial match) or #ID.',
+      description: 'Add a label to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board. The label must already exist on the target board (use deck_create_label first if needed).',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          label: { type: 'string', description: 'Label name (e.g. urgent, research, writing, admin, blocked)' }
+          label: { type: 'string', description: 'Label name (e.g. urgent, research, writing, admin, blocked)' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'label']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'label on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.addLabel(found.id, stackKey, args.label);
-          return `Added label "${args.label}" to card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.addLabel(found.id, stackKey, args.label);
+            return `Added label "${args.label}" to card #${found.id} "${found.title}".`;
+          }
+
+          const board = await deck.getBoard(boardId);
+          const labelDef = (board.labels || []).find(l => l.title.toLowerCase() === args.label.toLowerCase());
+          if (!labelDef) {
+            const available = (board.labels || []).map(l => `"${l.title}"`).join(', ');
+            return `No label "${args.label}" on board "${board.title}". Available labels: ${available || '(none)'}`;
+          }
+          await deck.assignLabelById(boardId, stackId, found.id, labelDef.id);
+          return `Added label "${labelDef.title}" to card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_add_label] ${err.message}`);
           return `Failed to add label: ${err.message}`;
@@ -1108,23 +1286,34 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_remove_label',
-      description: 'Remove a label from a card. Card identified by title (partial match) or #ID.',
+      description: 'Remove a label from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          label: { type: 'string', description: 'Label name to remove' }
+          label: { type: 'string', description: 'Label name to remove' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'label']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'unlabel on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.removeLabel(found.id, stackKey, args.label);
-          return `Removed label "${args.label}" from card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.removeLabel(found.id, stackKey, args.label);
+            return `Removed label "${args.label}" from card #${found.id} "${found.title}".`;
+          }
+
+          const board = await deck.getBoard(boardId);
+          const labelDef = (board.labels || []).find(l => l.title.toLowerCase() === args.label.toLowerCase());
+          if (!labelDef) {
+            return `No label "${args.label}" on board "${board.title}".`;
+          }
+          await deck.removeLabelById(boardId, stackId, found.id, labelDef.id);
+          return `Removed label "${labelDef.title}" from card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_remove_label] ${err.message}`);
           return `Failed to remove label: ${err.message}`;
@@ -1159,21 +1348,22 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_comment',
-      description: 'Add a comment to a card. Use this to leave notes, updates, or communicate about a task. Card identified by title (partial match) or #ID.',
+      description: 'Add a comment to a card. Use this to leave notes, updates, or communicate about a task. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to comment on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          message: { type: 'string', description: 'Comment text' }
+          message: { type: 'string', description: 'Comment text' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'message']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'comment on');
 
-          const { card: found } = resolved;
+          const { card: found } = resolution;
           await deck.addComment(found.id, args.message, 'STATUS', { prefix: false });
           return `Added comment to card #${found.id} "${found.title}".`;
         } catch (err) {
@@ -1185,20 +1375,21 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_comments',
-      description: 'List all comments on a card. Card identified by title (partial match) or #ID.',
+      description: 'List all comments on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read comments on a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'read comments on');
 
-          const { card: found } = resolved;
+          const { card: found } = resolution;
           const comments = await deck.getComments(found.id);
 
           if (comments.length === 0) return `No comments on card #${found.id} "${found.title}".`;
@@ -1354,24 +1545,39 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_mark_done',
-      description: 'Mark a card as done by moving it to the Done stack. Card identified by title (partial match) or #ID.',
+      description: 'Mark a card as done by moving it to the Done stack. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to mark a card on a shared board (requires a stack titled "Done" on that board).',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'mark done');
 
-          const { card: found, stackKey } = resolved;
-          if (stackKey === 'done') return `Card #${found.id} "${found.title}" is already in Done.`;
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
 
-          await deck.moveCard(found.id, stackKey, 'done');
-          return `Marked card #${found.id} "${found.title}" as done (moved from ${this._stackDisplayName(stackKey, deck)} to Done).`;
+          if (isDefaultBoard) {
+            if (stackKey === 'done') return `Card #${found.id} "${found.title}" is already in Done.`;
+            await deck.moveCard(found.id, stackKey, 'done');
+            return `Marked card #${found.id} "${found.title}" as done (moved from ${this._stackDisplayName(stackKey, deck)} to Done).`;
+          }
+
+          const stacks = await deck.getStacks(boardId);
+          const doneStack = (stacks || []).find(s => s.title.toLowerCase() === 'done');
+          if (!doneStack) {
+            const available = (stacks || []).map(s => `"${s.title}"`).join(', ');
+            return `No "Done" stack on this board. Available stacks: ${available || '(none)'}. Use deck_move_card with an explicit target_stack instead.`;
+          }
+          if (doneStack.id === stackId) {
+            return `Card #${found.id} "${found.title}" is already in "${doneStack.title}".`;
+          }
+          await deck.moveCardById(found.id, doneStack.id, 0);
+          return `Marked card #${found.id} "${found.title}" as done (moved from "${stackTitle}" to "${doneStack.title}").`;
         } catch (err) {
           this.logger.error(`[deck_mark_done] ${err.message}`);
           return `Failed to mark card as done: ${err.message}`;

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -650,6 +650,108 @@ class DeckClient {
       { title, description: opts.description || '', type: 'plain', order: 0 });
   }
 
+  // ============================================================
+  // GENERIC CARD CRUD (v2 — any board, by explicit IDs)
+  // ============================================================
+  // Mirrors the legacy stackName-based methods (createCard/deleteCard/etc.)
+  // but works against any board the bot user has ACL access to. Used by
+  // conversational deck_* tools when the user names a board other than
+  // the default. See issue #65.
+
+  async getCardById(boardId, stackId, cardId) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    return await this._request('GET',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`);
+  }
+
+  async updateCardById(boardId, stackId, cardId, updates) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    return await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
+      updates);
+  }
+
+  async deleteCardById(boardId, stackId, cardId) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    await this._request('DELETE',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`);
+    console.log(`[Deck] Card ${cardId} deleted (board=${boardId}, stack=${stackId})`);
+  }
+
+  /**
+   * Move a card to a different stack on the same board.
+   * Uses the internal /deck/cards/${cardId}/reorder endpoint, which is
+   * board-agnostic — only the destination stackId is needed.
+   */
+  async moveCardById(cardId, toStackId, order = 0) {
+    if (!cardId || !toStackId) throw new DeckApiError('cardId and toStackId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/cards/${cardId}/reorder`,
+      { stackId: toStackId, order });
+    console.log(`[Deck] Card ${cardId} moved to stack ${toStackId}`);
+  }
+
+  async assignLabelById(boardId, stackId, cardId, labelId) {
+    if (!boardId || !stackId || !cardId || !labelId) throw new DeckApiError('boardId, stackId, cardId, labelId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/assignLabel`,
+      { labelId });
+  }
+
+  async removeLabelById(boardId, stackId, cardId, labelId) {
+    if (!boardId || !stackId || !cardId || !labelId) throw new DeckApiError('boardId, stackId, cardId, labelId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/removeLabel`,
+      { labelId });
+  }
+
+  /**
+   * Assign a user to a card on any board. Looks up the user via the board's
+   * member list for case-insensitive matching, mirroring assignUser().
+   * Returns the matched uid on success, null if the user is not a board member.
+   */
+  async assignUserById(boardId, stackId, cardId, userId) {
+    if (!boardId || !stackId || !cardId || !userId) throw new DeckApiError('boardId, stackId, cardId, userId are required');
+    const board = await this._request('GET', `/index.php/apps/deck/api/v1.0/boards/${boardId}`);
+    const members = board.users || [];
+    const match = members.find(u =>
+      u.uid.toLowerCase() === userId.toLowerCase() ||
+      u.primaryKey.toLowerCase() === userId.toLowerCase()
+    );
+    if (!match) return null;
+
+    try {
+      await this._request('PUT',
+        `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/assignUser`,
+        { userId: match.uid });
+      return match.uid;
+    } catch (e) {
+      if (e.message?.includes('already assigned')) return match.uid;
+      throw e;
+    }
+  }
+
+  async unassignUserById(boardId, stackId, cardId, userId) {
+    if (!boardId || !stackId || !cardId || !userId) throw new DeckApiError('boardId, stackId, cardId, userId are required');
+    const board = await this._request('GET', `/index.php/apps/deck/api/v1.0/boards/${boardId}`);
+    const members = board.users || [];
+    const match = members.find(u =>
+      u.uid.toLowerCase() === userId.toLowerCase() ||
+      u.primaryKey.toLowerCase() === userId.toLowerCase()
+    );
+    if (!match) return null;
+
+    try {
+      await this._request('PUT',
+        `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/unassignUser`,
+        { userId: match.uid });
+      return match.uid;
+    } catch (e) {
+      if (e.message?.includes('not assigned')) return match.uid;
+      throw e;
+    }
+  }
+
   /**
    * Ensure the board exists with all required stacks
    * Creates if missing, verifies structure if exists

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -1191,6 +1191,429 @@ asyncTest('deck_share_board with group type', async () => {
 });
 
 // ============================================================
+// Tests - Board-aware card-mutation tools (issue #65)
+// ============================================================
+
+function createSharedBoardDeckClient(opts = {}) {
+  // A mock that simulates a shared "Content Pipeline" board (id 7) with
+  // realistic stack/card data, alongside the bot's own task board (id 1).
+  // Used to verify the foreign-board branch of card-mutation tools.
+  const sharedStacks = opts.sharedStacks || [
+    { id: 701, title: 'Inbox', cards: [
+      { id: 200, title: 'Draft outline', duedate: null, owner: { uid: 'jordan' }, type: 'plain' }
+    ]},
+    { id: 702, title: 'Working', cards: [
+      { id: 201, title: 'Editing pass', duedate: null, owner: { uid: 'jordan' }, type: 'plain' }
+    ]},
+    { id: 703, title: 'Done', cards: [] }
+  ];
+  const sharedLabels = opts.sharedLabels || [
+    { id: 1001, title: 'urgent' },
+    { id: 1002, title: 'blocked' }
+  ];
+
+  const calls = {};
+
+  return {
+    baseUrl: 'https://nc.example.com',
+    username: 'moltagent',
+    stackNames: {
+      inbox: 'Inbox', queued: 'Queued', working: 'Working',
+      review: 'Review', done: 'Done', reference: 'Reference'
+    },
+    _calls: calls,
+    getAllCards: async () => ({}),
+    listBoards: async () => [
+      { id: 1, title: DECK.boards.tasks, owner: { uid: 'moltagent' } },
+      { id: 7, title: 'Content Pipeline', owner: { uid: 'jordan' } }
+    ],
+    getBoard: async (boardId) => ({
+      id: boardId,
+      title: boardId === 7 ? 'Content Pipeline' : DECK.boards.tasks,
+      owner: { uid: boardId === 7 ? 'jordan' : 'moltagent' },
+      stacks: sharedStacks,
+      labels: sharedLabels,
+      users: [
+        { uid: 'alice', primaryKey: 'alice' },
+        { uid: 'jordan', primaryKey: 'jordan' },
+        { uid: 'moltagent', primaryKey: 'moltagent' }
+      ]
+    }),
+    getStacks: async (_boardId) => sharedStacks,
+    getCardById: async (boardId, stackId, cardId) => {
+      calls.getCardById = { boardId, stackId, cardId };
+      const stack = sharedStacks.find(s => s.id === stackId);
+      const card = stack?.cards.find(c => c.id === cardId);
+      return card
+        ? { ...card, description: 'shared-card desc', assignedUsers: [], labels: [] }
+        : null;
+    },
+    updateCardById: async (boardId, stackId, cardId, updates) => {
+      calls.updateCardById = { boardId, stackId, cardId, updates };
+    },
+    deleteCardById: async (boardId, stackId, cardId) => {
+      calls.deleteCardById = { boardId, stackId, cardId };
+    },
+    moveCardById: async (cardId, toStackId, order) => {
+      calls.moveCardById = { cardId, toStackId, order };
+    },
+    assignLabelById: async (boardId, stackId, cardId, labelId) => {
+      calls.assignLabelById = { boardId, stackId, cardId, labelId };
+    },
+    removeLabelById: async (boardId, stackId, cardId, labelId) => {
+      calls.removeLabelById = { boardId, stackId, cardId, labelId };
+    },
+    assignUserById: async (boardId, stackId, cardId, userId) => {
+      calls.assignUserById = { boardId, stackId, cardId, userId };
+      return userId;
+    },
+    unassignUserById: async (boardId, stackId, cardId, userId) => {
+      calls.unassignUserById = { boardId, stackId, cardId, userId };
+      return userId;
+    },
+    addComment: async (cardId, message, type, optsArg) => {
+      calls.addComment = { cardId, message, type, opts: optsArg };
+    },
+    getComments: async (cardId) => {
+      calls.getComments = { cardId };
+      return [{ actorId: 'jordan', message: 'looks good', creationDateTime: '2026-05-26T10:00:00Z' }];
+    },
+    // Default-board legacy methods that should NOT be touched on foreign path:
+    getCard: async () => { throw new Error('default-board getCard called for shared-board test'); },
+    updateCard: async () => { throw new Error('default-board updateCard called for shared-board test'); },
+    deleteCard: async () => { throw new Error('default-board deleteCard called for shared-board test'); },
+    moveCard: async () => { throw new Error('default-board moveCard called for shared-board test'); },
+    addLabel: async () => { throw new Error('default-board addLabel called for shared-board test'); },
+    removeLabel: async () => { throw new Error('default-board removeLabel called for shared-board test'); },
+    assignUser: async () => { throw new Error('default-board assignUser called for shared-board test'); },
+    unassignUser: async () => { throw new Error('default-board unassignUser called for shared-board test'); }
+  };
+}
+
+asyncTest('deck_delete_card on shared board routes through deleteCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.deleteCardById, { boardId: 7, stackId: 701, cardId: 200 });
+  assert.ok(result.result.includes('Deleted card #200'));
+  assert.ok(result.result.includes('Inbox'));
+});
+
+asyncTest('deck_mark_done on shared board moves to Done stack via moveCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_mark_done', {
+    card: 'Editing pass',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.moveCardById, { cardId: 201, toStackId: 703, order: 0 });
+  assert.ok(result.result.includes('Marked card #201'));
+  assert.ok(result.result.includes('Done'));
+});
+
+asyncTest('deck_mark_done on shared board without Done stack returns clear error', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'No Done stack here' }] },
+      { id: 702, title: 'In Review', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_mark_done', {
+    card: 'No Done',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.moveCardById, undefined);
+  assert.ok(result.result.includes('No "Done" stack'));
+  assert.ok(result.result.includes('deck_move_card'));
+});
+
+asyncTest('deck_get_card on shared board uses getCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_get_card', {
+    card: '#200',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.getCardById, { boardId: 7, stackId: 701, cardId: 200 });
+  assert.ok(result.result.includes('Card #200'));
+  assert.ok(result.result.includes('shared-card desc'));
+});
+
+asyncTest('deck_update_card on shared board uses updateCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_update_card', {
+    card: 'Draft outline',
+    title: 'Draft outline (v2)',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.updateCardById.boardId, 7);
+  assert.strictEqual(deck._calls.updateCardById.stackId, 701);
+  assert.strictEqual(deck._calls.updateCardById.cardId, 200);
+  assert.strictEqual(deck._calls.updateCardById.updates.title, 'Draft outline (v2)');
+});
+
+asyncTest('deck_move_card on shared board uses moveCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_move_card', {
+    card: 'Draft outline',
+    target_stack: 'Working',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.moveCardById, { cardId: 200, toStackId: 702, order: 0 });
+  assert.ok(result.result.includes('Moved'));
+});
+
+asyncTest('deck_move_card on shared board reports unknown target_stack', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_move_card', {
+    card: 'Draft outline',
+    target_stack: 'Backlog',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.moveCardById, undefined);
+  assert.ok(result.result.includes('No stack "Backlog"'));
+  assert.ok(result.result.includes('"Inbox"'));
+});
+
+asyncTest('deck_assign_user on shared board uses assignUserById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_assign_user', {
+    card: 'Draft outline',
+    user: 'alice',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignUserById.boardId, 7);
+  assert.strictEqual(deck._calls.assignUserById.userId, 'alice');
+  assert.ok(result.result.includes('Assigned'));
+});
+
+asyncTest('deck_unassign_user on shared board uses unassignUserById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_unassign_user', {
+    card: 'Draft outline',
+    user: 'alice',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.unassignUserById.boardId, 7);
+  assert.strictEqual(deck._calls.unassignUserById.userId, 'alice');
+});
+
+asyncTest('deck_set_due_date on shared board uses updateCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_set_due_date', {
+    card: 'Draft outline',
+    duedate: '2026-06-01',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.updateCardById.updates.duedate, '2026-06-01');
+  assert.ok(result.result.includes('2026-06-01'));
+});
+
+asyncTest('deck_add_label on shared board resolves label and uses assignLabelById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_label', {
+    card: 'Draft outline',
+    label: 'urgent',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignLabelById.boardId, 7);
+  assert.strictEqual(deck._calls.assignLabelById.labelId, 1001);
+  assert.ok(result.result.includes('Added label "urgent"'));
+});
+
+asyncTest('deck_add_label on shared board reports unknown label with available list', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_label', {
+    card: 'Draft outline',
+    label: 'critical',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignLabelById, undefined);
+  assert.ok(result.result.includes('No label "critical"'));
+  assert.ok(result.result.includes('"urgent"'));
+});
+
+asyncTest('deck_remove_label on shared board uses removeLabelById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_remove_label', {
+    card: 'Draft outline',
+    label: 'urgent',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.removeLabelById.labelId, 1001);
+});
+
+asyncTest('deck_add_comment on shared board calls board-agnostic addComment', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_comment', {
+    card: 'Draft outline',
+    message: 'first review pass complete',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.addComment.cardId, 200);
+  assert.strictEqual(deck._calls.addComment.message, 'first review pass complete');
+});
+
+asyncTest('deck_list_comments on shared board reads via card ID', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_list_comments', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.getComments.cardId, 200);
+  assert.ok(result.result.includes('looks good'));
+});
+
+asyncTest('board not found returns no_board error', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'whatever',
+    board: 'NonExistent'
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('No board found'));
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+});
+
+asyncTest('card not found on shared board cites board title', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'ghost card',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('No card found matching "ghost card"'));
+  assert.ok(result.result.includes('Content Pipeline'));
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+});
+
+asyncTest('ambiguous card title on shared board returns candidate list without mutating', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'Draft outline A' }] },
+      { id: 702, title: 'Working', cards: [{ id: 201, title: 'Draft outline B' }] },
+      { id: 703, title: 'Done', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+  assert.ok(result.result.includes('Multiple cards'));
+  assert.ok(result.result.includes('#200'));
+  assert.ok(result.result.includes('#201'));
+  assert.ok(result.result.includes('Draft outline A'));
+  assert.ok(result.result.includes('Draft outline B'));
+});
+
+asyncTest('ambiguous card title resolved via #ID picks the exact card', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'Draft outline A' }] },
+      { id: 702, title: 'Working', cards: [{ id: 201, title: 'Draft outline B' }] },
+      { id: 703, title: 'Done', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: '#201',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.deleteCardById, { boardId: 7, stackId: 702, cardId: 201 });
+});
+
+asyncTest('omitting board parameter still routes to default-board legacy methods', async () => {
+  // Regression guard: tool calls without `board` must hit the legacy mock
+  // surface — guarantees backward compatibility for callers that never pass board.
+  let touchedDefault = false;
+  const deck = createMockDeckClient({ working: [{ id: 5, title: 'Default-board task' }] });
+  deck.moveCard = async () => { touchedDefault = true; };
+
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+  const result = await registry.execute('deck_move_card', {
+    card: 'Default-board task',
+    target_stack: 'Done'
+  });
+
+  assert.ok(result.success);
+  assert.ok(touchedDefault, 'Legacy moveCard should have been called on the default board');
+});
+
+// ============================================================
 // Tests - 403 Permission Error Handling
 // ============================================================
 

--- a/test/unit/integrations/deck-client-v2.test.js
+++ b/test/unit/integrations/deck-client-v2.test.js
@@ -418,4 +418,156 @@ asyncTest('TC-ERR-003: 500 response from updateStack propagates as error', async
   );
 });
 
+// ============================================================
+// --- ID-based card mutation methods (issue #65) ---
+// ============================================================
+console.log('\n--- *ById card mutation methods ---\n');
+
+asyncTest('TC-GCB-001: getCardById sends GET to /boards/{b}/stacks/{s}/cards/{c}', async () => {
+  const fixture = { id: 200, title: 'Shared card' };
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: fixture, headers: {} }
+  });
+
+  const result = await client.getCardById(7, 701, 200);
+  assert.strictEqual(result.id, 200);
+});
+
+asyncTest('TC-GCB-002: getCardById without required IDs throws', async () => {
+  const { client } = makeClient();
+  await assert.rejects(() => client.getCardById(null, 701, 200), (err) => err.message.includes('required'));
+});
+
+asyncTest('TC-UCB-001: updateCardById sends PUT with updates body', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: { id: 200 }, headers: {} }
+  });
+
+  await client.updateCardById(7, 701, 200, { title: 'Renamed', duedate: '2026-06-01' });
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/cards/200'));
+  assert.ok(call);
+  assert.strictEqual(call.body.title, 'Renamed');
+  assert.strictEqual(call.body.duedate, '2026-06-01');
+});
+
+asyncTest('TC-DCB-001: deleteCardById sends DELETE to correct endpoint', async () => {
+  const { client, nc } = makeClient({
+    'DELETE:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.deleteCardById(7, 701, 200);
+  const call = nc._calls.find(c => c.method === 'DELETE' && c.path.endsWith('/cards/200'));
+  assert.ok(call);
+});
+
+asyncTest('TC-DCB-002: deleteCardById without cardId throws', async () => {
+  const { client } = makeClient();
+  await assert.rejects(() => client.deleteCardById(7, 701, null), (err) => err.message.includes('required'));
+});
+
+asyncTest('TC-MCB-001: moveCardById PUTs to internal reorder endpoint with destination stackId', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/cards/200/reorder': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.moveCardById(200, 703, 0);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path === '/index.php/apps/deck/cards/200/reorder');
+  assert.ok(call);
+  assert.strictEqual(call.body.stackId, 703);
+  assert.strictEqual(call.body.order, 0);
+});
+
+asyncTest('TC-MCB-002: moveCardById defaults order to 0 when omitted', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/cards/200/reorder': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.moveCardById(200, 703);
+  const call = nc._calls.find(c => c.method === 'PUT');
+  assert.strictEqual(call.body.order, 0);
+});
+
+asyncTest('TC-ALB-001: assignLabelById PUTs labelId to assignLabel endpoint', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignLabel': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.assignLabelById(7, 701, 200, 1001);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/assignLabel'));
+  assert.ok(call);
+  assert.strictEqual(call.body.labelId, 1001);
+});
+
+asyncTest('TC-RLB-001: removeLabelById PUTs labelId to removeLabel endpoint', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/removeLabel': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.removeLabelById(7, 701, 200, 1001);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/removeLabel'));
+  assert.ok(call);
+});
+
+asyncTest('TC-AUB-001: assignUserById looks up case-insensitive uid and assigns', async () => {
+  const { client, nc } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'Alice', primaryKey: 'Alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignUser': { status: 200, body: {}, headers: {} }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'Alice');
+  const assignCall = nc._calls.find(c => c.path.endsWith('/assignUser'));
+  assert.ok(assignCall);
+  assert.strictEqual(assignCall.body.userId, 'Alice');
+});
+
+asyncTest('TC-AUB-002: assignUserById returns null when user not a board member', async () => {
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'jordan', primaryKey: 'jordan' }] },
+      headers: {}
+    }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'stranger');
+  assert.strictEqual(matched, null);
+});
+
+asyncTest('TC-AUB-003: assignUserById swallows "already assigned" and returns uid', async () => {
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'alice', primaryKey: 'alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignUser': {
+      status: 400, body: { message: 'User already assigned' }, headers: {}
+    }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'alice');
+});
+
+asyncTest('TC-UUB-001: unassignUserById PUTs to unassignUser endpoint', async () => {
+  const { client, nc } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'alice', primaryKey: 'alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/unassignUser': { status: 200, body: {}, headers: {} }
+  });
+
+  const matched = await client.unassignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'alice');
+  const call = nc._calls.find(c => c.path.endsWith('/unassignUser'));
+  assert.ok(call);
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Summary
- Twelve card-mutation conversational tools (`deck_get_card`, `deck_update_card`, `deck_delete_card`, `deck_mark_done`, `deck_move_card`, `deck_assign_user`, `deck_unassign_user`, `deck_set_due_date`, `deck_add_label`, `deck_remove_label`, `deck_add_comment`, `deck_list_comments`) gain an optional `board` parameter and can now operate on any Deck board the bot user has ACL access to — same reach as the autonomous WorkflowEngine path.
- Generator-level fix: one new `_resolveCardOnBoard` helper in `ToolRegistry` replaces 12 instances of `_resolveCard` lock-in, plus eight thin board-agnostic `*ById` wrappers on `DeckClient` mirroring the existing default-board methods.
- Ambiguous-title matches on shared boards now return a structured candidate list instead of silently picking the first hit. Backward compatible: tool calls without `board` behave identically to before.

Closes #65.

## Test plan
- [x] `npm run lint` → 0 errors
- [x] `npm run test:unit` → 215/215 unit test files pass (was 215/215 before; +20 ToolRegistry tests + 13 DeckClient v2 tests added)
- [x] Service restart clean: `ToolActivator ready (ToolRegistry now has 76 tools)`, `Ready to receive NC Talk messages` reached, no errors
- [x] **Live in Talk (needs human):** ask Moltagent in Talk to delete or mark-done a card on a shared Deck board; observe the operation succeeds and journal logs the expected `*ById` call.
- [x] **Live in Talk:** ask Moltagent to operate on an ambiguous card title (two cards matching the same partial title on a shared board); confirm structured candidate list is returned and no card is mutated.
- [ ] **Live in Talk:** ask Moltagent to operate on a card on a board it has no access to; confirm a clear error is surfaced rather than a silent "card not found".

## Follow-ups (separate issues)
The codebase scan run as part of #65 found the same capability-narrowing pattern in:
- `calendar_list_events` — omits `calendarId` even though `CalDAVClient.getEvents(calendarId, …)` exists
- `wiki_read`, `wiki_write`, `wiki_search`, `wiki_list` — all default-collective only despite `CollectivesClient` exposing `listPages(collectiveId, …)` / `getPage(collectiveId, pageId)` / `createPage(collectiveId, …)`

Will file as discrete follow-ups once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)