### PR TITLE
fix(agent): re-prompt action turns that produced no tool calls

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -38,6 +38,9 @@ Domain-specific notes (not in tool schemas):
 - **Files**: When a user asks for a file you created, use `file_share` to share it — never tell them to navigate to the bot's storage.
 
 ### CRITICAL rules for tool use:
+
+**Action honesty.** If a request requires an action (creating, deleting, moving, sending, assigning, scheduling, writing, sharing — anything that changes state), call the appropriate tool. Never claim an action succeeded without a tool call having confirmed it. If you cannot perform the action, say what prevented you. The text you produce is not the action — the tool call is.
+
 - When asked to close/finish/complete a task → call deck_mark_done (or deck_move_card with target_stack "Done").
 - When asked to start/work on a task → call deck_move_card with target_stack "Working".
 - When asked to list tasks → call deck_list_cards (without stack param to search all stacks). Only filter by stack when the user explicitly asks for a specific stack.

--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -134,13 +134,14 @@ class AgentLoop {
     }
 
     // 3. Agent loop
-    const maxIter = options.maxIterations || this.maxIterations;
+    let maxIter = options.maxIterations || this.maxIterations;
     let iteration = 0;
     let lastResponse = null;
     const toolFailureCounts = {};  // toolName -> consecutive failure count
     let cumulativeToolResultChars = 0;
     const toolResultIndices = [];  // indices into messages[] of tool results
     const failedCallIds = new Set();  // tool_call_ids that returned errors
+    let actionGuardFired = false;  // once-per-turn re-prompt for tool-less action responses
 
     while (iteration < maxIter) {
       iteration++;
@@ -299,6 +300,35 @@ class AgentLoop {
         this.logger.info(`[AgentLoop] Iteration ${iteration} metadata: { toolsCalled: [${iterationToolsCalled.join(', ')}], cumulativeContextChars: ${cumulativeToolResultChars} }`);
 
         // Continue loop — LLM will process tool results
+        continue;
+      }
+
+      // Action-hallucination guard: when the classifier said this turn is an
+      // action but the LLM produced text without calling any tool, re-prompt
+      // once before letting the response reach the user. The check is
+      // structural (gate + tool-call history) — language-free.
+      //
+      // Skip when at least one tool has already executed this turn: that
+      // text response is the legitimate "summarize tool results" reply.
+      //
+      // Bounded to one re-prompt per turn via actionGuardFired so legitimate
+      // text-only refusals on the second pass ("I can't because…") are not
+      // re-prompted again. maxIter is bumped to guarantee at least one more
+      // iteration even when the short-message heuristic capped it at 2.
+      if (options.gate === 'action' && !actionGuardFired && toolResultIndices.length === 0) {
+        actionGuardFired = true;
+        maxIter = Math.max(maxIter, iteration + 1);
+
+        messages.push({
+          role: 'assistant',
+          content: response.content || ''
+        });
+        messages.push({
+          role: 'user',
+          content: '[SYSTEM] You were asked to perform an action but responded with text only — no tool was called. If you can perform the action, call the appropriate tool now. If you cannot perform it, explain what prevented you. Do not describe the result of an action you did not perform.'
+        });
+
+        this.logger.warn(`[AgentLoop] Action-hallucination guard fired at iteration ${iteration} — re-prompting (gate=action, zero tool calls)`);
         continue;
       }
 

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -657,8 +657,8 @@ class MessageProcessor {
         // Smart-mix: three-path routing (local text / local tools / cloud)
         // Build live context ONCE — passed to classifier, probes, synthesis, guard
         const liveContext = earlyLiveContext || (session ? buildLiveContext(session, pipelineMessage) : null);
-        const { useLocal, useDomainTools, intent, compound } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
-        console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}`);
+        const { useLocal, useDomainTools, intent, compound, gate } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
+        console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}${gate ? ` (gate=${gate})` : ''}`);
 
         // Intent-specific feedback: acknowledge the user immediately (fire-and-forget)
         const lang = this._getLanguage();
@@ -678,6 +678,7 @@ class MessageProcessor {
             messageId: extracted.messageId,
             inputType: extracted._isVoice ? 'voice' : 'text',
             user: extracted.user,
+            gate,
             systemSuffix: focusContext ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext) : flushPrompt,
             onArtifact
           });
@@ -743,6 +744,7 @@ class MessageProcessor {
                 messageId: extracted.messageId,
                 inputType: extracted._isVoice ? 'voice' : 'text',
                 user: extracted.user,
+                gate,
                 systemSuffix: focusContext || undefined,
                 onArtifact
               });
@@ -786,6 +788,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -817,6 +820,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -859,6 +863,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext
                 ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext)
                 : flushPrompt,
