### PR TITLE
docs: required vs optional NC apps (+ NC_USER, local-only, --omit=dev)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,8 @@ The following apps must be installed on your Storage Share. Most are pre-install
 
 The agent probes each optional integration at startup. If the app or its credential is not present, that feature is disabled and the agent continues normally. You never need to install an optional app just to make the service boot.
 
+> **Maintainer note — keep this list in sync.** The required/optional split also appears in the [Quick Start](quickstart.md), Step 2. These two copies are hand-synchronized: change one, change the other in the same commit. Collapsing the split into a single declared manifest that both the startup preflight and the docs read from — so the two surfaces can no longer drift — is tracked in [#87](https://github.com/moltagent/moltagent/issues/87). When that lands, this note gets deleted.
+
 ## Credential Organization in NC Passwords
 
 Create the following entries in the Passwords app and share them with the `moltagent` user. The folder structure is optional but recommended for organization.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,7 +13,7 @@ This guide covers the complete Moltagent deployment in detail. For a quick overv
 
 The following apps must be installed on your Storage Share. Most are pre-installed on Hetzner Storage Share. Check via Settings > Apps.
 
-**Required:**
+**Required** — the agent will not start without these:
 
 | App | Purpose |
 |-----|---------|
@@ -21,16 +21,18 @@ The following apps must be installed on your Storage Share. Most are pre-install
 | Deck | Kanban boards for Cockpit (agent control plane) and Workflow Engine |
 | Collectives | Wiki for Living Memory / knowledge system |
 | Talk | Chat interface, webhook pipeline, human-agent communication |
-| Mail | IMAP/SMTP integration for email workflows |
-| Calendar | CalDAV integration for smart meetings and scheduling |
-| Contacts | CardDAV contact resolution for meetings and email |
 
-**Optional:**
+**Optional** — each enables a feature; absence disables that feature cleanly with one log line, nothing more:
 
-| App | Purpose |
+| App | Feature enabled if present |
 |-----|---------|
+| Mail | Email monitoring, analysis, and draft replies (IMAP/SMTP) |
+| Calendar | CalDAV scheduling, meeting awareness, free/busy |
+| Contacts | CardDAV contact resolution for meetings and email |
 | News | RSS feeds for content discovery and editorial workflows |
 | Analytics | Data visualization (not used by the agent directly) |
+
+The agent probes each optional integration at startup. If the app or its credential is not present, that feature is disabled and the agent continues normally. You never need to install an optional app just to make the service boot.
 
 ## Credential Organization in NC Passwords
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,7 +44,21 @@ This guide walks you through deploying Moltagent on Hetzner infrastructure. The 
 ## Step 2: Configure Nextcloud
 
 1. Log into your Nextcloud admin panel
-2. Install required apps: **Passwords**, **Deck**, **Collectives**, **Talk**, **Mail**, **Calendar**, **Contacts**
+2. Install the Nextcloud apps Moltagent uses.
+
+   **Required** — the agent will not start without these:
+   - **Passwords** — credential broker (API keys, secrets)
+   - **Deck** — Cockpit control plane and Workflow Engine
+   - **Collectives** — Living Memory / knowledge wiki
+   - **Talk** — chat interface and webhook pipeline
+
+   **Optional** — install only the features you want; the agent runs fine without any of them:
+   - **Mail** — email monitoring and drafting (IMAP/SMTP)
+   - **Calendar** — CalDAV scheduling and meeting awareness
+   - **Contacts** — contact resolution for email and meetings
+   - **News** — RSS feeds for content workflows
+
+   If you skip an optional app, the corresponding feature simply stays off. You will see a single log line at startup noting the feature is disabled, and nothing else.
 3. Create the `moltagent` user via the Nextcloud admin panel (Settings → Users). On a managed Storage Share, `occ` is not available — use the web interface instead.
 
 4. Create the agent's folder structure:
@@ -116,7 +130,7 @@ curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 apt-get install -y nodejs
 git clone https://github.com/moltagent/moltagent.git /opt/moltagent
 cd /opt/moltagent
-npm install --production
+npm install --omit=dev
 ```
 
 ### Configure credentials
@@ -142,6 +156,11 @@ nano config/moltagent-providers.yaml
 cp deploy/moltagent.service /etc/systemd/system/
 # Edit the service file to set your NC_URL, NC_USER, OLLAMA_URL
 nano /etc/systemd/system/moltagent.service
+```
+
+> **Note on `NC_USER`:** Use the Nextcloud **user ID**, not the display name. You can see the user ID in the Nextcloud admin Users panel (it is the value in the "Username" / account-name column, which may differ from the display name shown elsewhere). A mismatch here surfaces as a `401 Authentication error` against NC Passwords at startup.
+
+```bash
 systemctl daemon-reload
 systemctl enable moltagent
 systemctl start moltagent
@@ -235,6 +254,20 @@ What changes:
 - In `config/moltagent-providers.yaml`, set the Ollama endpoint to your Ollama server's LAN IP (e.g. `http://192.168.1.50:11434`)
 - Set up the credential store and systemd service as described in Step 4 above
 - Skip the firewall rules — those are for the isolated VM setup
+
+### Running fully local (no cloud LLM)
+
+If you want zero cloud calls, set every role to your local provider in `config/moltagent-providers.yaml`:
+
+```yaml
+roles:
+  sovereign: [ollama-local]
+  free: [ollama-local]
+  value: [ollama-local]
+  premium: [ollama-local]
+```
+
+Remove or comment out the cloud provider blocks (e.g. `anthropic-claude`, `claude-sonnet`). With no cloud provider in any role, the agent never attempts a cloud call and you will not see `credential_error` lines for keys you did not configure. This is equivalent to the **all-local** preset described in [LLM Providers](providers.md).
 
 To verify:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,8 @@ This guide walks you through deploying Moltagent on Hetzner infrastructure. The 
    - **News** — RSS feeds for content workflows
 
    If you skip an optional app, the corresponding feature simply stays off. You will see a single log line at startup noting the feature is disabled, and nothing else.
+
+   <!-- Maintainer: this required/optional split is mirrored in deployment.md ("Nextcloud Apps"). Keep both in sync in the same commit until the single-manifest fix lands — see #87. -->
 3. Create the `moltagent` user via the Nextcloud admin panel (Settings → Users). On a managed Storage Share, `occ` is not available — use the web interface instead.
 
 4. Create the agent's folder structure:


### PR DESCRIPTION
Makes the deployment docs agree with the code and with reality: **Required** apps the agent genuinely needs to boot, **Optional** apps it tolerates the absence of. This is the same required/optional split the future startup preflight will consume (tracked in #87).

## Changes

**`quickstart.md`**
- Step 2: single Required/Optional split. Required = Passwords, Deck, Collectives, Talk. Optional = Mail, Calendar, Contacts, News. (Mail/Calendar/Contacts move from required → optional.)
- Step 4: `npm install --production` → `--omit=dev` (modern npm; avoids the husky lifecycle crash on the old form).
- Added `NC_USER` note: it's the Nextcloud **user ID**, not the display name (mismatch surfaces as a 401 against NC Passwords at startup).
- Added a "Running fully local (no cloud LLM)" note to stop `credential_error` noise for unconfigured cloud keys.

**`deployment.md`**
- "Nextcloud Apps" tables rebuilt to the same Required/Optional split (lockstep with quickstart).
- Added a maintainer drift-warning note: the split lives in two doc surfaces and is hand-synchronized until the single-declared-manifest fix (#87) lands.

## Notes for review
- The required/optional list is intentionally duplicated across both files for now; the drift-warning note + #87 track collapsing it to one source.
- Docs-only change. No code touched.

Related: #80 (`prepare`/husky), #87 (single-manifest preflight).