### PR TITLE
Release: LKA alive, tool gap closed, action hallucination guard

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -38,6 +38,9 @@ Domain-specific notes (not in tool schemas):
 - **Files**: When a user asks for a file you created, use `file_share` to share it — never tell them to navigate to the bot's storage.
 
 ### CRITICAL rules for tool use:
+
+**Action honesty.** If a request requires an action (creating, deleting, moving, sending, assigning, scheduling, writing, sharing — anything that changes state), call the appropriate tool. Never claim an action succeeded without a tool call having confirmed it. If you cannot perform the action, say what prevented you. The text you produce is not the action — the tool call is.
+
 - When asked to close/finish/complete a task → call deck_mark_done (or deck_move_card with target_stack "Done").
 - When asked to start/work on a task → call deck_move_card with target_stack "Working".
 - When asked to list tasks → call deck_list_cards (without stack param to search all stacks). Only filter by stack when the user explicitly asks for a specific stack.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,6 +131,7 @@ chmod 600 /etc/credstore/moltagent-nc-password
 ### Configure the agent
 
 ```bash
+# From the repo root (/opt/moltagent if you followed the clone step above):
 # Edit the provider configuration with your Ollama VM IP and provider preferences
 nano config/moltagent-providers.yaml
 ```
@@ -224,16 +225,26 @@ Send a message in the Talk room. If the webhook is configured correctly, the bot
 
 Check the [public dashboard](https://public.moltagent.cloud) architecture view for a reference of what a healthy system looks like.
 
-## Single-VM Development Setup
+## Home-Lab and Single-Server Setup
 
-For development and testing, you can run everything on a single machine:
+The three-VM architecture is a production security measure (network isolation). For testing, development, or home-lab use, you can run Moltagent alongside an existing Nextcloud and Ollama installation.
 
-1. Install Ollama locally
-2. Point the config at a Nextcloud instance (can be a test Storage Share or local Nextcloud)
-3. Run `npm test` to verify the test suite
-4. Run the agent directly with `node webhook-server.js`
+What changes:
 
-This skips network isolation and is not suitable for production, but it's sufficient for development and contribution testing.
+- Clone the repo on the same server as Nextcloud (or any machine that can reach your Nextcloud and Ollama instances)
+- In `config/moltagent-providers.yaml`, set the Ollama endpoint to your Ollama server's LAN IP (e.g. `http://192.168.1.50:11434`)
+- Set up the credential store and systemd service as described in Step 4 above
+- Skip the firewall rules — those are for the isolated VM setup
+
+To verify:
+
+```bash
+cd /path/to/moltagent
+npm test                      # Run the test suite
+node webhook-server.js        # Start the agent directly (foreground, useful for debugging)
+```
+
+This skips network isolation and is not suitable for production, but works for development, contribution testing, and home-lab exploration.
 
 ## Next Steps
 

--- a/scripts/run-all-tests.js
+++ b/scripts/run-all-tests.js
@@ -14,6 +14,11 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+// config.js requires NC_URL; supply a harmless test default so the suite
+// can load modules that transitively import config. The daemon's startup
+// boundary (webhook-server.js) still throws loudly when NC_URL is unset.
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const args = process.argv.slice(2);
 const runUnit = args.includes('--unit') || args.length === 0;
 const runIntegration = args.includes('--integration') || args.length === 0;

--- a/scripts/test-talk-bot.sh
+++ b/scripts/test-talk-bot.sh
@@ -12,12 +12,19 @@
 #   ./scripts/test-talk-bot.sh 3000 my-secret     # Custom port/secret
 #
 
-set -e
+set -euo pipefail
 
 # Configuration
 PORT="${1:-3000}"
 SECRET="${2:-test-secret-for-webhook-testing-must-be-long-enough}"
-BACKEND="${NC_URL:-https://YOUR_NEXTCLOUD_URL}"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./scripts/test-talk-bot.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 BASE_URL="http://localhost:${PORT}"
 
 # Colors

--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -134,13 +134,14 @@ class AgentLoop {
     }
 
     // 3. Agent loop
-    const maxIter = options.maxIterations || this.maxIterations;
+    let maxIter = options.maxIterations || this.maxIterations;
     let iteration = 0;
     let lastResponse = null;
     const toolFailureCounts = {};  // toolName -> consecutive failure count
     let cumulativeToolResultChars = 0;
     const toolResultIndices = [];  // indices into messages[] of tool results
     const failedCallIds = new Set();  // tool_call_ids that returned errors
+    let actionGuardFired = false;  // once-per-turn re-prompt for tool-less action responses
 
     while (iteration < maxIter) {
       iteration++;
@@ -299,6 +300,35 @@ class AgentLoop {
         this.logger.info(`[AgentLoop] Iteration ${iteration} metadata: { toolsCalled: [${iterationToolsCalled.join(', ')}], cumulativeContextChars: ${cumulativeToolResultChars} }`);
 
         // Continue loop — LLM will process tool results
+        continue;
+      }
+
+      // Action-hallucination guard: when the classifier said this turn is an
+      // action but the LLM produced text without calling any tool, re-prompt
+      // once before letting the response reach the user. The check is
+      // structural (gate + tool-call history) — language-free.
+      //
+      // Skip when at least one tool has already executed this turn: that
+      // text response is the legitimate "summarize tool results" reply.
+      //
+      // Bounded to one re-prompt per turn via actionGuardFired so legitimate
+      // text-only refusals on the second pass ("I can't because…") are not
+      // re-prompted again. maxIter is bumped to guarantee at least one more
+      // iteration even when the short-message heuristic capped it at 2.
+      if (options.gate === 'action' && !actionGuardFired && toolResultIndices.length === 0) {
+        actionGuardFired = true;
+        maxIter = Math.max(maxIter, iteration + 1);
+
+        messages.push({
+          role: 'assistant',
+          content: response.content || ''
+        });
+        messages.push({
+          role: 'user',
+          content: '[SYSTEM] You were asked to perform an action but responded with text only — no tool was called. If you can perform the action, call the appropriate tool now. If you cannot perform it, explain what prevented you. Do not describe the result of an action you did not perform.'
+        });
+
+        this.logger.warn(`[AgentLoop] Action-hallucination guard fired at iteration ${iteration} — re-prompting (gate=action, zero tool calls)`);
         continue;
       }
 

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -471,6 +471,114 @@ class ToolRegistry {
   }
 
   /**
+   * Resolve a card on either the default board (legacy behaviour, preserved
+   * for backward compatibility) or a named/ID-identified board. Returns one
+   * of four shapes so the caller can render an appropriate user-facing
+   * message without a second resolution pass.
+   *
+   * @private
+   * @param {Object} deck - DeckClient instance
+   * @param {string} cardIdentifier - Card title (partial match) or "#ID"
+   * @param {string} [boardParam] - Board name (partial match) or ID. If
+   *   omitted, walks the bot's default task board.
+   * @returns {Promise<
+   *     { found: true, card, boardId, stackId, stackTitle, isDefaultBoard, stackKey? }
+   *   | { found: false, reason: 'no_board', boardQuery }
+   *   | { found: false, reason: 'no_card', boardTitle, cardQuery }
+   *   | { found: false, reason: 'ambiguous', boardTitle, cardQuery, candidates }
+   * >}
+   */
+  async _resolveCardOnBoard(deck, cardIdentifier, boardParam) {
+    if (!boardParam) {
+      const resolved = await this._resolveCard(deck, cardIdentifier);
+      if (!resolved) return { found: false, reason: 'no_card', boardTitle: null, cardQuery: cardIdentifier };
+
+      const stackTitle = (deck.stackNames && deck.stackNames[resolved.stackKey]) || resolved.stackKey;
+      return {
+        found: true,
+        card: resolved.card,
+        boardId: null,
+        stackId: null,
+        stackTitle,
+        isDefaultBoard: true,
+        stackKey: resolved.stackKey
+      };
+    }
+
+    const board = await this._resolveBoard(deck, boardParam);
+    if (!board) return { found: false, reason: 'no_board', boardQuery: boardParam };
+
+    const stacks = await deck.getStacks(board.id);
+    const idStr = String(cardIdentifier).startsWith('#')
+      ? String(cardIdentifier).slice(1)
+      : null;
+    const titleLower = idStr ? null : String(cardIdentifier).toLowerCase();
+
+    const matches = [];
+    for (const stack of stacks || []) {
+      for (const card of stack.cards || []) {
+        const matchById = idStr && String(card.id) === idStr;
+        const matchByTitle = !idStr && card.title && card.title.toLowerCase().includes(titleLower);
+        if (matchById || matchByTitle) {
+          matches.push({ card, stackId: stack.id, stackTitle: stack.title });
+        }
+      }
+    }
+
+    if (matches.length === 0) {
+      return { found: false, reason: 'no_card', boardTitle: board.title, cardQuery: cardIdentifier };
+    }
+    if (matches.length > 1) {
+      return {
+        found: false,
+        reason: 'ambiguous',
+        boardTitle: board.title,
+        cardQuery: cardIdentifier,
+        candidates: matches.map(m => ({
+          id: m.card.id,
+          title: m.card.title,
+          stackTitle: m.stackTitle
+        }))
+      };
+    }
+
+    const m = matches[0];
+    return {
+      found: true,
+      card: m.card,
+      boardId: board.id,
+      stackId: m.stackId,
+      stackTitle: m.stackTitle,
+      isDefaultBoard: false
+    };
+  }
+
+  /**
+   * Render a non-found resolution as a user-facing string. Returns null
+   * if the resolution is `found: true` (caller should not invoke this).
+   * @private
+   */
+  _renderResolutionError(resolution, action = 'operate on') {
+    if (resolution.found) return null;
+    if (resolution.reason === 'no_board') {
+      return `No board found matching "${resolution.boardQuery}".`;
+    }
+    if (resolution.reason === 'no_card') {
+      return resolution.boardTitle
+        ? `No card found matching "${resolution.cardQuery}" on board "${resolution.boardTitle}".`
+        : `No card found matching "${resolution.cardQuery}".`;
+    }
+    if (resolution.reason === 'ambiguous') {
+      const list = resolution.candidates
+        .map(c => `  - #${c.id} "${c.title}" in ${c.stackTitle}`)
+        .join('\n');
+      return `Multiple cards on board "${resolution.boardTitle}" match "${resolution.cardQuery}". ` +
+        `Please specify which card to ${action} by passing the card ID (e.g. "#${resolution.candidates[0].id}"):\n${list}`;
+    }
+    return `Could not resolve card "${resolution.cardQuery}".`;
+  }
+
+  /**
    * Resolve cards across all accessible boards.
    * Returns flat array of { card, stackTitle, boardTitle, boardId }.
    * @private
@@ -607,7 +715,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_move_card',
-      description: 'Move a card to a different stack. Use this when asked to close, finish, start, or queue a task. The card can be identified by title (partial match) or ID.',
+      description: 'Move a card to a different stack. Use this when asked to close, finish, start, or queue a task. The card can be identified by title (partial match) or ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
         type: 'object',
         properties: {
@@ -617,33 +725,51 @@ class ToolRegistry {
           },
           target_stack: {
             type: 'string',
-            description: 'Destination stack',
-            enum: [DECK.stacks.inbox, DECK.stacks.queued, DECK.stacks.working, DECK.stacks.done, DECK.stacks.review]
+            description: 'Destination stack title. On the default task board: Inbox, Queued, Working, Done, Review. On a shared board: the stack title as it appears on that board (use deck_list_stacks to discover).'
+          },
+          board: {
+            type: 'string',
+            description: 'Board name (partial match) or board ID. If omitted, uses the task board.'
           }
         },
         required: ['card', 'target_stack']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-
-          if (!resolved) {
-            const allCards = await deck.getAllCards();
-            const available = Object.entries(allCards)
-              .flatMap(([k, cards]) => cards.map(c => `  - "${c.title}" in ${this._stackDisplayName(k, deck)}`))
-              .join('\n');
-            return `No card found matching "${args.card}".${available ? ` Available cards:\n${available}` : ''}`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) {
+            if (!args.board && resolution.reason === 'no_card') {
+              const allCards = await deck.getAllCards();
+              const available = Object.entries(allCards)
+                .flatMap(([k, cards]) => cards.map(c => `  - "${c.title}" in ${this._stackDisplayName(k, deck)}`))
+                .join('\n');
+              return `No card found matching "${args.card}".${available ? ` Available cards:\n${available}` : ''}`;
+            }
+            return this._renderResolutionError(resolution, 'move');
           }
 
-          const { card: foundCard, stackKey: fromStackKey } = resolved;
-          const toStackKey = this._stackKey(args.target_stack);
+          const { card: foundCard, boardId, stackId: fromStackId, stackTitle: fromStackTitle, isDefaultBoard, stackKey: fromStackKey } = resolution;
 
-          if (fromStackKey === toStackKey) {
-            return `Card "${foundCard.title}" is already in ${args.target_stack}.`;
+          if (isDefaultBoard) {
+            const toStackKey = this._stackKey(args.target_stack);
+            if (fromStackKey === toStackKey) {
+              return `Card "${foundCard.title}" is already in ${args.target_stack}.`;
+            }
+            await deck.moveCard(foundCard.id, fromStackKey, toStackKey);
+            return `Moved "${foundCard.title}" (card #${foundCard.id}) from ${this._stackDisplayName(fromStackKey, deck)} to ${args.target_stack}.`;
           }
 
-          await deck.moveCard(foundCard.id, fromStackKey, toStackKey);
-          return `Moved "${foundCard.title}" (card #${foundCard.id}) from ${this._stackDisplayName(fromStackKey, deck)} to ${args.target_stack}.`;
+          const stacks = await deck.getStacks(boardId);
+          const targetStack = (stacks || []).find(s => s.title.toLowerCase() === args.target_stack.toLowerCase());
+          if (!targetStack) {
+            const available = (stacks || []).map(s => `"${s.title}"`).join(', ');
+            return `No stack "${args.target_stack}" on this board. Available stacks: ${available || '(none)'}`;
+          }
+          if (targetStack.id === fromStackId) {
+            return `Card "${foundCard.title}" is already in "${targetStack.title}".`;
+          }
+          await deck.moveCardById(foundCard.id, targetStack.id, 0);
+          return `Moved "${foundCard.title}" (card #${foundCard.id}) from "${fromStackTitle}" to "${targetStack.title}".`;
         } catch (err) {
           this.logger.error(`[deck_move_card] ${err.message}`);
           return `Failed to move card: ${err.message}`;
@@ -860,24 +986,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_get_card',
-      description: 'Get full details of a card including description, due date, assigned users, labels, and comments. Card identified by title (partial match) or #ID.',
+      description: 'Get full details of a card including description, due date, assigned users, labels, and comments. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read from a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'read');
 
-          const { card: found, stackKey } = resolved;
-          const full = await deck.getCard(found.id, stackKey);
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
+          const full = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
           const comments = await deck.getComments(found.id);
 
-          let result = `Card #${full.id}: "${full.title}" in ${this._stackDisplayName(stackKey, deck)}\n`;
+          let result = `Card #${full.id}: "${full.title}" in ${stackTitle}\n`;
           if (full.description) result += `Description: ${full.description}\n`;
           if (full.duedate) result += `Due: ${full.duedate}\n`;
 
@@ -907,24 +1036,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_update_card',
-      description: 'Update a card\'s title, description, or due date. Card identified by title (partial match) or #ID.',
+      description: 'Update a card\'s title, description, or due date. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
           title: { type: 'string', description: 'New title' },
           description: { type: 'string', description: 'New description' },
-          duedate: { type: 'string', description: 'New due date (ISO format) or "none" to clear' }
+          duedate: { type: 'string', description: 'New due date (ISO format) or "none" to clear' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'update');
 
-          const { card: found, stackKey } = resolved;
-          const current = await deck.getCard(found.id, stackKey);
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          const current = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
 
           const updates = {
             title: args.title || current.title,
@@ -934,7 +1066,11 @@ class ToolRegistry {
             duedate: args.duedate === 'none' ? null : (args.duedate || current.duedate || null)
           };
 
-          await deck.updateCard(found.id, stackKey, updates);
+          if (isDefaultBoard) {
+            await deck.updateCard(found.id, stackKey, updates);
+          } else {
+            await deck.updateCardById(boardId, stackId, found.id, updates);
+          }
 
           const changes = [];
           if (args.title) changes.push(`title: "${args.title}"`);
@@ -951,22 +1087,27 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_card',
-      description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID.',
+      description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to delete a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'delete');
 
-          const { card: found, stackKey } = resolved;
-          await deck.deleteCard(found.id, stackKey);
-          return `Deleted card #${found.id} "${found.title}" from ${this._stackDisplayName(stackKey, deck)}.`;
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.deleteCard(found.id, stackKey);
+          } else {
+            await deck.deleteCardById(boardId, stackId, found.id);
+          }
+          return `Deleted card #${found.id} "${found.title}" from ${stackTitle}.`;
         } catch (err) {
           this.logger.error(`[deck_delete_card] ${err.message}`);
           return `Failed to delete card: ${err.message}`;
@@ -976,61 +1117,76 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_assign_user',
-      description: 'Assign a user to a card. Card identified by title (partial match) or #ID.',
+      description: 'Assign a user to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to assign on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          user: { type: 'string', description: 'NC username to assign' }
+          user: { type: 'string', description: 'NC username to assign' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'user']
       },
       handler: async (args) => {
-        const resolved = await this._resolveCard(deck, args.card);
-        if (!resolved) return `No card found matching "${args.card}".`;
+        const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+        if (!resolution.found) return this._renderResolutionError(resolution, 'assign on');
 
-        const { card: found, stackKey } = resolved;
+        const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
         if (isStructuralCard(found)) {
           return `Card #${found.id} "${found.title}" is a structural/config card, not a work item. Structural cards should not be assigned to users. If you need to modify this card, do so explicitly.`;
         }
-        const assignResult = await deck.assignUser(found.id, stackKey, args.user);
-        if (assignResult === undefined || assignResult === null) {
-          // assignUser returns undefined when user is not a board member
-          // Re-read card to verify assignment actually took effect
-          try {
-            const updated = await deck.getCard(found.id, stackKey);
-            const isAssigned = (updated.assignedUsers || []).some(
-              a => (a.participant?.uid || '').toLowerCase() === args.user.toLowerCase()
-            );
-            if (!isAssigned) return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
-          } catch {
-            // If re-read fails, we can't confirm — report uncertainty
-            return `Assignment of "${args.user}" to card #${found.id} could not be confirmed. The user may not be a member of this board.`;
+
+        if (isDefaultBoard) {
+          const assignResult = await deck.assignUser(found.id, stackKey, args.user);
+          if (assignResult === undefined || assignResult === null) {
+            try {
+              const updated = await deck.getCard(found.id, stackKey);
+              const isAssigned = (updated.assignedUsers || []).some(
+                a => (a.participant?.uid || '').toLowerCase() === args.user.toLowerCase()
+              );
+              if (!isAssigned) return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
+            } catch {
+              return `Assignment of "${args.user}" to card #${found.id} could not be confirmed. The user may not be a member of this board.`;
+            }
           }
+          return `Assigned "${args.user}" to card #${found.id} "${found.title}".`;
         }
-        return `Assigned "${args.user}" to card #${found.id} "${found.title}".`;
+
+        const matched = await deck.assignUserById(boardId, stackId, found.id, args.user);
+        if (matched === null) {
+          return `Could not assign "${args.user}" to card #${found.id} — user may not be a member of this board.`;
+        }
+        return `Assigned "${matched}" to card #${found.id} "${found.title}".`;
       }
     });
 
     this.register({
       name: 'deck_unassign_user',
-      description: 'Remove a user assignment from a card. Card identified by title (partial match) or #ID.',
+      description: 'Remove a user assignment from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to unassign on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          user: { type: 'string', description: 'NC username to unassign' }
+          user: { type: 'string', description: 'NC username to unassign' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'user']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'unassign on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.unassignUser(found.id, stackKey, args.user);
-          return `Unassigned "${args.user}" from card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.unassignUser(found.id, stackKey, args.user);
+            return `Unassigned "${args.user}" from card #${found.id} "${found.title}".`;
+          }
+          const matched = await deck.unassignUserById(boardId, stackId, found.id, args.user);
+          if (matched === null) {
+            return `Could not unassign "${args.user}" from card #${found.id} — user is not a member of this board.`;
+          }
+          return `Unassigned "${matched}" from card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_unassign_user] ${err.message}`);
           return `Failed to unassign user: ${err.message}`;
@@ -1040,33 +1196,43 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_set_due_date',
-      description: 'Set or clear the due date on a card. Card identified by title (partial match) or #ID.',
+      description: 'Set or clear the due date on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          duedate: { type: 'string', description: 'Due date in ISO format (e.g. 2026-02-15) or "none" to clear' }
+          duedate: { type: 'string', description: 'Due date in ISO format (e.g. 2026-02-15) or "none" to clear' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'duedate']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'update');
 
-          const { card: found, stackKey } = resolved;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
           if (isStructuralCard(found)) {
             return `Card #${found.id} "${found.title}" is a structural/config card, not a work item. Structural cards should not have due dates. If you need to modify this card, do so explicitly.`;
           }
-          const current = await deck.getCard(found.id, stackKey);
+
+          const current = isDefaultBoard
+            ? await deck.getCard(found.id, stackKey)
+            : await deck.getCardById(boardId, stackId, found.id);
 
           const duedate = args.duedate.toLowerCase() === 'none' ? null : args.duedate;
-          await deck.updateCard(found.id, stackKey, {
+          const updates = {
             title: current.title,
             type: current.type || 'plain',
             owner: current.owner?.uid || current.owner || deck.username,
             duedate
-          });
+          };
+
+          if (isDefaultBoard) {
+            await deck.updateCard(found.id, stackKey, updates);
+          } else {
+            await deck.updateCardById(boardId, stackId, found.id, updates);
+          }
 
           return duedate
             ? `Set due date on card #${found.id} "${found.title}" to ${duedate}.`
@@ -1082,23 +1248,35 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_label',
-      description: 'Add a label to a card. Card identified by title (partial match) or #ID.',
+      description: 'Add a label to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board. The label must already exist on the target board (use deck_create_label first if needed).',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          label: { type: 'string', description: 'Label name (e.g. urgent, research, writing, admin, blocked)' }
+          label: { type: 'string', description: 'Label name (e.g. urgent, research, writing, admin, blocked)' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'label']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'label on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.addLabel(found.id, stackKey, args.label);
-          return `Added label "${args.label}" to card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.addLabel(found.id, stackKey, args.label);
+            return `Added label "${args.label}" to card #${found.id} "${found.title}".`;
+          }
+
+          const board = await deck.getBoard(boardId);
+          const labelDef = (board.labels || []).find(l => l.title.toLowerCase() === args.label.toLowerCase());
+          if (!labelDef) {
+            const available = (board.labels || []).map(l => `"${l.title}"`).join(', ');
+            return `No label "${args.label}" on board "${board.title}". Available labels: ${available || '(none)'}`;
+          }
+          await deck.assignLabelById(boardId, stackId, found.id, labelDef.id);
+          return `Added label "${labelDef.title}" to card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_add_label] ${err.message}`);
           return `Failed to add label: ${err.message}`;
@@ -1108,23 +1286,34 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_remove_label',
-      description: 'Remove a label from a card. Card identified by title (partial match) or #ID.',
+      description: 'Remove a label from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          label: { type: 'string', description: 'Label name to remove' }
+          label: { type: 'string', description: 'Label name to remove' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'label']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'unlabel on');
 
-          const { card: found, stackKey } = resolved;
-          await deck.removeLabel(found.id, stackKey, args.label);
-          return `Removed label "${args.label}" from card #${found.id} "${found.title}".`;
+          const { card: found, boardId, stackId, isDefaultBoard, stackKey } = resolution;
+          if (isDefaultBoard) {
+            await deck.removeLabel(found.id, stackKey, args.label);
+            return `Removed label "${args.label}" from card #${found.id} "${found.title}".`;
+          }
+
+          const board = await deck.getBoard(boardId);
+          const labelDef = (board.labels || []).find(l => l.title.toLowerCase() === args.label.toLowerCase());
+          if (!labelDef) {
+            return `No label "${args.label}" on board "${board.title}".`;
+          }
+          await deck.removeLabelById(boardId, stackId, found.id, labelDef.id);
+          return `Removed label "${labelDef.title}" from card #${found.id} "${found.title}".`;
         } catch (err) {
           this.logger.error(`[deck_remove_label] ${err.message}`);
           return `Failed to remove label: ${err.message}`;
@@ -1159,21 +1348,22 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_comment',
-      description: 'Add a comment to a card. Use this to leave notes, updates, or communicate about a task. Card identified by title (partial match) or #ID.',
+      description: 'Add a comment to a card. Use this to leave notes, updates, or communicate about a task. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to comment on a shared board.',
       parameters: {
         type: 'object',
         properties: {
           card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
-          message: { type: 'string', description: 'Comment text' }
+          message: { type: 'string', description: 'Comment text' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card', 'message']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'comment on');
 
-          const { card: found } = resolved;
+          const { card: found } = resolution;
           await deck.addComment(found.id, args.message, 'STATUS', { prefix: false });
           return `Added comment to card #${found.id} "${found.title}".`;
         } catch (err) {
@@ -1185,20 +1375,21 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_comments',
-      description: 'List all comments on a card. Card identified by title (partial match) or #ID.',
+      description: 'List all comments on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read comments on a shared board.',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'read comments on');
 
-          const { card: found } = resolved;
+          const { card: found } = resolution;
           const comments = await deck.getComments(found.id);
 
           if (comments.length === 0) return `No comments on card #${found.id} "${found.title}".`;
@@ -1354,24 +1545,39 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_mark_done',
-      description: 'Mark a card as done by moving it to the Done stack. Card identified by title (partial match) or #ID.',
+      description: 'Mark a card as done by moving it to the Done stack. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to mark a card on a shared board (requires a stack titled "Done" on that board).',
       parameters: {
         type: 'object',
         properties: {
-          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' }
+          card: { type: 'string', description: 'Card title (partial match) or card ID prefixed with #' },
+          board: { type: 'string', description: 'Board name (partial match) or board ID. If omitted, uses the task board.' }
         },
         required: ['card']
       },
       handler: async (args) => {
         try {
-          const resolved = await this._resolveCard(deck, args.card);
-          if (!resolved) return `No card found matching "${args.card}".`;
+          const resolution = await this._resolveCardOnBoard(deck, args.card, args.board);
+          if (!resolution.found) return this._renderResolutionError(resolution, 'mark done');
 
-          const { card: found, stackKey } = resolved;
-          if (stackKey === 'done') return `Card #${found.id} "${found.title}" is already in Done.`;
+          const { card: found, boardId, stackId, stackTitle, isDefaultBoard, stackKey } = resolution;
 
-          await deck.moveCard(found.id, stackKey, 'done');
-          return `Marked card #${found.id} "${found.title}" as done (moved from ${this._stackDisplayName(stackKey, deck)} to Done).`;
+          if (isDefaultBoard) {
+            if (stackKey === 'done') return `Card #${found.id} "${found.title}" is already in Done.`;
+            await deck.moveCard(found.id, stackKey, 'done');
+            return `Marked card #${found.id} "${found.title}" as done (moved from ${this._stackDisplayName(stackKey, deck)} to Done).`;
+          }
+
+          const stacks = await deck.getStacks(boardId);
+          const doneStack = (stacks || []).find(s => s.title.toLowerCase() === 'done');
+          if (!doneStack) {
+            const available = (stacks || []).map(s => `"${s.title}"`).join(', ');
+            return `No "Done" stack on this board. Available stacks: ${available || '(none)'}. Use deck_move_card with an explicit target_stack instead.`;
+          }
+          if (doneStack.id === stackId) {
+            return `Card #${found.id} "${found.title}" is already in "${doneStack.title}".`;
+          }
+          await deck.moveCardById(found.id, doneStack.id, 0);
+          return `Marked card #${found.id} "${found.title}" as done (moved from "${stackTitle}" to "${doneStack.title}").`;
         } catch (err) {
           this.logger.error(`[deck_mark_done] ${err.message}`);
           return `Failed to mark card as done: ${err.message}`;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -67,6 +67,27 @@ function envStr(envVar, defaultValue) {
 }
 
 /**
+ * Read a required environment variable; throw if unset or empty.
+ * Use for values where a silent placeholder fallback would mask
+ * a misconfigured deployment (e.g. base URLs, credentials).
+ * @param {string} envVar - Environment variable name
+ * @param {string} [description] - Human-readable description shown in the error
+ * @returns {string}
+ */
+function envRequired(envVar, description) {
+  const value = process.env[envVar];
+  if (value === undefined || value === '') {
+    const what = description ? ` (${description})` : '';
+    throw new Error(
+      `[config] Required environment variable ${envVar} is not set${what}. ` +
+      `Refusing to start with an unconfigured ${envVar} — a placeholder default ` +
+      `would silently leak into outbound headers and audit logs.`
+    );
+  }
+  return value;
+}
+
+/**
  * Parse comma-separated list from environment variable
  * @param {string} envVar - Environment variable name
  * @param {string[]} defaultValue - Default if not set
@@ -211,7 +232,7 @@ const config = {
   // Nextcloud Connection
   // -------------------------------------------------------------------------
   nextcloud: {
-    url: envStr('NC_URL', 'https://YOUR_NEXTCLOUD_URL'),
+    url: envRequired('NC_URL', 'Nextcloud base URL, e.g. https://nc.example.com'),
     username: envStr('NC_USER', 'moltagent')
   },
 

--- a/src/lib/integrations/collectives-client.js
+++ b/src/lib/integrations/collectives-client.js
@@ -45,6 +45,10 @@ class CollectivesClient {
     this.baseUrl = this.nc.ncUrl;
     this.username = this.nc.ncUser || 'moltagent';
 
+    // Optional logger; falls back to console so section-collision diagnostics
+    // still reach journald when no structured logger is wired in.
+    this.logger = config.logger || console;
+
     // Configuration
     this.collectiveName = config.collectiveName || appConfig.knowledge?.collectiveName || 'Moltagent Knowledge';
 
@@ -79,7 +83,7 @@ class CollectivesClient {
    * @param {Object} [body] - Request body
    * @returns {Promise<Object>} Response body
    */
-  async _ocsRequest(method, path, body = null) {
+  async _ocsRequest(method, path, body = null, { skipCache = false } = {}) {
     const url = `${this.ocsBase}${path}`;
     const options = {
       method,
@@ -88,6 +92,10 @@ class CollectivesClient {
         'Accept': 'application/json'
       }
     };
+
+    // Force a fresh read past the NCRequestManager response cache. Used by
+    // ensureSection so its existence check never decides on a stale page list.
+    if (skipCache) options.skipCache = true;
 
     if (body && (method === 'POST' || method === 'PUT')) {
       options.headers['Content-Type'] = 'application/json';
@@ -235,10 +243,12 @@ class CollectivesClient {
   /**
    * List all pages in a collective
    * @param {number} collectiveId - Collective ID
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Array>} List of pages
    */
-  async listPages(collectiveId) {
-    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`);
+  async listPages(collectiveId, { skipCache = false } = {}) {
+    const data = await this._ocsRequest('GET', `/collectives/${collectiveId}/pages`, null, { skipCache });
     return data?.pages || data || [];
   }
 
@@ -301,8 +311,10 @@ class CollectivesClient {
     this._sectionLocks.set(lockKey, lock);
 
     try {
-      // Re-check after acquiring lock in case a previous run just created it.
-      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId);
+      // Re-check after acquiring the lock in case a previous run just created
+      // it. skipCache: this existence check is the gate that decides whether to
+      // create — a stale page list here is exactly what produces "(2)" sections.
+      const existing = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
       if (existing) {
         this._sectionCache.set(lockKey, existing);
         return existing;
@@ -318,6 +330,39 @@ class CollectivesClient {
       }
 
       const created = await this.createPage(collectiveId, actualParentId, sectionName);
+
+      // Post-creation collision guard. If the existence check still raced a
+      // stale listing, Collectives appends "(N)" to disambiguate. Detect that
+      // suffix, trash the artifact, and return the real section instead —
+      // otherwise the duplicate accumulates on every heartbeat (issue #25).
+      const wanted = (sectionName || '').toLowerCase().trim();
+      const suffixMatch = (created?.title || '').match(/^(.*?)\s*\(\d+\)\s*$/);
+      if (suffixMatch && suffixMatch[1].toLowerCase().trim() === wanted) {
+        const real = await this._findSectionPage(collectiveId, sectionName, parentPageId, { skipCache: true });
+        if (real && real.id !== created.id) {
+          this.logger.warn(
+            `[Collectives] ensureSection collision: requested "${sectionName}", ` +
+            `got "${created.title}". Trashing duplicate and returning existing.`
+          );
+          try {
+            await this.trashPage(collectiveId, created.id);
+          } catch (err) {
+            this.logger.warn(
+              `[Collectives] Failed to trash collision artifact "${created.title}" ` +
+              `(id ${created.id}): ${err.message}`
+            );
+          }
+          this._sectionCache.set(lockKey, real);
+          return real;
+        }
+        // No un-suffixed section to fall back to — keep the suffixed page rather
+        // than lose the section entirely. Log so it is visible for manual cleanup.
+        this.logger.warn(
+          `[Collectives] ensureSection got "${created.title}" for "${sectionName}" ` +
+          'but found no un-suffixed section to fall back to — keeping it.'
+        );
+      }
+
       this._sectionCache.set(lockKey, created);
       return created;
     } finally {
@@ -336,11 +381,14 @@ class CollectivesClient {
    *
    * @param {number} collectiveId - Collective ID
    * @param {string} sectionName  - Target section title
+   * @param {number|null} [parentPageId] - Restrict search to children of this page
+   * @param {Object} [opts]
+   * @param {boolean} [opts.skipCache=false] - Bypass the response cache for a fresh read
    * @returns {Promise<Object|null>} Page object or null if not found
    * @private
    */
-  async _findSectionPage(collectiveId, sectionName, parentPageId = null) {
-    const pages = await this.listPages(collectiveId);
+  async _findSectionPage(collectiveId, sectionName, parentPageId = null, { skipCache = false } = {}) {
+    const pages = await this.listPages(collectiveId, { skipCache });
     const pageList = Array.isArray(pages) ? pages : [];
     const target = (sectionName || '').toLowerCase().trim();
 

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -650,6 +650,108 @@ class DeckClient {
       { title, description: opts.description || '', type: 'plain', order: 0 });
   }
 
+  // ============================================================
+  // GENERIC CARD CRUD (v2 — any board, by explicit IDs)
+  // ============================================================
+  // Mirrors the legacy stackName-based methods (createCard/deleteCard/etc.)
+  // but works against any board the bot user has ACL access to. Used by
+  // conversational deck_* tools when the user names a board other than
+  // the default. See issue #65.
+
+  async getCardById(boardId, stackId, cardId) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    return await this._request('GET',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`);
+  }
+
+  async updateCardById(boardId, stackId, cardId, updates) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    return await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
+      updates);
+  }
+
+  async deleteCardById(boardId, stackId, cardId) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+    await this._request('DELETE',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`);
+    console.log(`[Deck] Card ${cardId} deleted (board=${boardId}, stack=${stackId})`);
+  }
+
+  /**
+   * Move a card to a different stack on the same board.
+   * Uses the internal /deck/cards/${cardId}/reorder endpoint, which is
+   * board-agnostic — only the destination stackId is needed.
+   */
+  async moveCardById(cardId, toStackId, order = 0) {
+    if (!cardId || !toStackId) throw new DeckApiError('cardId and toStackId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/cards/${cardId}/reorder`,
+      { stackId: toStackId, order });
+    console.log(`[Deck] Card ${cardId} moved to stack ${toStackId}`);
+  }
+
+  async assignLabelById(boardId, stackId, cardId, labelId) {
+    if (!boardId || !stackId || !cardId || !labelId) throw new DeckApiError('boardId, stackId, cardId, labelId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/assignLabel`,
+      { labelId });
+  }
+
+  async removeLabelById(boardId, stackId, cardId, labelId) {
+    if (!boardId || !stackId || !cardId || !labelId) throw new DeckApiError('boardId, stackId, cardId, labelId are required');
+    await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/removeLabel`,
+      { labelId });
+  }
+
+  /**
+   * Assign a user to a card on any board. Looks up the user via the board's
+   * member list for case-insensitive matching, mirroring assignUser().
+   * Returns the matched uid on success, null if the user is not a board member.
+   */
+  async assignUserById(boardId, stackId, cardId, userId) {
+    if (!boardId || !stackId || !cardId || !userId) throw new DeckApiError('boardId, stackId, cardId, userId are required');
+    const board = await this._request('GET', `/index.php/apps/deck/api/v1.0/boards/${boardId}`);
+    const members = board.users || [];
+    const match = members.find(u =>
+      u.uid.toLowerCase() === userId.toLowerCase() ||
+      u.primaryKey.toLowerCase() === userId.toLowerCase()
+    );
+    if (!match) return null;
+
+    try {
+      await this._request('PUT',
+        `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/assignUser`,
+        { userId: match.uid });
+      return match.uid;
+    } catch (e) {
+      if (e.message?.includes('already assigned')) return match.uid;
+      throw e;
+    }
+  }
+
+  async unassignUserById(boardId, stackId, cardId, userId) {
+    if (!boardId || !stackId || !cardId || !userId) throw new DeckApiError('boardId, stackId, cardId, userId are required');
+    const board = await this._request('GET', `/index.php/apps/deck/api/v1.0/boards/${boardId}`);
+    const members = board.users || [];
+    const match = members.find(u =>
+      u.uid.toLowerCase() === userId.toLowerCase() ||
+      u.primaryKey.toLowerCase() === userId.toLowerCase()
+    );
+    if (!match) return null;
+
+    try {
+      await this._request('PUT',
+        `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/unassignUser`,
+        { userId: match.uid });
+      return match.uid;
+    } catch (e) {
+      if (e.message?.includes('not assigned')) return match.uid;
+      throw e;
+    }
+  }
+
   /**
    * Ensure the board exists with all required stacks
    * Creates if missing, verifies structure if exists

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -1606,13 +1606,9 @@ Here are the current wiki sections and their entities:
 
 ${sectionLines || '(No sections found yet.)'}
 
-Write the landing page in this format:
+Do NOT include frontmatter (no --- blocks). Write only the markdown body starting with the # heading.
 
----
-type: index
-confidence: high
-decay_days: -1
----
+Write the landing page in this format:
 
 # Moltagent Knowledge
 
@@ -1659,7 +1655,19 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
       context: { trigger: 'wiki_steward_level0', internal: true },
     });
 
-    const landingBody = (routerResult?.result || routerResult?.content || '').trim();
+    let landingBody = (routerResult?.result || routerResult?.content || '').trim();
+
+    // Belt: strip code fences the LLM may wrap around the output despite the prompt
+    landingBody = landingBody
+      .replace(/^```(?:markdown|yaml|md)?\s*\n?/i, '')
+      .replace(/\n?```\s*$/i, '');
+
+    // Belt: strip any frontmatter block the LLM may still emit despite the instruction
+    landingBody = landingBody
+      .replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '');
+
+    landingBody = landingBody.trim();
+
     if (!landingBody) {
       this.logger.warn('[WikiSteward] _updateLandingPage: LLM returned empty body');
       return { clusters: 0 };
@@ -1668,20 +1676,32 @@ Keep Level 0 under 100 lines total so it loads fast for every query.`;
     // Count clusters for the return value
     const clusterMatches = landingBody.match(/^###\s+/gm) || [];
 
-    // Resolve any [[wikilinks]] the LLM emitted into live Nextcloud file links
-    // before writing. writePageContent is raw (no auto-resolve), so we must do
-    // this step explicitly here.
-    const resolvedBody = await this._resolveWikilinks(landingBody);
+    const landingFrontmatter = {
+      type: 'index',
+      confidence: 'high',
+      decay_days: -1,
+      auto_maintained: true,
+      compost: 'never',
+      last_refresh: new Date().toISOString().split('T')[0],
+    };
 
     // Write the landing page — it's the root page of the collective
+    // writePageWithFrontmatter resolves [[wikilinks]] internally; no explicit pre-resolve needed.
     try {
-      // Landing page typically lives at the collective root title
       const landingPageTitle = this.collectivesClient.collectiveName || 'Moltagent Knowledge';
-      await this.collectivesClient.writePageContent(`${landingPageTitle}.md`, resolvedBody);
+      await this.collectivesClient.writePageWithFrontmatter(
+        landingPageTitle,
+        landingFrontmatter,
+        landingBody
+      );
     } catch (err) {
-      // Fallback: try writing as plain path
+      // Fallback: try with the literal known title
       try {
-        await this.collectivesClient.writePageContent('Moltagent Knowledge.md', resolvedBody);
+        await this.collectivesClient.writePageWithFrontmatter(
+          'Moltagent Knowledge',
+          landingFrontmatter,
+          landingBody
+        );
       } catch (err2) {
         this.logger.warn(`[WikiSteward] _updateLandingPage write failed: ${err2.message}`);
         return { clusters: 0 };

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -743,7 +743,18 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
    * @returns {string} Prompt text.
    */
   _connectionAssessmentPrompt(neighborhood) {
-    const pageLinks = neighborhood.pages.map(p =>
+    // Structural guard: section index / navigation pages are not knowledge
+    // entities and must never be link targets. Drop them from the data the LLM
+    // sees so it cannot suggest links to "Documents", "People", etc. Index
+    // pages carry `type: index`; structural pages carry the `compost: never`
+    // pin. The prompt EXCLUSION instruction below is the intelligence-layer
+    // counterpart — belt and suspenders.
+    const contentPages = neighborhood.pages.filter(p => {
+      const fm = p.frontmatter || {};
+      return fm.type !== 'index' && fm.compost !== 'never';
+    });
+
+    const pageLinks = contentPages.map(p =>
       `### ${p.title}\n` +
       `Graph connections: ${p.graphConnections.map(e => `${e.predicate} → ${e.object}`).join(', ') || 'none'}\n` +
       `Wikilinks in content: ${p.wikilinks.join(', ') || 'none'}`
@@ -767,6 +778,12 @@ Near-duplicate (EN): Pages "ManeraMedia GmbH" and "Manera Media GmbH" likely des
 Near-duplicate (DE): Die Seiten "ManeraMedia GmbH" und "Manera Media GmbH" beschreiben wahrscheinlich dieselbe Organisation.
 Near-duplicate (PT): As páginas "ManeraMedia GmbH" e "Manera Media GmbH" provavelmente descrevem a mesma organização.
 ---
+
+EXCLUSION: Do NOT suggest links to section index pages. Pages whose type is "index"
+or whose title matches a top-level section name (Documents, People, Projects,
+Organizations, Research, Procedures, Images, Meta, emails) are structural navigation,
+not knowledge entities. They must never appear in missingLinks or orphan suggestions.
+Only suggest links between actual knowledge entities (people, projects, documents, concepts).
 
 Here are the pages with their graph connections and wikilinks:
 
@@ -1121,8 +1138,15 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
     const body = result.body || '';
 
-    // Idempotency: skip if [[target]] already appears anywhere in the body
+    // Idempotency: skip if the link to `target` already appears in the body,
+    // in EITHER form. writePageWithFrontmatter() runs resolveWikilinks() before
+    // every write, transforming [[target]] into [target](url). On the next
+    // heartbeat read only the resolved form remains — so a check for the
+    // unresolved form alone passes and appends a duplicate every cycle.
+    // Matching `[target](` is structural markdown-link syntax, not natural
+    // language, so it is allowed under the language policy.
     if (body.includes(`[[${target}]]`)) return false;
+    if (body.includes(`[${target}](`)) return false;
 
     // Append a Related section entry
     const relLine = `\n- [[${target}]] (${relationship || 'related'})\n`;
@@ -1260,13 +1284,11 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
     fm.compost_reason = reason || 'Marked by Memory Steward';
     fm.compost_marked_at = new Date().toISOString();
 
-    let body = result.body || '';
-    const markerSignature = 'Archived by Memory Steward';
-    if (!body.includes(markerSignature)) {
-      body = `${body}\n\n---\n_${markerSignature}: ${reason || 'Marked by Memory Steward'}_\n`;
-    }
-
-    await this.collectivesClient.writePageWithFrontmatter(page, fm, body);
+    // Frontmatter carries the compost state. No inline body annotation:
+    // it was redundant with compost_ready/compost_reason/compost_marked_at and
+    // disrupted the Connection Steward's `## Related` section regex by inserting
+    // content between the heading and EOF. The body holds knowledge only.
+    await this.collectivesClient.writePageWithFrontmatter(page, fm, result.body || '');
     this.logger.info(`[WikiSteward:memory] Marked "${page}" for composting: ${reason}`);
     return true;
   }

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -394,6 +394,31 @@ class WikiSteward {
   }
 
   /**
+   * Return the section name for a page, or null if no section can be derived.
+   *
+   * Chain:
+   *   1. page.section (truthy) — returned directly; defensive for future API restores.
+   *   2. page.filePath (non-empty string) — first non-empty segment after split('/').
+   *   3. page.parentId === landingPageId (direct child of landing) — page.title.
+   *   4. null — landing page itself (parentId===0, empty filePath) and orphans.
+   *
+   * @param {{ section?: string, filePath?: string, parentId?: number, title?: string }} page
+   * @param {number|undefined} landingPageId
+   * @returns {string|null}
+   */
+  _getPageSection(page, landingPageId) {
+    if (page.section) return page.section;
+    if (page.filePath) {
+      const parts = page.filePath.split('/').filter(Boolean);
+      return parts[0] || null;
+    }
+    if (landingPageId && page.parentId === landingPageId && page.title) {
+      return page.title;
+    }
+    return null;
+  }
+
+  /**
    * Enumerate clusters known to the system. First attempt: read Level 0
    * landing page and parse its `## Knowledge Domains` `###` headings to get
    * cluster names. Fallback: enumerate unique `section` values from listPages().
@@ -426,14 +451,7 @@ class WikiSteward {
       const landingPageId = landingPage?.id;
       const sectionCounts = new Map();
       for (const page of pageList) {
-        let section = page.section || null;
-        if (!section && page.filePath) {
-          const parts = page.filePath.split('/').filter(Boolean);
-          section = parts[0] || null;
-        }
-        if (!section && landingPageId && page.parentId === landingPageId && page.title) {
-          section = page.title;
-        }
+        const section = this._getPageSection(page, landingPageId);
         if (section) {
           sectionCounts.set(section, (sectionCounts.get(section) || 0) + 1);
         }
@@ -480,24 +498,17 @@ class WikiSteward {
       this.collectiveId = collectiveId;
     }
 
-    // List pages that belong to this cluster by exact section match (structural truth).
-    // Section names come from _listClusters which derives them from real filesystem sections.
+    // List pages that belong to this cluster via _getPageSection (single chokepoint
+    // shared with _listClusters; resilient to Collectives API filePath shape changes).
     let clusterPages = [];
     try {
       const allPages = await this.collectivesClient.listPages(collectiveId);
       const pageList = Array.isArray(allPages) ? allPages : [];
       const clusterName = cluster.name;
 
-      clusterPages = pageList.filter(p => {
-        // Match on explicit section field first
-        if (p.section === clusterName) return true;
-        // Fallback: first path segment of filePath
-        if (!p.section && p.filePath) {
-          const parts = p.filePath.split('/');
-          return parts.length > 1 && parts[0] === clusterName;
-        }
-        return false;
-      });
+      const landingPage = pageList.find(p => p.parentId === 0);
+      const landingPageId = landingPage?.id;
+      clusterPages = pageList.filter(p => this._getPageSection(p, landingPageId) === clusterName);
     } catch (err) {
       this.logger.warn(`[WikiSteward] Failed to list pages for cluster "${cluster.name}": ${err.message}`);
       return neighborhood;

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -890,6 +890,25 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
   // ---------------------------------------------------------------------------
 
   /**
+   * Determine whether a page is structural infrastructure that should not be
+   * modified by steward interventions. Structural pages serve as navigation
+   * scaffolding (section indexes, landing pages, meta pages) — their content
+   * is either auto-maintained by the fractal index refresh or intentionally
+   * minimal. Frontmatter `type: section|index|meta` marks them by role; the
+   * `compost: never` pin marks them by lifecycle policy. Either is sufficient.
+   *
+   * @param {EnrichedPage} page - Page object from neighborhood.pages
+   * @returns {boolean}
+   */
+  _isStructuralPage(page) {
+    if (!page || !page.frontmatter) return false;
+    const t = page.frontmatter.type;
+    if (t === 'section' || t === 'index' || t === 'meta') return true;
+    if (page.frontmatter.compost === 'never') return true;
+    return false;
+  }
+
+  /**
    * Execute the assessment's recommended actions. Each steward type dispatches
    * to a different set of per-action executors (the "farm hand" operations).
    *
@@ -910,9 +929,24 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       return results;
     }
 
+    // Structural pages are infrastructure, not content. Skip all interventions
+    // on them — they are maintained by the fractal index refresh cycle, not by
+    // steward assessments. Defense in depth alongside the prompt-level
+    // exclusion in _connectionAssessmentPrompt and the compost: never pin
+    // honored by _markForComposting.
+    const structuralTitles = new Set(
+      (neighborhood?.pages || [])
+        .filter(p => this._isStructuralPage(p))
+        .map(p => p.title)
+    );
+
     switch (stewardType) {
       case 'knowledge': {
         for (const c of assessment.contradictions || []) {
+          if (structuralTitles.has(c.pageA) || structuralTitles.has(c.pageB)) {
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page in contradiction: "${c.pageA}" / "${c.pageB}"`);
+            continue;
+          }
           try {
             const flagged = await this._flagContradiction(c.pageA, c.pageB, c.claim);
             if (flagged) results.pagesModified += 2;
@@ -921,6 +955,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const s of assessment.stale || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.info(`[WikiSteward:knowledge] Skipping structural page "${s.page}" for staleness`);
+            continue;
+          }
           try {
             const lowered = await this._lowerConfidence(s.page, s.reason);
             if (lowered) results.pagesModified++;
@@ -928,6 +966,9 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             this.logger.warn(`[WikiSteward:knowledge] _lowerConfidence("${s.page}") failed: ${err.message}`);
           }
         }
+        // _logKnowledgeGap writes to Meta/Pending Questions, not to the
+        // referenced page — the gap observation is valid even if the
+        // referencing page is structural. No guard needed here.
         for (const g of assessment.gaps || []) {
           try {
             await this._logKnowledgeGap(g.entity, g.referencedIn);
@@ -941,6 +982,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'connection': {
         for (const m of assessment.missingLinks || []) {
+          if (structuralTitles.has(m.page)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${m.page}" for missing link`);
+            continue;
+          }
           try {
             const added = await this._addWikilink(m.page, m.shouldLinkTo, m.relationship);
             if (added) {
@@ -952,6 +997,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const o of assessment.orphans || []) {
+          if (structuralTitles.has(o.page)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page "${o.page}" for orphan resolution`);
+            continue;
+          }
           for (const target of o.suggestedConnections || []) {
             try {
               const added = await this._addWikilink(o.page, target, 'related');
@@ -965,6 +1014,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const d of assessment.nearDuplicates || []) {
+          if (structuralTitles.has(d.pageA) || structuralTitles.has(d.pageB)) {
+            this.logger.info(`[WikiSteward:connection] Skipping structural page in duplicate check: "${d.pageA}" / "${d.pageB}"`);
+            continue;
+          }
           try {
             await this._flagDuplicate(d.pageA, d.pageB, d.similarity || 0);
           } catch (err) {
@@ -977,6 +1030,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
       case 'memory': {
         for (const s of assessment.strengthen || []) {
+          if (structuralTitles.has(s.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${s.page}" for strengthening`);
+            continue;
+          }
           try {
             const strengthened = await this._strengthenPage(s.page);
             if (strengthened) results.pagesModified++;
@@ -985,6 +1042,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const c of assessment.compost || []) {
+          if (structuralTitles.has(c.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${c.page}" for composting`);
+            continue;
+          }
           try {
             await this._markForComposting(c.page, c.reason);
           } catch (err) {
@@ -992,6 +1053,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
         }
         for (const e of assessment.embed || []) {
+          if (structuralTitles.has(e.page)) {
+            this.logger.info(`[WikiSteward:memory] Skipping structural page "${e.page}" for embedding`);
+            continue;
+          }
           // Find the full pageRef from neighborhood so _embedPage has path/section
           const pageRef = neighborhood.pages.find(p => p.title === e.page) || { id: null, title: e.page };
           try {

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -657,8 +657,8 @@ class MessageProcessor {
         // Smart-mix: three-path routing (local text / local tools / cloud)
         // Build live context ONCE — passed to classifier, probes, synthesis, guard
         const liveContext = earlyLiveContext || (session ? buildLiveContext(session, pipelineMessage) : null);
-        const { useLocal, useDomainTools, intent, compound } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
-        console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}`);
+        const { useLocal, useDomainTools, intent, compound, gate } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
+        console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}${gate ? ` (gate=${gate})` : ''}`);
 
         // Intent-specific feedback: acknowledge the user immediately (fire-and-forget)
         const lang = this._getLanguage();
@@ -678,6 +678,7 @@ class MessageProcessor {
             messageId: extracted.messageId,
             inputType: extracted._isVoice ? 'voice' : 'text',
             user: extracted.user,
+            gate,
             systemSuffix: focusContext ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext) : flushPrompt,
             onArtifact
           });
@@ -743,6 +744,7 @@ class MessageProcessor {
                 messageId: extracted.messageId,
                 inputType: extracted._isVoice ? 'voice' : 'text',
                 user: extracted.user,
+                gate,
                 systemSuffix: focusContext || undefined,
                 onArtifact
               });
@@ -786,6 +788,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -817,6 +820,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -859,6 +863,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext
                 ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext)
                 : flushPrompt,
@@ -902,6 +907,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -930,6 +936,7 @@ class MessageProcessor {
               messageId: extracted.messageId,
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
+              gate,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -966,7 +973,8 @@ class MessageProcessor {
             messageId: extracted.messageId,
             inputType: extracted._isVoice ? 'voice' : 'text',
             voiceReplyEnabled,
-            user: extracted.user
+            user: extracted.user,
+            gate
           };
 
           // Bug 3 fix: Short confirmations shouldn't loop to max iterations
@@ -1746,7 +1754,7 @@ class MessageProcessor {
         }
       }
 
-      let { intent, domain, compound } = classification;
+      let { gate, intent, domain, compound } = classification;
 
       // Trust boundary: in smart-mix mode (cloud available), everything goes
       // through cloud except knowledge (dedicated probe pipeline) and compound
@@ -1754,24 +1762,24 @@ class MessageProcessor {
 
       // Confirmation/selection → cloud (needs full history)
       if (intent === 'confirmation' || intent === 'selection') {
-        return { useLocal: false, useDomainTools: false, intent, compound: false };
+        return { useLocal: false, useDomainTools: false, intent, compound: false, gate };
       }
       if (intent === 'confirmation_declined') {
-        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false };
+        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate };
       }
       // Knowledge → dedicated handler (probes, deep reads, web fallback, synthesis)
       if (intent === 'knowledge') {
-        return { useLocal: true, useDomainTools: true, intent, compound: !!compound };
+        return { useLocal: true, useDomainTools: true, intent, compound: !!compound, gate };
       }
       // Compound + domain → compound handler (already cloud-powered)
       if (compound && DOMAIN_INTENTS.has(intent)) {
-        return { useLocal: true, useDomainTools: true, intent, compound: true };
+        return { useLocal: true, useDomainTools: true, intent, compound: true, gate };
       }
       // Everything else → cloud via AgentLoop (Haiku, full tools, web search)
-      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound };
+      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate };
     } catch (err) {
       console.warn(`[Message] Smart-mix classification failed: ${err.message}`);
-      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false };
+      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false, gate: null };
     }
   }
 

--- a/src/lib/workflows/schedule-handler.js
+++ b/src/lib/workflows/schedule-handler.js
@@ -49,6 +49,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const DeckClient = require('../integrations/deck-client');
 
 // ─── HTML normalisation ──────────────────────────────────────────────
 
@@ -296,8 +297,27 @@ class ScheduleHandler {
     console.log(`[Schedule] Parsed ${schedules.length} schedule(s) from "${wb.board.title}"`);
     if (schedules.length === 0) return result;
 
+    // PAUSED chokepoint (#28, same generator as #13/#17/#22): if any stack
+    // on this board has a CONFIG card with the PAUSED label, no schedule
+    // on the board fires. The structural guard at DeckClient.createCardOnBoard
+    // would catch the writes, but the schedule's LLM agent loop runs to
+    // completion first — burning cloud spend and pulse time before the
+    // result gets thrown away. Guard at the firing point.
+    const pausedStacks = (wb.stacks || []).filter(s => DeckClient.stackHasPausedConfig(s));
+    for (const stack of pausedStacks) {
+      console.log(`[Workflow] Stack "${stack.title}" skipped for schedules — CONFIG card has PAUSED label`);
+    }
+
     for (const schedule of schedules) {
       try {
+        if (pausedStacks.length > 0) {
+          for (const ps of pausedStacks) {
+            console.log(`[Schedule] Skipping schedule on PAUSED stack: "${schedule.action}" (board=${wb.board.id}, stack=${ps.id})`);
+          }
+          result.skipped++;
+          continue;
+        }
+
         if (!this._isDue(wb.board.id, schedule)) {
           result.skipped++;
           continue;

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -278,26 +278,14 @@ class WorkflowEngine {
       }
     }
 
-    // Process SCHEDULE block from board rules (timed actions)
+    // Process SCHEDULE block from board rules (timed actions).
+    // PAUSED-stack handling lives inside ScheduleHandler.processSchedules
+    // (#28): if any stack on this board has a PAUSED CONFIG card, every
+    // schedule on the board is skipped before its LLM agent loop fires.
     try {
-      // Filter out PAUSED stacks so schedules cannot target them.
-      // The schedule handler builds LLM context from wb.stacks — if a stack
-      // is absent, the LLM cannot see it, reference it, or create cards in it.
-      const pausedStackNames = [];
-      const activeStacks = stacks.filter(stack => {
-        if (DeckClient.stackHasPausedConfig(stack)) {
-          console.log(`[Workflow] Stack "${stack.title}" skipped for schedules — CONFIG card has PAUSED label`);
-          pausedStackNames.push(stack.title);
-          return false;
-        }
-        return true;
-      });
-      const schedWb = activeStacks.length < stacks.length
-        ? { ...wb, stacks: activeStacks, _pausedStacks: pausedStackNames }
-        : wb;
       // Respect board-level MODEL directive for schedule actions
       const boardForceLocal = this._getBoardForceLocal(wb);
-      const schedResult = await this._scheduleHandler.processSchedules(schedWb, { forceLocal: boardForceLocal });
+      const schedResult = await this._scheduleHandler.processSchedules(wb, { forceLocal: boardForceLocal });
       result.schedulesExecuted = schedResult.executed;
       if (schedResult.executed > 0) {
         console.log(`[Workflow] Schedules on "${board.title}": ${schedResult.executed} executed, ${schedResult.skipped} skipped`);

--- a/test/manual/knowledge-pipeline-tests.sh
+++ b/test/manual/knowledge-pipeline-tests.sh
@@ -2,8 +2,17 @@
 # Knowledge Pipeline Test Suite — 5 probes to diagnose knowledge quality
 # Sends signed webhook requests to localhost:3000 and captures pipeline logs
 
+set -euo pipefail
+
 SECRET="7d02a6d8a79d17636424b73013900ed6ad8054a610843a905ae2b42a8834023039e256db2204056680c9bf438f821eb27dc6eabc875c6768c5ee7754bda51aaf"
-BACKEND="https://YOUR_NEXTCLOUD_URL"
+if [ -z "${NC_URL:-}" ]; then
+    echo "ERROR: NC_URL is not set." >&2
+    echo "       Export the Nextcloud base URL this test should target," >&2
+    echo "       e.g.  NC_URL=https://nc.example.com ./test/manual/knowledge-pipeline-tests.sh" >&2
+    echo "       It must match an entry in the webhook server's allowedBackends." >&2
+    exit 1
+fi
+BACKEND="$NC_URL"
 ROOM="strte9d4"
 PORT=3000
 LOG_DIR="/tmp/knowledge-tests-$(date +%Y%m%d-%H%M%S)"

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1419,6 +1419,149 @@ asyncTest('system prompt defaults to UTC timezone', async () => {
 });
 
 // ============================================================
+// Action-hallucination guard (issue surfaced during PR #66 verification)
+// ============================================================
+
+asyncTest('action-hallucination guard: text-only response with gate=action triggers re-prompt then tool call', async () => {
+  // Iteration 1: LLM hallucinates success in text only.
+  // Iteration 2: After guard's re-prompt, LLM calls the tool.
+  // Iteration 3: LLM produces final text after tool result.
+  const provider = createMockProvider([
+    { content: '✅ Deleted both cards', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_delete_card', arguments: { card: '#42' } }] },
+    { content: 'Deleted card #42.', toolCalls: null }
+  ]);
+
+  let executedTool = null;
+  const registry = createMockToolRegistry({
+    deck_delete_card: async (args) => { executedTool = args; return { success: true, result: 'Deleted #42' }; }
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete card 42', 'room-abc', { gate: 'action' });
+  assert.deepStrictEqual(executedTool, { card: '#42' });
+  assert.strictEqual(response, 'Deleted card #42.');
+});
+
+asyncTest('action-hallucination guard fires at most once per turn (legitimate text-only refusal accepted)', async () => {
+  // Iteration 1: LLM responds text-only (claims failure).
+  // Iteration 2: After re-prompt, LLM still text-only (legitimate explanation).
+  //              Guard must NOT fire again — second text is the final answer.
+  const provider = createMockProvider([
+    { content: 'OK, I deleted it.', toolCalls: null },
+    { content: 'I cannot delete it — the board does not exist.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete card 42 on Imaginary board', 'room-abc', { gate: 'action' });
+  assert.strictEqual(response, 'I cannot delete it — the board does not exist.');
+  assert.strictEqual(provider._getCallCount(), 2);  // exactly 2 LLM calls, no infinite loop
+});
+
+asyncTest('action-hallucination guard bumps maxIter when capped at 2 (short-message heuristic case)', async () => {
+  // Simulates "delete both" — short message, message-processor sets maxIterations=2.
+  // Without the bump, the re-prompt would consume iteration 2 but the loop exits
+  // before the LLM can act. With the bump, the LLM gets one more shot.
+  const provider = createMockProvider([
+    { content: '✅ Done', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'call_x', name: 'deck_delete_card', arguments: { card: '#1' } }] },
+    { content: 'Done.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_delete_card: async () => ({ success: true, result: 'ok' })
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete both', 'room-abc', { gate: 'action', maxIterations: 2 });
+  assert.strictEqual(response, 'Done.');
+  assert.strictEqual(provider._getCallCount(), 3);
+});
+
+asyncTest('action-hallucination guard does NOT fire for gate=knowledge', async () => {
+  // Knowledge responses are legitimately text-only — guard must not interfere.
+  const provider = createMockProvider([
+    { content: 'The wiki says X.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('what is X?', 'room-abc', { gate: 'knowledge' });
+  assert.strictEqual(response, 'The wiki says X.');
+  assert.strictEqual(provider._getCallCount(), 1);
+});
+
+asyncTest('action-hallucination guard does NOT fire when gate option is omitted (proactive/internal triggers)', async () => {
+  // ProactiveEvaluator and DeferralQueue call process() without a gate.
+  // Guard must not fire — there's no classifier signal to act on.
+  const provider = createMockProvider([
+    { content: 'Acknowledged.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('internal prompt', 'room-abc');
+  assert.strictEqual(response, 'Acknowledged.');
+  assert.strictEqual(provider._getCallCount(), 1);
+});
+
+asyncTest('action-hallucination guard does NOT fire when LLM calls a tool on iteration 1 (normal action flow)', async () => {
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_create_card', arguments: { title: 'T' } }] },
+    { content: 'Card created.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_create_card: async () => ({ success: true, result: 'created' })
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('create card T', 'room-abc', { gate: 'action' });
+  assert.strictEqual(response, 'Card created.');
+  assert.strictEqual(provider._getCallCount(), 2);  // no re-prompt needed
+});
+
+// ============================================================
 // Cleanup & Summary
 // ============================================================
 

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -1191,6 +1191,429 @@ asyncTest('deck_share_board with group type', async () => {
 });
 
 // ============================================================
+// Tests - Board-aware card-mutation tools (issue #65)
+// ============================================================
+
+function createSharedBoardDeckClient(opts = {}) {
+  // A mock that simulates a shared "Content Pipeline" board (id 7) with
+  // realistic stack/card data, alongside the bot's own task board (id 1).
+  // Used to verify the foreign-board branch of card-mutation tools.
+  const sharedStacks = opts.sharedStacks || [
+    { id: 701, title: 'Inbox', cards: [
+      { id: 200, title: 'Draft outline', duedate: null, owner: { uid: 'jordan' }, type: 'plain' }
+    ]},
+    { id: 702, title: 'Working', cards: [
+      { id: 201, title: 'Editing pass', duedate: null, owner: { uid: 'jordan' }, type: 'plain' }
+    ]},
+    { id: 703, title: 'Done', cards: [] }
+  ];
+  const sharedLabels = opts.sharedLabels || [
+    { id: 1001, title: 'urgent' },
+    { id: 1002, title: 'blocked' }
+  ];
+
+  const calls = {};
+
+  return {
+    baseUrl: 'https://nc.example.com',
+    username: 'moltagent',
+    stackNames: {
+      inbox: 'Inbox', queued: 'Queued', working: 'Working',
+      review: 'Review', done: 'Done', reference: 'Reference'
+    },
+    _calls: calls,
+    getAllCards: async () => ({}),
+    listBoards: async () => [
+      { id: 1, title: DECK.boards.tasks, owner: { uid: 'moltagent' } },
+      { id: 7, title: 'Content Pipeline', owner: { uid: 'jordan' } }
+    ],
+    getBoard: async (boardId) => ({
+      id: boardId,
+      title: boardId === 7 ? 'Content Pipeline' : DECK.boards.tasks,
+      owner: { uid: boardId === 7 ? 'jordan' : 'moltagent' },
+      stacks: sharedStacks,
+      labels: sharedLabels,
+      users: [
+        { uid: 'alice', primaryKey: 'alice' },
+        { uid: 'jordan', primaryKey: 'jordan' },
+        { uid: 'moltagent', primaryKey: 'moltagent' }
+      ]
+    }),
+    getStacks: async (_boardId) => sharedStacks,
+    getCardById: async (boardId, stackId, cardId) => {
+      calls.getCardById = { boardId, stackId, cardId };
+      const stack = sharedStacks.find(s => s.id === stackId);
+      const card = stack?.cards.find(c => c.id === cardId);
+      return card
+        ? { ...card, description: 'shared-card desc', assignedUsers: [], labels: [] }
+        : null;
+    },
+    updateCardById: async (boardId, stackId, cardId, updates) => {
+      calls.updateCardById = { boardId, stackId, cardId, updates };
+    },
+    deleteCardById: async (boardId, stackId, cardId) => {
+      calls.deleteCardById = { boardId, stackId, cardId };
+    },
+    moveCardById: async (cardId, toStackId, order) => {
+      calls.moveCardById = { cardId, toStackId, order };
+    },
+    assignLabelById: async (boardId, stackId, cardId, labelId) => {
+      calls.assignLabelById = { boardId, stackId, cardId, labelId };
+    },
+    removeLabelById: async (boardId, stackId, cardId, labelId) => {
+      calls.removeLabelById = { boardId, stackId, cardId, labelId };
+    },
+    assignUserById: async (boardId, stackId, cardId, userId) => {
+      calls.assignUserById = { boardId, stackId, cardId, userId };
+      return userId;
+    },
+    unassignUserById: async (boardId, stackId, cardId, userId) => {
+      calls.unassignUserById = { boardId, stackId, cardId, userId };
+      return userId;
+    },
+    addComment: async (cardId, message, type, optsArg) => {
+      calls.addComment = { cardId, message, type, opts: optsArg };
+    },
+    getComments: async (cardId) => {
+      calls.getComments = { cardId };
+      return [{ actorId: 'jordan', message: 'looks good', creationDateTime: '2026-05-26T10:00:00Z' }];
+    },
+    // Default-board legacy methods that should NOT be touched on foreign path:
+    getCard: async () => { throw new Error('default-board getCard called for shared-board test'); },
+    updateCard: async () => { throw new Error('default-board updateCard called for shared-board test'); },
+    deleteCard: async () => { throw new Error('default-board deleteCard called for shared-board test'); },
+    moveCard: async () => { throw new Error('default-board moveCard called for shared-board test'); },
+    addLabel: async () => { throw new Error('default-board addLabel called for shared-board test'); },
+    removeLabel: async () => { throw new Error('default-board removeLabel called for shared-board test'); },
+    assignUser: async () => { throw new Error('default-board assignUser called for shared-board test'); },
+    unassignUser: async () => { throw new Error('default-board unassignUser called for shared-board test'); }
+  };
+}
+
+asyncTest('deck_delete_card on shared board routes through deleteCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.deleteCardById, { boardId: 7, stackId: 701, cardId: 200 });
+  assert.ok(result.result.includes('Deleted card #200'));
+  assert.ok(result.result.includes('Inbox'));
+});
+
+asyncTest('deck_mark_done on shared board moves to Done stack via moveCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_mark_done', {
+    card: 'Editing pass',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.moveCardById, { cardId: 201, toStackId: 703, order: 0 });
+  assert.ok(result.result.includes('Marked card #201'));
+  assert.ok(result.result.includes('Done'));
+});
+
+asyncTest('deck_mark_done on shared board without Done stack returns clear error', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'No Done stack here' }] },
+      { id: 702, title: 'In Review', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_mark_done', {
+    card: 'No Done',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.moveCardById, undefined);
+  assert.ok(result.result.includes('No "Done" stack'));
+  assert.ok(result.result.includes('deck_move_card'));
+});
+
+asyncTest('deck_get_card on shared board uses getCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_get_card', {
+    card: '#200',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.getCardById, { boardId: 7, stackId: 701, cardId: 200 });
+  assert.ok(result.result.includes('Card #200'));
+  assert.ok(result.result.includes('shared-card desc'));
+});
+
+asyncTest('deck_update_card on shared board uses updateCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_update_card', {
+    card: 'Draft outline',
+    title: 'Draft outline (v2)',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.updateCardById.boardId, 7);
+  assert.strictEqual(deck._calls.updateCardById.stackId, 701);
+  assert.strictEqual(deck._calls.updateCardById.cardId, 200);
+  assert.strictEqual(deck._calls.updateCardById.updates.title, 'Draft outline (v2)');
+});
+
+asyncTest('deck_move_card on shared board uses moveCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_move_card', {
+    card: 'Draft outline',
+    target_stack: 'Working',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.moveCardById, { cardId: 200, toStackId: 702, order: 0 });
+  assert.ok(result.result.includes('Moved'));
+});
+
+asyncTest('deck_move_card on shared board reports unknown target_stack', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_move_card', {
+    card: 'Draft outline',
+    target_stack: 'Backlog',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.moveCardById, undefined);
+  assert.ok(result.result.includes('No stack "Backlog"'));
+  assert.ok(result.result.includes('"Inbox"'));
+});
+
+asyncTest('deck_assign_user on shared board uses assignUserById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_assign_user', {
+    card: 'Draft outline',
+    user: 'alice',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignUserById.boardId, 7);
+  assert.strictEqual(deck._calls.assignUserById.userId, 'alice');
+  assert.ok(result.result.includes('Assigned'));
+});
+
+asyncTest('deck_unassign_user on shared board uses unassignUserById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_unassign_user', {
+    card: 'Draft outline',
+    user: 'alice',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.unassignUserById.boardId, 7);
+  assert.strictEqual(deck._calls.unassignUserById.userId, 'alice');
+});
+
+asyncTest('deck_set_due_date on shared board uses updateCardById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_set_due_date', {
+    card: 'Draft outline',
+    duedate: '2026-06-01',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.updateCardById.updates.duedate, '2026-06-01');
+  assert.ok(result.result.includes('2026-06-01'));
+});
+
+asyncTest('deck_add_label on shared board resolves label and uses assignLabelById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_label', {
+    card: 'Draft outline',
+    label: 'urgent',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignLabelById.boardId, 7);
+  assert.strictEqual(deck._calls.assignLabelById.labelId, 1001);
+  assert.ok(result.result.includes('Added label "urgent"'));
+});
+
+asyncTest('deck_add_label on shared board reports unknown label with available list', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_label', {
+    card: 'Draft outline',
+    label: 'critical',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.assignLabelById, undefined);
+  assert.ok(result.result.includes('No label "critical"'));
+  assert.ok(result.result.includes('"urgent"'));
+});
+
+asyncTest('deck_remove_label on shared board uses removeLabelById', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_remove_label', {
+    card: 'Draft outline',
+    label: 'urgent',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.removeLabelById.labelId, 1001);
+});
+
+asyncTest('deck_add_comment on shared board calls board-agnostic addComment', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_add_comment', {
+    card: 'Draft outline',
+    message: 'first review pass complete',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.addComment.cardId, 200);
+  assert.strictEqual(deck._calls.addComment.message, 'first review pass complete');
+});
+
+asyncTest('deck_list_comments on shared board reads via card ID', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_list_comments', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.getComments.cardId, 200);
+  assert.ok(result.result.includes('looks good'));
+});
+
+asyncTest('board not found returns no_board error', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'whatever',
+    board: 'NonExistent'
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('No board found'));
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+});
+
+asyncTest('card not found on shared board cites board title', async () => {
+  const deck = createSharedBoardDeckClient();
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'ghost card',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('No card found matching "ghost card"'));
+  assert.ok(result.result.includes('Content Pipeline'));
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+});
+
+asyncTest('ambiguous card title on shared board returns candidate list without mutating', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'Draft outline A' }] },
+      { id: 702, title: 'Working', cards: [{ id: 201, title: 'Draft outline B' }] },
+      { id: 703, title: 'Done', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: 'Draft outline',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(deck._calls.deleteCardById, undefined);
+  assert.ok(result.result.includes('Multiple cards'));
+  assert.ok(result.result.includes('#200'));
+  assert.ok(result.result.includes('#201'));
+  assert.ok(result.result.includes('Draft outline A'));
+  assert.ok(result.result.includes('Draft outline B'));
+});
+
+asyncTest('ambiguous card title resolved via #ID picks the exact card', async () => {
+  const deck = createSharedBoardDeckClient({
+    sharedStacks: [
+      { id: 701, title: 'Inbox', cards: [{ id: 200, title: 'Draft outline A' }] },
+      { id: 702, title: 'Working', cards: [{ id: 201, title: 'Draft outline B' }] },
+      { id: 703, title: 'Done', cards: [] }
+    ]
+  });
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+
+  const result = await registry.execute('deck_delete_card', {
+    card: '#201',
+    board: 'Content Pipeline'
+  });
+
+  assert.ok(result.success);
+  assert.deepStrictEqual(deck._calls.deleteCardById, { boardId: 7, stackId: 702, cardId: 201 });
+});
+
+asyncTest('omitting board parameter still routes to default-board legacy methods', async () => {
+  // Regression guard: tool calls without `board` must hit the legacy mock
+  // surface — guarantees backward compatibility for callers that never pass board.
+  let touchedDefault = false;
+  const deck = createMockDeckClient({ working: [{ id: 5, title: 'Default-board task' }] });
+  deck.moveCard = async () => { touchedDefault = true; };
+
+  const registry = new ToolRegistry({ deckClient: deck, logger: silentLogger });
+  const result = await registry.execute('deck_move_card', {
+    card: 'Default-board task',
+    target_stack: 'Done'
+  });
+
+  assert.ok(result.success);
+  assert.ok(touchedDefault, 'Legacy moveCard should have been called on the default board');
+});
+
+// ============================================================
 // Tests - 403 Permission Error Handling
 // ============================================================
 

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -48,8 +48,14 @@ function loadConfigWithEnv(envOverrides = {}) {
     }
   }
 
+  // NC_URL is required by config.js; supply a test default unless the
+  // caller explicitly overrides it (including to '').
+  const envWithDefaults = Object.prototype.hasOwnProperty.call(envOverrides, 'NC_URL')
+    ? envOverrides
+    : { NC_URL: 'https://test.example.com', ...envOverrides };
+
   // Apply overrides
-  Object.assign(process.env, envOverrides);
+  Object.assign(process.env, envWithDefaults);
 
   // Clear require cache and reload
   delete require.cache[require.resolve('../../src/lib/config')];
@@ -64,10 +70,31 @@ console.log('\n=== Config Module Tests ===\n');
 
 // --- Default Values ---
 
-test('TC-CFG-001: Default nextcloud.url is set', () => {
-  const config = loadConfigWithEnv({});
-  assert.strictEqual(typeof config.nextcloud.url, 'string');
-  assert.ok(config.nextcloud.url.startsWith('https://'));
+test('TC-CFG-001: Missing NC_URL throws on config load', () => {
+  // Drop NC_URL out of env (loadConfigWithEnv would otherwise supply a test default).
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must refuse to load when NC_URL is not set'
+  );
+});
+
+test('TC-CFG-001a: Empty NC_URL throws on config load', () => {
+  const envOverrides = { NC_URL: '' };
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('NC_')) delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+  delete require.cache[require.resolve('../../src/lib/config')];
+  assert.throws(
+    () => require('../../src/lib/config'),
+    /NC_URL/,
+    'config.js must reject NC_URL=""'
+  );
 });
 
 test('TC-CFG-002: Default nextcloud.username is moltagent', () => {

--- a/test/unit/integrations/collectives-client.test.js
+++ b/test/unit/integrations/collectives-client.test.js
@@ -487,6 +487,71 @@ asyncTest('writePageWithFrontmatter resolves wikilinks before writing', async ()
   assert.ok(!writtenContent.includes('[['), 'Should not contain raw wikilinks');
 });
 
+// -- ensureSection — collision dedup (Fix D) --
+
+const silentLogger = { warn() {}, info() {}, error() {}, debug() {} };
+
+asyncTest('ensureSection returns the existing section without creating', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createCalls = 0;
+  client.createPage = async () => { createCalls++; return { id: 999, title: 'WRONG' }; };
+  client.listPages = async () => ([
+    { id: 1, title: 'Landing page', parentId: 0 },
+    { id: 2, title: 'Documents', parentId: 1 },
+  ]);
+
+  const result = await client.ensureSection(10, 'Documents');
+  assert.strictEqual(result.id, 2, 'should return the existing Documents section');
+  assert.strictEqual(createCalls, 0, 'createPage must not be called when the section exists');
+});
+
+asyncTest('ensureSection creates the section when it does not exist', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  let createArgs = null;
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async (cid, parentId, title) => {
+    createArgs = { cid, parentId, title };
+    return { id: 50, title, parentId };
+  };
+
+  const result = await client.ensureSection(10, 'Research');
+  assert.strictEqual(result.id, 50, 'should return the newly created section');
+  assert.deepStrictEqual(createArgs, { cid: 10, parentId: 1, title: 'Research' });
+});
+
+asyncTest('ensureSection detects a (N) collision and trashes the artifact', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  let listCalls = 0;
+  // The pre-create check races a stale list (no Documents). After createPage
+  // collides, the fresh skipCache re-find sees the real Documents section.
+  client.listPages = async () => {
+    listCalls++;
+    const pages = [{ id: 1, title: 'Landing page', parentId: 0 }];
+    if (listCalls >= 2) pages.push({ id: 7, title: 'Documents', parentId: 1 });
+    return pages;
+  };
+  client.createPage = async () => ({ id: 99, title: 'Documents (2)', parentId: 1 });
+  let trashedId = null;
+  client.trashPage = async (cid, pid) => { trashedId = pid; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashedId, 99, 'the (2) collision artifact should be trashed');
+  assert.strictEqual(result.id, 7, 'should return the real Documents section, not the artifact');
+});
+
+asyncTest('ensureSection keeps the suffixed page when no real section can be found', async () => {
+  const client = new CollectivesClient(createCollectivesMockNC(), { logger: silentLogger });
+  // Both the pre-check and the post-collision re-find see no un-suffixed section.
+  client.listPages = async () => ([{ id: 1, title: 'Landing page', parentId: 0 }]);
+  client.createPage = async () => ({ id: 88, title: 'Documents (2)', parentId: 1 });
+  let trashed = false;
+  client.trashPage = async () => { trashed = true; };
+
+  const result = await client.ensureSection(10, 'Documents', 1);
+  assert.strictEqual(trashed, false, 'must not trash when there is no section to fall back to');
+  assert.strictEqual(result.id, 88, 'should keep the suffixed page rather than lose the section');
+});
+
 // ============================================================
 // Summary
 // ============================================================

--- a/test/unit/integrations/deck-client-v2.test.js
+++ b/test/unit/integrations/deck-client-v2.test.js
@@ -418,4 +418,156 @@ asyncTest('TC-ERR-003: 500 response from updateStack propagates as error', async
   );
 });
 
+// ============================================================
+// --- ID-based card mutation methods (issue #65) ---
+// ============================================================
+console.log('\n--- *ById card mutation methods ---\n');
+
+asyncTest('TC-GCB-001: getCardById sends GET to /boards/{b}/stacks/{s}/cards/{c}', async () => {
+  const fixture = { id: 200, title: 'Shared card' };
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: fixture, headers: {} }
+  });
+
+  const result = await client.getCardById(7, 701, 200);
+  assert.strictEqual(result.id, 200);
+});
+
+asyncTest('TC-GCB-002: getCardById without required IDs throws', async () => {
+  const { client } = makeClient();
+  await assert.rejects(() => client.getCardById(null, 701, 200), (err) => err.message.includes('required'));
+});
+
+asyncTest('TC-UCB-001: updateCardById sends PUT with updates body', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: { id: 200 }, headers: {} }
+  });
+
+  await client.updateCardById(7, 701, 200, { title: 'Renamed', duedate: '2026-06-01' });
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/cards/200'));
+  assert.ok(call);
+  assert.strictEqual(call.body.title, 'Renamed');
+  assert.strictEqual(call.body.duedate, '2026-06-01');
+});
+
+asyncTest('TC-DCB-001: deleteCardById sends DELETE to correct endpoint', async () => {
+  const { client, nc } = makeClient({
+    'DELETE:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.deleteCardById(7, 701, 200);
+  const call = nc._calls.find(c => c.method === 'DELETE' && c.path.endsWith('/cards/200'));
+  assert.ok(call);
+});
+
+asyncTest('TC-DCB-002: deleteCardById without cardId throws', async () => {
+  const { client } = makeClient();
+  await assert.rejects(() => client.deleteCardById(7, 701, null), (err) => err.message.includes('required'));
+});
+
+asyncTest('TC-MCB-001: moveCardById PUTs to internal reorder endpoint with destination stackId', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/cards/200/reorder': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.moveCardById(200, 703, 0);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path === '/index.php/apps/deck/cards/200/reorder');
+  assert.ok(call);
+  assert.strictEqual(call.body.stackId, 703);
+  assert.strictEqual(call.body.order, 0);
+});
+
+asyncTest('TC-MCB-002: moveCardById defaults order to 0 when omitted', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/cards/200/reorder': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.moveCardById(200, 703);
+  const call = nc._calls.find(c => c.method === 'PUT');
+  assert.strictEqual(call.body.order, 0);
+});
+
+asyncTest('TC-ALB-001: assignLabelById PUTs labelId to assignLabel endpoint', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignLabel': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.assignLabelById(7, 701, 200, 1001);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/assignLabel'));
+  assert.ok(call);
+  assert.strictEqual(call.body.labelId, 1001);
+});
+
+asyncTest('TC-RLB-001: removeLabelById PUTs labelId to removeLabel endpoint', async () => {
+  const { client, nc } = makeClient({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/removeLabel': { status: 200, body: {}, headers: {} }
+  });
+
+  await client.removeLabelById(7, 701, 200, 1001);
+  const call = nc._calls.find(c => c.method === 'PUT' && c.path.endsWith('/removeLabel'));
+  assert.ok(call);
+});
+
+asyncTest('TC-AUB-001: assignUserById looks up case-insensitive uid and assigns', async () => {
+  const { client, nc } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'Alice', primaryKey: 'Alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignUser': { status: 200, body: {}, headers: {} }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'Alice');
+  const assignCall = nc._calls.find(c => c.path.endsWith('/assignUser'));
+  assert.ok(assignCall);
+  assert.strictEqual(assignCall.body.userId, 'Alice');
+});
+
+asyncTest('TC-AUB-002: assignUserById returns null when user not a board member', async () => {
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'jordan', primaryKey: 'jordan' }] },
+      headers: {}
+    }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'stranger');
+  assert.strictEqual(matched, null);
+});
+
+asyncTest('TC-AUB-003: assignUserById swallows "already assigned" and returns uid', async () => {
+  const { client } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'alice', primaryKey: 'alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/assignUser': {
+      status: 400, body: { message: 'User already assigned' }, headers: {}
+    }
+  });
+
+  const matched = await client.assignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'alice');
+});
+
+asyncTest('TC-UUB-001: unassignUserById PUTs to unassignUser endpoint', async () => {
+  const { client, nc } = makeClient({
+    'GET:/index.php/apps/deck/api/v1.0/boards/7': {
+      status: 200,
+      body: { id: 7, users: [{ uid: 'alice', primaryKey: 'alice' }] },
+      headers: {}
+    },
+    'PUT:/index.php/apps/deck/api/v1.0/boards/7/stacks/701/cards/200/unassignUser': { status: 200, body: {}, headers: {} }
+  });
+
+  const matched = await client.unassignUserById(7, 701, 200, 'alice');
+  assert.strictEqual(matched, 'alice');
+  const call = nc._calls.find(c => c.path.endsWith('/unassignUser'));
+  assert.ok(call);
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/integrations/talk-multi-room.test.js
+++ b/test/unit/integrations/talk-multi-room.test.js
@@ -14,6 +14,10 @@
  * Run: node test/unit/integrations/talk-multi-room.test.js
  */
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 const assert = require('assert');
 
 let testsPassed = 0;

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -262,6 +262,85 @@ asyncTest('_readNeighborhood() skips pages that throw at the outer level and con
 });
 
 // ---------------------------------------------------------------------------
+// CLUSTER SECTION DERIVATION (#51 — _getPageSection + _readNeighborhood with
+// current Collectives API filePath shape)
+// ---------------------------------------------------------------------------
+
+test('_getPageSection returns section from folder-only filePath (current API shape)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ filePath: 'Documents', section: undefined, parentId: 1 }, 99);
+  assert.strictEqual(section, 'Documents');
+});
+
+test('_getPageSection honors explicit page.section when present (defensive)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection({ section: 'People', filePath: '', parentId: 1 }, 99);
+  assert.strictEqual(section, 'People');
+});
+
+test('_getPageSection falls back to title when page is direct child of landing', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 99, title: 'Research' },
+    99
+  );
+  assert.strictEqual(section, 'Research');
+});
+
+test('_getPageSection returns null for the landing page itself', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const section = steward._getPageSection(
+    { filePath: '', section: undefined, parentId: 0, title: 'Knowledge Domains' },
+    99
+  );
+  assert.strictEqual(section, null);
+});
+
+asyncTest('_readNeighborhood() populates pages when filePath is folder-only (current API shape)', async () => {
+  // Mimics what listPages actually returns post-API-change:
+  //   section: undefined, filePath: "Documents" (no slash, no page name).
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One': { frontmatter: { type: 'reference' }, body: 'first doc', path: 'Documents/Doc One.md' },
+      'Doc Two': { frontmatter: { type: 'reference' }, body: 'second doc', path: 'Documents/Doc Two.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 11, title: 'Doc Two',           section: undefined, filePath: 'Documents', parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.cluster, 'Documents');
+  assert.strictEqual(neighborhood.pages.length, 2, 'should include both Documents pages');
+  const titles = neighborhood.pages.map(p => p.title).sort();
+  assert.deepStrictEqual(titles, ['Doc One', 'Doc Two']);
+});
+
+asyncTest('_readNeighborhood() excludes pages belonging to other clusters', async () => {
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: {
+      'Doc One':  { frontmatter: {}, body: 'doc', path: 'Documents/Doc One.md' },
+      'Carlos':   { frontmatter: {}, body: 'person', path: 'People/Carlos.md' },
+    },
+    listPagesResult: [
+      { id: 1,  title: 'Knowledge Domains', section: undefined, filePath: '', parentId: 0 },
+      { id: 10, title: 'Doc One',           section: undefined, filePath: 'Documents', parentId: 1 },
+      { id: 20, title: 'Carlos',            section: undefined, filePath: 'People',    parentId: 1 },
+    ],
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = await steward._readNeighborhood({ name: 'Documents' });
+
+  assert.strictEqual(neighborhood.pages.length, 1, 'should only include Documents pages');
+  assert.strictEqual(neighborhood.pages[0].title, 'Doc One');
+});
+
+// ---------------------------------------------------------------------------
 // KNOWLEDGE STEWARD LENS
 // ---------------------------------------------------------------------------
 

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -844,11 +844,7 @@ asyncTest('tend() calls observationLog.resolve after intervention resolves types
 
 // Test 19: refreshLandingPage() builds prompt from cluster list, writes to collectivesClient
 asyncTest('refreshLandingPage() calls router and writes landing page content', async () => {
-  const mockLandingBody = `---
-type: index
----
-
-# Moltagent Knowledge
+  const mockLandingBody = `# Moltagent Knowledge
 
 ## Knowledge Domains
 
@@ -882,10 +878,131 @@ Key entities: Carlos, Eelco
   assert.ok(router._calls.length > 0, 'router should have been called');
   const routerCall = router._calls[0];
   assert.strictEqual(routerCall.job, 'synthesis');
-  // Verify the content was written somewhere
-  const writtenContent = collectivesClient._writtenContent;
-  const writtenKeys = Object.keys(writtenContent);
-  assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
+  // After the fix, landing page goes through writePageWithFrontmatter, not writePageContent
+  assert.ok(
+    collectivesClient._writtenPages['Moltagent Knowledge'],
+    'landing page should be written via writePageWithFrontmatter'
+  );
+});
+
+// Test 43.1: _updateLandingPage writes frontmatter via structured path
+asyncTest('_updateLandingPage writes frontmatter fields via writePageWithFrontmatter', async () => {
+  const cleanBody = `# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.
+Key entities: Alice`;
+
+  const router = {
+    _calls: [],
+    async route(opts) {
+      this._calls.push(opts);
+      return { result: cleanBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'writePageWithFrontmatter must be called for the landing page title');
+  assert.ok(
+    !collectivesClient._writtenContent['Moltagent Knowledge.md'],
+    'raw writePageContent must NOT be used for the landing page'
+  );
+  const fm = written.frontmatter;
+  assert.strictEqual(fm.type, 'index');
+  assert.strictEqual(fm.decay_days, -1);
+  assert.strictEqual(fm.compost, 'never');
+  assert.strictEqual(fm.auto_maintained, true);
+  assert.strictEqual(fm.confidence, 'high');
+});
+
+// Test 43.2: _updateLandingPage strips code fences from LLM output
+asyncTest('_updateLandingPage strips code fences from LLM output before writing', async () => {
+  const fencedBody = '```markdown\n# Moltagent Knowledge\n\n## Knowledge Domains\n\n### People\nContacts.\n```';
+
+  const router = {
+    async route() {
+      return { result: fencedBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after fence stripping');
+  assert.ok(!written.body.includes('```'), 'body must not contain backtick fences');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading');
+});
+
+// Test 43.3: _updateLandingPage strips rogue frontmatter from LLM output
+asyncTest('_updateLandingPage strips rogue frontmatter block from LLM output', async () => {
+  const rogueFmBody = `---
+type: index
+decay_days: -1
+---
+
+# Moltagent Knowledge
+
+## Knowledge Domains
+
+### People
+Contacts.`;
+
+  const router = {
+    async route() {
+      return { result: rogueFmBody, provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  const written = collectivesClient._writtenPages['Moltagent Knowledge'];
+  assert.ok(written, 'page should still be written after frontmatter stripping');
+  assert.ok(written.body.startsWith('# Moltagent Knowledge'), 'body must start with the heading, not ---');
+  assert.ok(!written.body.startsWith('---'), 'body must not begin with a frontmatter fence');
+});
+
+// Test 43.4: _updateLandingPage includes compost: never in frontmatter (focused single-fact)
+asyncTest('_updateLandingPage always sets compost: never in landing page frontmatter', async () => {
+  const router = {
+    async route() {
+      return { result: '# Moltagent Knowledge\n\n### People\nContacts.', provider: 'mock', model: 'mock', cost: 0 };
+    }
+  };
+
+  const collectivesClient = makeMockCollectivesClient({
+    collectiveName: 'Moltagent Knowledge',
+    listPagesResult: [{ id: 1, title: 'Alice', section: 'People', parentId: 1 }],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, llmRouter: router }));
+  await steward.refreshLandingPage();
+
+  assert.strictEqual(
+    collectivesClient._writtenPages['Moltagent Knowledge'].frontmatter.compost,
+    'never'
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -888,4 +888,219 @@ Key entities: Carlos, Eelco
   assert.ok(writtenKeys.length > 0, 'landing page content should have been written');
 });
 
+// ---------------------------------------------------------------------------
+// STRUCTURAL PAGE GUARD (#59) — _isStructuralPage + _intervene chokepoint
+// ---------------------------------------------------------------------------
+
+// Helper: build a neighborhood with arbitrary pages for intervention tests
+function makeInterveneNeighborhood(pages, cluster = 'Documents') {
+  return {
+    cluster,
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: cluster,
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set([cluster]),
+    deckCards: [],
+  };
+}
+
+// Test #59.1: _isStructuralPage returns true for type: section
+test('_isStructuralPage returns true for type:section', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'section' } }), true);
+});
+
+// Test #59.2: _isStructuralPage returns true for type: index
+test('_isStructuralPage returns true for type:index', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'index' } }), true);
+});
+
+// Test #59.3: _isStructuralPage returns true for type: meta
+test('_isStructuralPage returns true for type:meta', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: { type: 'meta' } }), true);
+});
+
+// Test #59.4: _isStructuralPage returns true for compost: never (lifecycle pin)
+test('_isStructuralPage returns true for compost:never (lifecycle pin)', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', compost: 'never' } }),
+    true,
+    'compost: never alone marks a page as structural infrastructure'
+  );
+});
+
+// Test #59.5: _isStructuralPage returns false for normal content page
+test('_isStructuralPage returns false for normal content page', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(
+    steward._isStructuralPage({ frontmatter: { type: 'entity', confidence: 'high' } }),
+    false
+  );
+});
+
+// Test #59.6: _isStructuralPage returns false for page with no frontmatter
+test('_isStructuralPage returns false for page with missing/empty frontmatter', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._isStructuralPage({ frontmatter: null }), false);
+  assert.strictEqual(steward._isStructuralPage({}), false);
+  assert.strictEqual(steward._isStructuralPage(null), false);
+});
+
+// Test #59.7: Connection Steward skips structural page in missingLinks loop
+asyncTest('_intervene(connection): skips structural page in missingLinks', async () => {
+  const pagesByTitle = {
+    'Carlos':    { frontmatter: {}, body: 'Content page.', path: 'People/Carlos.md' },
+    'Documents': { frontmatter: { type: 'index' }, body: '# Documents', path: 'Documents.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',    frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Documents', shouldLinkTo: 'Eelco', relationship: 'related' },
+      { page: 'Carlos',    shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Documents'],
+    'structural page (type:index) must not be written by Connection Steward'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still receive its wikilink'
+  );
+});
+
+// Test #59.8: Memory Steward skips structural page in compost loop
+asyncTest('_intervene(memory): skips structural page in compost', async () => {
+  const pagesByTitle = {
+    'Carlos':   { frontmatter: { confidence: 'low' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Research': { frontmatter: { type: 'index', compost: 'never' }, body: '# Research', path: 'Research.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',   frontmatter: { confidence: 'low' } },
+    { title: 'Research', frontmatter: { type: 'index', compost: 'never' } },
+  ]);
+
+  const assessment = {
+    strengthen: [],
+    compost: [
+      { page: 'Research', reason: 'Never accessed' },
+      { page: 'Carlos',   reason: 'Stale and unaccessed' },
+    ],
+    embed: [],
+  };
+
+  await steward._intervene('memory', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Research'],
+    'structural page (type:index + compost:never) must not be touched by _markForComposting'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still be marked for composting'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.compost_ready,
+    true,
+    'content page compost_ready set'
+  );
+});
+
+// Test #59.9: Knowledge Steward skips structural page in stale loop
+asyncTest('_intervene(knowledge): skips structural page in stale', async () => {
+  const pagesByTitle = {
+    'Carlos':            { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Pending Questions': { frontmatter: { type: 'meta' },       body: '# Pending Questions', path: 'Meta/Pending Questions.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos',            frontmatter: { confidence: 'high' } },
+    { title: 'Pending Questions', frontmatter: { type: 'meta' } },
+  ], 'Meta');
+
+  const assessment = {
+    contradictions: [],
+    stale: [
+      { page: 'Pending Questions', reason: 'No new entries in 90 days' },
+      { page: 'Carlos',            reason: 'Last verified 180 days ago' },
+    ],
+    gaps: [],
+  };
+
+  await steward._intervene('knowledge', assessment, neighborhood);
+
+  assert.ok(
+    !collectivesClient._writtenPages['Pending Questions'],
+    'structural page (type:meta) must not have confidence lowered'
+  );
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page should still have confidence lowered'
+  );
+  assert.strictEqual(
+    collectivesClient._writtenPages['Carlos'].frontmatter.confidence,
+    'medium',
+    'content page confidence stepped down high → medium'
+  );
+});
+
+// Test #59.10: guard does not interfere with normal content-page interventions
+asyncTest('_intervene: content pages are still processed normally when no structural page in neighborhood', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: { confidence: 'high' }, body: 'Content.', path: 'People/Carlos.md' },
+    'Eelco':  { frontmatter: { confidence: 'high' }, body: 'Researcher.', path: 'People/Eelco.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const neighborhood = makeInterveneNeighborhood([
+    { title: 'Carlos', frontmatter: { confidence: 'high' } },
+    { title: 'Eelco',  frontmatter: {} /* untyped — still a content page */ },
+  ], 'People');
+
+  const assessment = {
+    missingLinks: [
+      { page: 'Carlos', shouldLinkTo: 'Eelco', relationship: 'works_with' },
+    ],
+    orphans: [],
+    nearDuplicates: [],
+  };
+
+  const result = await steward._intervene('connection', assessment, neighborhood);
+
+  assert.ok(result.linksAdded >= 1, 'untyped + high-confidence pages remain in scope');
+  assert.ok(
+    collectivesClient._writtenPages['Carlos'],
+    'content page (Carlos) should still be written'
+  );
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -532,6 +532,153 @@ asyncTest('_markForComposting honors compost: never pin — does not mark pinned
 });
 
 // ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix A: wikilink idempotency survives resolution
