### PR TITLE
fix(package): make prepare script tolerate missing husky (#80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:deck": "node scripts/test-deck-integration.js",
     "lint": "eslint src/ test/ webhook-server.js",
     "lint:fix": "eslint src/ test/ webhook-server.js --fix",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "keywords": [
     "sovereign-ai",


### PR DESCRIPTION
## Summary

- `package.json:21` — change `"prepare": "husky"` → `"prepare": "husky || true"`
- One-character fix; standard npm idiom for prepare scripts that depend on devDependencies
- Unblocks `npm install --omit=dev` (and the deprecated `--production`) on clean clones

## Why

Surfaced by **Discussion #72 Post 1** (architectonio) — first external installer following QuickStart. `npm install --production` invokes the `prepare` lifecycle script, which runs `husky`; but husky is a devDependency and isn't present in production installs, so the entire install fails with exit 127 (`sh: 1: husky: not found`).

`husky || true` runs husky when available (dev environments) and succeeds silently when it isn't (production). No behavioral change for developers — git hooks still get wired the same way.

## Test plan

- [x] Reproduce Antonio's failure on a clean clone with the **un**fixed `package.json` → exit 127 with `husky: not found` (matches Discussion #72 transcript)
- [x] Verify POSIX shell semantics: `sh -c 'husky || true'` returns 0 when husky is not on PATH
- [ ] Confirm `npm install --omit=dev` on a clean clone now completes without error (acceptance from #80)
- [ ] Confirm `npm install` in a dev environment still sets up husky hooks

## Related

- Closes #80
- Discussion #72 Post 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)