### PR TITLE
fix(llm): collapse Ollama endpoint resolution into one shared resolver

### DIFF
--- a/src/lib/llm/providers/index.js
+++ b/src/lib/llm/providers/index.js
@@ -12,6 +12,7 @@ const OllamaProvider = require('./ollama-provider');
 const OpenAICompatibleProvider = require('./openai-compatible-provider');
 const AnthropicProvider = require('./anthropic-provider');
 const GoogleProvider = require('./google-provider');
+const { resolveOllamaEndpoint } = require('../../shared/resolve-ollama-endpoint');
 
 /**
  * Provider adapter registry
@@ -201,6 +202,13 @@ function createProvider(adapterId, config) {
     ...config,
     costModel: config.costModel || adapter.defaults.costModel
   };
+
+  if (adapterId === 'ollama') {
+    mergedConfig.endpoint = resolveOllamaEndpoint(mergedConfig.endpoint, {
+      defaultUrl: adapter.defaults.endpoint,
+      source: `provider:${config.id || 'ollama'}`,
+    });
+  }
 
   return new adapter.class(mergedConfig);
 }

--- a/src/lib/shared/resolve-ollama-endpoint.js
+++ b/src/lib/shared/resolve-ollama-endpoint.js
@@ -1,0 +1,91 @@
+/**
+ * Resolve the effective Ollama endpoint URL from layered sources.
+ *
+ * Single canonical resolver for every Ollama provider construction site.
+ * Lives here because the same precedence question recurs at five places
+ * (providers registry, three OllamaToolsProvider sites in webhook-server,
+ * heartbeat-manager player registration) and any of them silently picking
+ * a YOUR_* placeholder kills local inference.
+ *
+ * Precedence (highest first):
+ *   1. OLLAMA_URL env var, if set and not a YOUR_* placeholder
+ *   2. candidate (typically YAML/JSON config value), if not a placeholder
+ *   3. defaultUrl ('http://localhost:11434' unless caller overrides)
+ *
+ * A YOUR_* literal in any candidate is treated as the absence of
+ * configuration, not configuration. The placeholder is documentation for
+ * the deployer; the resolver makes the code agree with that intent.
+ *
+ * @module shared/resolve-ollama-endpoint
+ */
+
+'use strict';
+
+const DEFAULT_FALLBACK = 'http://localhost:11434';
+const PLACEHOLDER_MARKER = 'YOUR_';
+
+const _warnedOnce = new Set();
+
+function _isPlaceholder(value) {
+  return typeof value === 'string' && value.includes(PLACEHOLDER_MARKER);
+}
+
+function _warnOnce(key, message, logger) {
+  if (_warnedOnce.has(key)) return;
+  _warnedOnce.add(key);
+  (logger?.warn || console.warn).call(logger || console, message);
+}
+
+/**
+ * @param {string|null|undefined} candidate - Endpoint from config (YAML/JSON/inline)
+ * @param {Object} [options]
+ * @param {string} [options.envUrl=process.env.OLLAMA_URL] - Env var override
+ * @param {string} [options.defaultUrl='http://localhost:11434'] - Final fallback
+ * @param {Object} [options.logger=console] - Logger for warn-once placeholder notice
+ * @param {string} [options.source] - Caller label for diagnostic warnings
+ * @returns {string} Trailing-slash-stripped endpoint URL
+ */
+function resolveOllamaEndpoint(candidate, options = {}) {
+  const envUrl = options.envUrl !== undefined ? options.envUrl : process.env.OLLAMA_URL;
+  const defaultUrl = options.defaultUrl || DEFAULT_FALLBACK;
+  const logger = options.logger || console;
+  const source = options.source || 'ollama';
+
+  if (envUrl && !_isPlaceholder(envUrl)) {
+    return envUrl.replace(/\/$/, '');
+  }
+
+  if (envUrl && _isPlaceholder(envUrl)) {
+    _warnOnce(
+      `env:${envUrl}`,
+      `[resolveOllamaEndpoint] OLLAMA_URL is a placeholder ("${envUrl}") — ignoring`,
+      logger
+    );
+  }
+
+  if (candidate && !_isPlaceholder(candidate)) {
+    return candidate.replace(/\/$/, '');
+  }
+
+  if (candidate && _isPlaceholder(candidate)) {
+    _warnOnce(
+      `${source}:${candidate}`,
+      `[resolveOllamaEndpoint] ${source} endpoint is a placeholder ("${candidate}") — falling back to ${defaultUrl}`,
+      logger
+    );
+  }
+
+  return defaultUrl.replace(/\/$/, '');
+}
+
+/** Test helper — resets the warn-once latch. */
+function _resetWarnedForTests() {
+  _warnedOnce.clear();
+}
+
+module.exports = {
+  resolveOllamaEndpoint,
+  _resetWarnedForTests,
+  DEFAULT_FALLBACK,
+  PLACEHOLDER_MARKER,
+};