@@ -902,6 +907,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -930,6 +936,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -966,7 +973,8 @@ class MessageProcessor {
             messageId: extracted.messageId,
             inputType: extracted._isVoice ? 'voice' : 'text',
             voiceReplyEnabled,
-            user: extracted.user
+            user: extracted.user,
+            gate
           };
 
           // Bug 3 fix: Short confirmations shouldn't loop to max iterations
@@ -1746,7 +1754,7 @@ class MessageProcessor {
         }
       }
 
-      let { intent, domain, compound } = classification;
+      let { gate, intent, domain, compound } = classification;
 
       // Trust boundary: in smart-mix mode (cloud available), everything goes
       // through cloud except knowledge (dedicated probe pipeline) and compound
@@ -1754,24 +1762,24 @@ class MessageProcessor {
 
       // Confirmation/selection → cloud (needs full history)
       if (intent === 'confirmation' || intent === 'selection') {
-        return { useLocal: false, useDomainTools: false, intent, compound: false };
+        return { useLocal: false, useDomainTools: false, intent, compound: false, gate };
       }
       if (intent === 'confirmation_declined') {
-        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false };
+        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate };
       }
       // Knowledge → dedicated handler (probes, deep reads, web fallback, synthesis)
       if (intent === 'knowledge') {
-        return { useLocal: true, useDomainTools: true, intent, compound: !!compound };
+        return { useLocal: true, useDomainTools: true, intent, compound: !!compound, gate };
       }
       // Compound + domain → compound handler (already cloud-powered)
       if (compound && DOMAIN_INTENTS.has(intent)) {
-        return { useLocal: true, useDomainTools: true, intent, compound: true };
+        return { useLocal: true, useDomainTools: true, intent, compound: true, gate };
       }
       // Everything else → cloud via AgentLoop (Haiku, full tools, web search)
-      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound };
+      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate };
     } catch (err) {
       console.warn(`[Message] Smart-mix classification failed: ${err.message}`);
-      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false };
+      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false, gate: null };
     }
   }
 

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1419,6 +1419,149 @@ asyncTest('system prompt defaults to UTC timezone', async () => {
 });
 
 // ============================================================