+// ---------------------------------------------------------------------------
+
+// Fix A.1: _addWikilink returns false when the unresolved [[target]] is present.
+asyncTest('_addWikilink skips when unresolved [[target]] already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [[ManeraMedia GmbH]] (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — unresolved form already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.2: _addWikilink returns false when the RESOLVED [target](url) is present.
+// This is the new behavior — writePageWithFrontmatter resolves [[X]] to [X](url),
+// so on the next heartbeat only the resolved form remains in the body.
+asyncTest('_addWikilink skips when resolved [target](url) already in body', async () => {
+  const pagesByTitle = {
+    'Carlos': {
+      frontmatter: {},
+      body: 'Carlos.\n\n## Related\n- [ManeraMedia GmbH](https://nc.example/f/12345) (works_at)\n',
+      path: 'People/Carlos.md',
+    },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, false, 'should skip — resolved markdown link already present');
+  assert.ok(!collectivesClient._writtenPages['Carlos'], 'page must not be rewritten');
+});
+
+// Fix A.3: _addWikilink adds the link when neither form is present.
+asyncTest('_addWikilink adds the link when neither form is present', async () => {
+  const pagesByTitle = {
+    'Carlos': { frontmatter: {}, body: 'Carlos works somewhere.', path: 'People/Carlos.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const added = await steward._addWikilink('Carlos', 'ManeraMedia GmbH', 'works_at');
+  assert.strictEqual(added, true, 'should add — neither form present');
+  const written = collectivesClient._writtenPages['Carlos'];
+  assert.ok(written && written.body.includes('[[ManeraMedia GmbH]]'), 'body should carry the new link');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix B: Connection Steward excludes index pages
+// ---------------------------------------------------------------------------
+
+function makeConnectionNeighborhood(pages) {
+  return {
+    cluster: 'Documents',
+    pages: pages.map((p, i) => ({
+      id: String(i + 1),
+      title: p.title,
+      section: 'Documents',
+      frontmatter: p.frontmatter || {},
+      bodyPreview: '',
+      hasEmbedding: false,
+      graphConnections: [],
+      wikilinks: [],
+    })),
+    graphEdges: [],
+    sections: new Set(['Documents']),
+    deckCards: [],
+  };
+}
+
+// Fix B.1: pages with `type: index` are excluded from the assessment data.
+test('_connectionAssessmentPrompt excludes type:index pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Documents', frontmatter: { type: 'index' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Documents'), 'index page must not appear as a link target');
+});
+
+// Fix B.2: pages with `compost: never` (structural pin) are excluded.
+test('_connectionAssessmentPrompt excludes compost:never pages from pageLinks', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const neighborhood = makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+    { title: 'Structural Nav Page', frontmatter: { compost: 'never' } },
+  ]);
+
+  const prompt = steward._connectionAssessmentPrompt(neighborhood);
+  assert.ok(prompt.includes('### Carlos Mendez'), 'content page should appear');
+  assert.ok(!prompt.includes('### Structural Nav Page'), 'pinned structural page must not appear');
+});
+
+// Fix B.3: the EXCLUSION instruction is present in the prompt.
+test('_connectionAssessmentPrompt carries the EXCLUSION instruction', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  const prompt = steward._connectionAssessmentPrompt(makeConnectionNeighborhood([
+    { title: 'Carlos Mendez', frontmatter: {} },
+  ]));
+  assert.ok(prompt.includes('EXCLUSION:'), 'prompt should instruct the LLM to exclude index pages');
+});
+
+// ---------------------------------------------------------------------------
+// CROSS-WRITE INTERFERENCE — Fix C: _markForComposting writes frontmatter only
+// ---------------------------------------------------------------------------
+
+// Fix C.1: _markForComposting sets the compost frontmatter fields.
+asyncTest('_markForComposting sets compost_ready/compost_reason/compost_marked_at', async () => {
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: '# Stale Doc\n\nbody', path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  const ok = await steward._markForComposting('Stale Doc', 'Never accessed, past decay');
+  assert.strictEqual(ok, true);
+  const fm = collectivesClient._writtenPages['Stale Doc'].frontmatter;
+  assert.strictEqual(fm.compost_ready, true, 'compost_ready should be true');
+  assert.strictEqual(fm.compost_reason, 'Never accessed, past decay', 'compost_reason should be set');
+  assert.ok(fm.compost_marked_at, 'compost_marked_at should be set');
+});
+
+// Fix C.2: _markForComposting does NOT modify the page body — no inline marker.
+asyncTest('_markForComposting leaves the page body unchanged (no inline archive marker)', async () => {
+  const originalBody = '# Stale Doc\n\nReal content.\n\n## Related\n- [Eelco](https://nc.example/f/9) (related)\n';
+  const pagesByTitle = {
+    'Stale Doc': { frontmatter: { confidence: 'low' }, body: originalBody, path: 'Documents/Stale.md' },
+  };
+  const collectivesClient = makeMockCollectivesClient({ pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient }));
+
+  await steward._markForComposting('Stale Doc', 'Never accessed');
+  const writtenBody = collectivesClient._writtenPages['Stale Doc'].body;
+  assert.strictEqual(writtenBody, originalBody, 'body must be byte-identical — no inline annotation');
+  assert.ok(!writtenBody.includes('Archived by Memory Steward'), 'no inline archive marker in body');
+});
+
+// ---------------------------------------------------------------------------
 // INTEGRATION WITH tend()
 // ---------------------------------------------------------------------------
 