--- a/test/unit/shared/resolve-ollama-endpoint.test.js
+++ b/test/unit/shared/resolve-ollama-endpoint.test.js
@@ -1,0 +1,234 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2024 Moltagent contributors
+ *
+ * resolveOllamaEndpoint() Unit Tests
+ *
+ * Architecture Brief:
+ *   Tests the canonical Ollama endpoint resolver. The function exists because
+ *   YOUR_OLLAMA_IP placeholders were silently entering five provider
+ *   constructors (three in webhook-server, one in providers/index.js, one in
+ *   heartbeat-manager) and killing local inference for months — ProviderChain
+ *   absorbed every failure as a routing fallback to Claude.
+ *
+ *   Cases below pin the precedence chain (env > candidate > default), the
+ *   placeholder-rejection at every layer, and the warn-once behavior so
+ *   journald isn't spammed on every heartbeat.
+ *
+ * Run: node test/unit/shared/resolve-ollama-endpoint.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const {
+  resolveOllamaEndpoint,
+  _resetWarnedForTests,
+  DEFAULT_FALLBACK,
+} = require('../../../src/lib/shared/resolve-ollama-endpoint');
+
+function silentLogger() {
+  const warnings = [];
+  return {
+    warnings,
+    warn: (msg) => warnings.push(msg),
+    info: () => {},
+    error: () => {},
+  };
+}
+
+console.log('\n=== resolveOllamaEndpoint Tests ===\n');
+
+test('env var wins over candidate when both are valid', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint('http://192.168.1.100:11434', {
+    envUrl: 'http://10.0.0.5:11434',
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://10.0.0.5:11434');
+});
+
+test('candidate used when env unset', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint('http://192.168.1.100:11434', {
+    envUrl: undefined,
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://192.168.1.100:11434');
+});
+
+test('candidate used when env empty string', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint('http://192.168.1.100:11434', {
+    envUrl: '',
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://192.168.1.100:11434');
+});
+
+test('placeholder env var is rejected, candidate wins', () => {
+  _resetWarnedForTests();
+  const log = silentLogger();
+  const got = resolveOllamaEndpoint('http://192.168.1.100:11434', {
+    envUrl: 'http://YOUR_OLLAMA_IP:11434',
+    logger: log,
+  });
+  assert.strictEqual(got, 'http://192.168.1.100:11434');
+  assert.ok(
+    log.warnings.some((w) => w.includes('OLLAMA_URL is a placeholder')),
+    'expected placeholder-env warning'
+  );
+});
+
+test('placeholder candidate is rejected, default wins', () => {
+  _resetWarnedForTests();
+  const log = silentLogger();
+  const got = resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', {
+    envUrl: undefined,
+    logger: log,
+  });
+  assert.strictEqual(got, DEFAULT_FALLBACK);
+  assert.ok(
+    log.warnings.some((w) => w.includes('endpoint is a placeholder')),
+    'expected placeholder-candidate warning'
+  );
+});
+
+test('both placeholders → default localhost', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', {
+    envUrl: 'http://YOUR_OLLAMA_IP:11434',
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, DEFAULT_FALLBACK);
+});
+
+test('null candidate, no env → default localhost', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint(null, {
+    envUrl: undefined,
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, DEFAULT_FALLBACK);
+});
+
+test('undefined candidate, no env → default localhost', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint(undefined, {
+    envUrl: undefined,
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, DEFAULT_FALLBACK);
+});
+
+test('custom defaultUrl honored when both env and candidate absent', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint(null, {
+    envUrl: undefined,
+    defaultUrl: 'http://custom-default:11434',
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://custom-default:11434');
+});
+
+test('trailing slash stripped from env value', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint(null, {
+    envUrl: 'http://10.0.0.5:11434/',
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://10.0.0.5:11434');
+});
+
+test('trailing slash stripped from candidate value', () => {
+  _resetWarnedForTests();
+  const got = resolveOllamaEndpoint('http://192.168.1.100:11434/', {
+    envUrl: undefined,
+    logger: silentLogger(),
+  });
+  assert.strictEqual(got, 'http://192.168.1.100:11434');
+});
+
+test('warn-once: same placeholder candidate logged only once across calls', () => {
+  _resetWarnedForTests();
+  const log = silentLogger();
+  resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', { envUrl: undefined, logger: log });
+  resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', { envUrl: undefined, logger: log });
+  resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', { envUrl: undefined, logger: log });
+  const placeholderWarns = log.warnings.filter((w) => w.includes('endpoint is a placeholder'));
+  assert.strictEqual(placeholderWarns.length, 1, 'expected exactly one warn-once for the same placeholder');
+});
+
+test('source label appears in warning for diagnostic clarity', () => {
+  _resetWarnedForTests();
+  const log = silentLogger();
+  resolveOllamaEndpoint('http://YOUR_OLLAMA_IP:11434', {
+    envUrl: undefined,
+    logger: log,
+    source: 'provider:ollama-local',
+  });
+  assert.ok(
+    log.warnings.some((w) => w.includes('provider:ollama-local')),
+    'expected source label in warning'
+  );
+});
+
+test('createProvider integration: ollama adapter strips placeholder endpoint', () => {
+  _resetWarnedForTests();
+  const originalEnv = process.env.OLLAMA_URL;
+  delete process.env.OLLAMA_URL;
+  try {
+    const { createProvider } = require('../../../src/lib/llm/providers');
+    const provider = createProvider('ollama', {
+      id: 'test-ollama',
+      endpoint: 'http://YOUR_OLLAMA_IP:11434',
+      model: 'phi4-mini',
+    });
+    assert.strictEqual(provider.endpoint, 'http://localhost:11434');
+  } finally {
+    if (originalEnv !== undefined) process.env.OLLAMA_URL = originalEnv;
+  }
+});
+
+test('createProvider integration: OLLAMA_URL env wins over YAML candidate', () => {
+  _resetWarnedForTests();
+  const originalEnv = process.env.OLLAMA_URL;
+  process.env.OLLAMA_URL = 'http://10.0.0.5:11434';
+  try {
+    const { createProvider } = require('../../../src/lib/llm/providers');
+    const provider = createProvider('ollama', {
+      id: 'test-ollama-env',
+      endpoint: 'http://192.168.1.100:11434',
+      model: 'phi4-mini',
+    });
+    assert.strictEqual(provider.endpoint, 'http://10.0.0.5:11434');
+  } finally {
+    if (originalEnv !== undefined) process.env.OLLAMA_URL = originalEnv;
+    else delete process.env.OLLAMA_URL;
+  }
+});
+
+test('createProvider integration: non-ollama adapter unaffected by resolver', () => {
+  _resetWarnedForTests();
+  const originalEnv = process.env.OLLAMA_URL;
+  process.env.OLLAMA_URL = 'http://10.0.0.5:11434';
+  try {
+    const { createProvider } = require('../../../src/lib/llm/providers');
+    const provider = createProvider('anthropic', {
+      id: 'test-anthropic',
+      endpoint: 'https://api.anthropic.com',
+    });
+    assert.strictEqual(provider.endpoint, 'https://api.anthropic.com');
+  } finally {
+    if (originalEnv !== undefined) process.env.OLLAMA_URL = originalEnv;
+    else delete process.env.OLLAMA_URL;
+  }
+});
+
+setTimeout(() => {
+  const result = summary();
+  exitWithCode();
+  if (result.failed > 0) process.exitCode = 1;
+}, 100);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -27,6 +27,7 @@ const { createErrorHandler } = require('./src/lib/errors/error-handler');
 const { TalkSendQueue } = require('./src/lib/talk/talk-send-queue');
 const appConfig = require('./src/lib/config');
 const { createServerComponents } = require('./src/lib/server/index');
+const { resolveOllamaEndpoint } = require('./src/lib/shared/resolve-ollama-endpoint');
 
 // Knowledge modules for agent memory context
 let ContextLoader, LearningLog;
@@ -1487,22 +1488,31 @@ async function initialize() {
       const { OpenAIToolsProvider } = require('./src/lib/agent/providers/openai-tools');
       const getCredential = credentialBroker.createGetter();
 
+      // Resolve Ollama endpoint once: OLLAMA_URL env > providers.json > localhost.
+      // The candidate-then-CONFIG.ollama.url chain previously propagated the
+      // YOUR_OLLAMA_IP placeholder from both the JSON template and config.js's
+      // own env-var default. The resolver strips placeholders at every layer.
+      const ollamaEndpoint = resolveOllamaEndpoint(
+        ollamaConfig.endpoint || CONFIG.ollama.url,
+        { source: 'webhook-server' }
+      );
+
       let ollamaProvider = null;
       if (OllamaToolsProvider) {
         ollamaProvider = new OllamaToolsProvider({
-          endpoint: ollamaConfig.endpoint || CONFIG.ollama.url,
+          endpoint: ollamaEndpoint,
           model: ollamaConfig.model || CONFIG.ollama.model,
           timeout: CONFIG.ollama.timeout,
           toolTimeout: CONFIG.ollama.toolTimeout
         });
-        console.log(`[INIT] OllamaToolsProvider ready (${ollamaConfig.endpoint || CONFIG.ollama.url}, ${ollamaConfig.model || CONFIG.ollama.model})`);
+        console.log(`[INIT] OllamaToolsProvider ready (${ollamaEndpoint}, ${ollamaConfig.model || CONFIG.ollama.model})`);
       }
 
       let ollamaCredentialProvider = null;
       if (OllamaToolsProvider && CONFIG.ollama.modelCredential &&
           CONFIG.ollama.modelCredential !== (ollamaConfig.model || CONFIG.ollama.model)) {
         ollamaCredentialProvider = new OllamaToolsProvider({
-          endpoint: ollamaConfig.endpoint || CONFIG.ollama.url,
+          endpoint: ollamaEndpoint,
           model: CONFIG.ollama.modelCredential,
           timeout: CONFIG.ollama.timeout,
           toolTimeout: CONFIG.ollama.toolTimeout
@@ -1516,7 +1526,7 @@ async function initialize() {
       let ollamaFastProvider = null;
       if (OllamaToolsProvider && fastModel !== (ollamaConfig.model || CONFIG.ollama.model)) {
         ollamaFastProvider = new OllamaToolsProvider({
-          endpoint: ollamaConfig.endpoint || CONFIG.ollama.url,
+          endpoint: ollamaEndpoint,
           model: fastModel,
           timeout: 30000,
           toolTimeout: 30000


### PR DESCRIPTION
The placeholder http://YOUR_OLLAMA_IP:11434 was reaching five different provider construction sites: three OllamaToolsProvider inlines in webhook-server.js (main, credential, fast), createProvider() in the LLM registry, and the heartbeat-manager player path. Each site applied its own fallback chain; none stripped the YOUR_* literal; CONFIG.ollama.url itself defaulted to the same placeholder when OLLAMA_URL was unset (config.js:251). ProviderChain caught every resulting connection failure as "local unavailable" and rerouted to Claude, so local inference was silently dead while everything looked healthy. PR #79's confirmation classifier was the first consumer with no cloud fallback, so it broke visibly — that surfaced the months-old condition.

Resolution shape:
  - resolveOllamaEndpoint(candidate, { envUrl, defaultUrl, source }) in src/lib/shared/. Precedence is OLLAMA_URL > candidate > localhost. Any YOUR_* literal at any layer is treated as the absence of configuration, not configuration. Trailing slashes stripped. Warn-once per (source, value) pair so a paused-but-restarted service doesn't spam journald on every heartbeat.
  - createProvider('ollama', ...) routes mergedConfig.endpoint through the resolver before instantiation. Other adapters untouched.
  - webhook-server.js computes ollamaEndpoint once and threads it into all three OllamaToolsProvider sites and the [INIT] log line, so what journald reports is what the provider actually got.

Two deferrals, not oversights:
  - The same construction pattern exists at heartbeat-manager.js:1880 (chat provider for dynamically registered players). It has its own `endpoint || ollamaUrl || localhost` chain. Not touched in this PR to keep scope tight; this is the next call site to migrate, and the resolver is ready for it.
  - The YOUR_* defaults at config.js:251 (and the parallel whisper, speaches, heald entries) are deliberate template documentation, consistent with the YAML placeholder. The resolver now neutralizes them at consumption time, so they remain as deployer-facing hints rather than working as runtime defaults.

Tests: 16 cases for the resolver (precedence, placeholder rejection at both layers, warn-once, source-label propagation, three createProvider integration cases). 217/217 unit test files pass. Lint 0 errors.

BUILT not yet VERIFIED — bot VM restart and [INIT] log capture pending.

## What

<!-- What does this PR change? One or two sentences. -->

## Why

<!-- Why is this change needed? Link to an issue if applicable. Closes #000 -->

## How

<!-- Brief description of the approach. Mention any architectural decisions. -->

## Testing

<!-- How did you verify this works? -->

- [ ] Tests pass (`npm test`)
- [ ] Tested manually against a Nextcloud instance
- [ ] No language-specific logic added (multilingual by default)

## Checklist

- [ ] Commit messages are descriptive
- [ ] No credentials, IPs, or client-specific data in the diff
- [ ] Documentation updated if needed