+// Action-hallucination guard (issue surfaced during PR #66 verification)
+// ============================================================
+
+asyncTest('action-hallucination guard: text-only response with gate=action triggers re-prompt then tool call', async () => {
+  // Iteration 1: LLM hallucinates success in text only.
+  // Iteration 2: After guard's re-prompt, LLM calls the tool.
+  // Iteration 3: LLM produces final text after tool result.
+  const provider = createMockProvider([
+    { content: '✅ Deleted both cards', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_delete_card', arguments: { card: '#42' } }] },
+    { content: 'Deleted card #42.', toolCalls: null }
+  ]);
+
+  let executedTool = null;
+  const registry = createMockToolRegistry({
+    deck_delete_card: async (args) => { executedTool = args; return { success: true, result: 'Deleted #42' }; }
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete card 42', 'room-abc', { gate: 'action' });
+  assert.deepStrictEqual(executedTool, { card: '#42' });
+  assert.strictEqual(response, 'Deleted card #42.');
+});
+
+asyncTest('action-hallucination guard fires at most once per turn (legitimate text-only refusal accepted)', async () => {
+  // Iteration 1: LLM responds text-only (claims failure).
+  // Iteration 2: After re-prompt, LLM still text-only (legitimate explanation).
+  //              Guard must NOT fire again — second text is the final answer.
+  const provider = createMockProvider([
+    { content: 'OK, I deleted it.', toolCalls: null },
+    { content: 'I cannot delete it — the board does not exist.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete card 42 on Imaginary board', 'room-abc', { gate: 'action' });
+  assert.strictEqual(response, 'I cannot delete it — the board does not exist.');
+  assert.strictEqual(provider._getCallCount(), 2);  // exactly 2 LLM calls, no infinite loop
+});
+
+asyncTest('action-hallucination guard bumps maxIter when capped at 2 (short-message heuristic case)', async () => {
+  // Simulates "delete both" — short message, message-processor sets maxIterations=2.
+  // Without the bump, the re-prompt would consume iteration 2 but the loop exits
+  // before the LLM can act. With the bump, the LLM gets one more shot.
+  const provider = createMockProvider([
+    { content: '✅ Done', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'call_x', name: 'deck_delete_card', arguments: { card: '#1' } }] },
+    { content: 'Done.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_delete_card: async () => ({ success: true, result: 'ok' })
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete both', 'room-abc', { gate: 'action', maxIterations: 2 });
+  assert.strictEqual(response, 'Done.');
+  assert.strictEqual(provider._getCallCount(), 3);
+});
+
+asyncTest('action-hallucination guard does NOT fire for gate=knowledge', async () => {
+  // Knowledge responses are legitimately text-only — guard must not interfere.
+  const provider = createMockProvider([
+    { content: 'The wiki says X.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('what is X?', 'room-abc', { gate: 'knowledge' });
+  assert.strictEqual(response, 'The wiki says X.');
+  assert.strictEqual(provider._getCallCount(), 1);
+});
+
+asyncTest('action-hallucination guard does NOT fire when gate option is omitted (proactive/internal triggers)', async () => {
+  // ProactiveEvaluator and DeferralQueue call process() without a gate.
+  // Guard must not fire — there's no classifier signal to act on.
+  const provider = createMockProvider([
+    { content: 'Acknowledged.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('internal prompt', 'room-abc');
+  assert.strictEqual(response, 'Acknowledged.');
+  assert.strictEqual(provider._getCallCount(), 1);
+});
+
+asyncTest('action-hallucination guard does NOT fire when LLM calls a tool on iteration 1 (normal action flow)', async () => {
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_create_card', arguments: { title: 'T' } }] },
+    { content: 'Card created.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_create_card: async () => ({ success: true, result: 'created' })
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('create card T', 'room-abc', { gate: 'action' });
+  assert.strictEqual(response, 'Card created.');
+  assert.strictEqual(provider._getCallCount(), 2);  // no re-prompt needed
+});
+
+// ============================================================
 // Cleanup & Summary
 // ============================================================
 


### PR DESCRIPTION
## Summary
- AgentLoop now refuses to send a text-only response when the classifier said `gate=action` and no tool has been called in the turn. Instead it injects a `[SYSTEM]` user message ("call the tool or explain what prevented you") and gives the LLM one more iteration. Bounded to one re-prompt per turn; second text-only response (e.g., legitimate refusal) is accepted without further bouncing.
- `_smartMixClassify` now returns `gate` alongside `intent`/`compound` — it was being dropped on the destructure at message-processor.js:1749 so the verdict never reached AgentLoop. All eight smart-mix `agentLoop.process` call sites pass it through. Internal-trigger paths (ProactiveEvaluator, DeferralQueue, generic agent_loop without classifier) leave gate undefined; the guard correctly does not fire.
- SOUL.md gains one paragraph at the head of the tool-use section: actions require tool calls, the text is not the action.

## Why this is needed
PR #66 live verification surfaced the bug. A user said "delete both" after an ambiguity response listing two cards. Classifier returned `gate=action`. Claude produced 48 tokens of `"✅ Deleted both cards"` text with **zero** `tool_use` blocks. AgentLoop exited on the text-only branch, the response went out, both cards remained on the board. Direct API check confirmed the cards still alive. Pure linguistic completion of an action that never happened.

## Why structural, not lexical
The detection is binary and language-free: classifier said action, response had zero tool calls. No regex on natural language, no scanning for success markers ("done", "deleted", "✅", "erledigt", "concluído"). Rule 1 (the LLM is the language layer) is preserved. The guard mechanism doesn't care whether the user typed in English, German, Portuguese, or anything else.

## Test plan
- [x] `npm run lint` → 0 errors
- [x] `npm run test:unit` → 215/215 unit test files pass
- [x] 6 new AgentLoop tests:
  - text-only response with `gate=action` → re-prompt fires → tool called on iteration 2
  - once-per-turn bound: text → re-prompt → text again (legitimate refusal) → accepted without infinite loop
  - `maxIterations=2` from short-message heuristic → guard bumps cap so re-prompted attempt has room
  - `gate=knowledge` → guard does not fire
  - no `gate` option (internal trigger) → guard does not fire
  - normal action flow (tool called on iteration 1, text on iteration 2) → guard does not fire (tool was already called this turn)
- [x] Service restart clean: `ToolActivator ready (ToolRegistry now has 76 tools)`, `Ready to receive NC Talk messages`, no boot errors
- [ ] **Live verification (needs human in Talk):** repeat the exact PR #66 incident — "close the test card in Content Pipeline - Molti" → ambiguity → "delete both". The strongest reproduction needs **PR #66 also applied** so the conversational tools can reach shared boards. With PR #66 active: cards should actually delete or surface a real failure reason. Without PR #66: the guard should still fire on any text-only action response and force a second attempt.
- [ ] **Live verification of the bounded-fire case:** ask Moltagent to perform an action on a nonexistent board. Expected: iteration 1 hallucinates or refuses → guard fires once → iteration 2 produces a real explanation. No loop. One extra Haiku call (~\$0.002).

## Out of scope (separate follow-ups)
- The English-only confirmation-word regex at message-processor.js:1019 (Rule 1 violation, contains hardcoded `yes|no|ok|sure|yeah|nah|do it|...`). Unrelated mechanism, same surface area.
- The dead 403 path at tool-registry.js:305–310 (handlers swallow before the graceful path can fire). Flagged during PR #66 verification; needs separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)