--- a/test/unit/providers/ollama-credential-model.test.js
+++ b/test/unit/providers/ollama-credential-model.test.js
@@ -12,6 +12,10 @@
 const assert = require('assert');
 const { test, summary, exitWithCode } = require('../../helpers/test-runner');
 
+// config.js requires NC_URL; supply a test default if not already set
+// (the central test runner does this too, but support direct invocation).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+
 // Store original env to restore after tests
 const originalEnv = { ...process.env };
 

--- a/test/unit/workflows/schedule-handler.test.js
+++ b/test/unit/workflows/schedule-handler.test.js
@@ -569,6 +569,131 @@ asyncTest('processSchedules: single-action schedule still works with cloudTier',
   assert.strictEqual(taskOpts.allowCloud, true);
 });
 
+// ─── PAUSED-stack chokepoint (#28) ───────────────────────────────────
+
+asyncTest('processSchedules: skips ALL schedules when any stack has PAUSED CONFIG', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; return 'done'; } };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent });
+
+  const wb = {
+    board: { id: 144, title: 'Content Pipeline - Molti' },
+    description: 'WORKFLOW: pipeline\n\nSCHEDULE:\nEvery 1h: Scan NC News feeds. LLM: cloud\nEvery 7d: Archive stale cards. LLM: local',
+    stacks: [
+      {
+        id: 663,
+        title: 'Ideas',
+        cards: [
+          {
+            id: 100,
+            title: 'CONFIG: Evaluation',
+            archived: false,
+            deletedAt: null,
+            labels: [{ title: 'PAUSED' }]
+          }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.executed, 0, 'no schedules executed');
+  assert.strictEqual(result.skipped, 2, 'both schedules skipped');
+  assert.strictEqual(callCount, 0, 'agentLoop never invoked');
+});
+
+asyncTest('processSchedules: PAUSED skip is independent of due-time and budget', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; } };
+  const blockingBudget = { canSpend: () => ({ allowed: true }) };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent, budgetEnforcer: blockingBudget });
+
+  const wb = {
+    board: { id: 1, title: 'Test' },
+    description: 'SCHEDULE:\nEvery 1h: Do something. LLM: cloud',
+    stacks: [
+      {
+        id: 10,
+        title: 'Ideas',
+        cards: [
+          { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'PAUSED' }] }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  // Even on first call (when isDue would return true), skip.
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.skipped, 1);
+  assert.strictEqual(callCount, 0);
+
+  // Re-running does not mark the schedule as run, so when the stack is
+  // unpaused the schedule fires immediately.
+  wb.stacks[0].cards[0].labels = [];
+  const result2 = await handler.processSchedules(wb);
+  assert.strictEqual(result2.executed, 1, 'fires once unpaused');
+  assert.strictEqual(callCount, 1);
+});
+
+asyncTest('processSchedules: schedules still run when no stacks have PAUSED CONFIG', async () => {
+  let callCount = 0;
+  const mockAgent = { processWorkflowTask: async () => { callCount++; return 'ok'; } };
+  const handler = new ScheduleHandler({ agentLoop: mockAgent });
+
+  const wb = {
+    board: { id: 1, title: 'Test' },
+    description: 'SCHEDULE:\nEvery 1h: Do work. LLM: cloud',
+    stacks: [
+      {
+        id: 10,
+        title: 'Ideas',
+        cards: [
+          { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'ACTIVE' }] }
+        ]
+      }
+    ],
+    workflowType: 'pipeline'
+  };
+
+  const result = await handler.processSchedules(wb);
+  assert.strictEqual(result.executed, 1);
+  assert.strictEqual(callCount, 1);
+});
+
+asyncTest('processSchedules: PAUSED skip log mentions board, stack, and action', async () => {
+  const logs = [];
+  const origLog = console.log;
+  console.log = (msg) => { logs.push(msg); };
+  try {
+    const handler = new ScheduleHandler({ agentLoop: { processWorkflowTask: async () => {} } });
+    const wb = {
+      board: { id: 144, title: 'Pipeline' },
+      description: 'SCHEDULE:\nEvery 1h: Scan NC News feeds. LLM: cloud',
+      stacks: [
+        {
+          id: 663,
+          title: 'Ideas',
+          cards: [
+            { id: 100, title: 'CONFIG: x', archived: false, deletedAt: null, labels: [{ title: 'PAUSED' }] }
+          ]
+        }
+      ],
+      workflowType: 'pipeline'
+    };
+    await handler.processSchedules(wb);
+    const skipLog = logs.find(l => l.startsWith('[Schedule] Skipping schedule on PAUSED stack:'));
+    assert.ok(skipLog, 'skip log line emitted');
+    assert.ok(skipLog.includes('"Scan NC News feeds. LLM: cloud"') || skipLog.includes('"Scan NC News feeds.'), 'log includes action text');
+    assert.ok(skipLog.includes('board=144'), 'log includes board id');
+    assert.ok(skipLog.includes('stack=663'), 'log includes stack id');
+    assert.ok(logs.some(l => l === '[Workflow] Stack "Ideas" skipped for schedules — CONFIG card has PAUSED label'), 'preserves existing per-stack log');
+  } finally {
+    console.log = origLog;
+  }
+});
+
 setTimeout(() => {
   summary();
   exitWithCode();


### PR DESCRIPTION
**WikiSteward restoration**
- Neighborhood filter restored — stewards see pages for the first 
  time since late April (#51)
- Cross-write interference prevention: idempotent wikilinks, section 
  collision dedup, index page exclusion (#50)
- Structural page intervention guard — stewards skip type:section/
  index/meta instead of hallucinating content onto stubs (#59)
- Landing page frontmatter via structured write path, enabling 
  compost:never pin for the first time (#43)

**Conversational agent**
- Deck tools reach shared boards — board-aware resolution for all 
  card mutation tools (#65)
- Action hallucination guard — re-prompt when classifier says action 
  but LLM returns text without calling any tool (#68)
- SOUL.md rule: never claim an action succeeded without a tool call

**Infrastructure**
- NC_URL required at config load, placeholder fallback removed (#62)
- Quickstart docs: config path clarified for home-lab setups (#73)

10 commits, 23 files, 2,285 additions, 208 deletions.
All changes production-verified before merge.