### PR TITLE
docs: add Credential Format Reference, fix broken email Notes format

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Moltagent runs on a box in your office, workshop or farm. Or on a virtual server
 | [Deployment Guide](docs/deployment.md)   | SearXNG, Speaches, email, credentials, full setup    |
 | [Architecture](docs/architecture.md)     | Three-VM isolation, network segmentation             |
 | [Security Model](docs/security-model.md) | Trust boundaries, credential brokering, threat model |
+| [Credentials](docs/credentials.md)       | NC Passwords field mapping for every credential      |
 | [Configuration](docs/configuration.md)   | Full reference for config.yaml                       |
 | [LLM Providers](docs/providers.md)       | 13 adapters, job routing, cost optimization          |
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,134 @@
+# Credential Format Reference
+
+Moltagent reads every secret it needs from the Nextcloud **Passwords** app. You create an entry there, share it with the `moltagent` user, and the agent fetches it on demand.
+
+This page documents the exact mapping between the NC Passwords UI fields and what the code reads, so you can configure each credential correctly the first time. The authority is the code: `src/lib/credential-cache.js` (`_processCredential`, `_extractHost`, `_parseExtras`) and the consumer of each credential.
+
+## How a credential is shaped
+
+When the agent fetches a credential by name, `_processCredential` decides its shape from the **name**:
+
+- **Simple credential** — the entry's **Password** field value is the entire credential. The agent receives a single string.
+- **Complex credential** — the agent builds an object from several NC Passwords fields. A credential is treated as complex when its name *contains* one of: `email-imap`, `email-smtp`, `caldav`, `oauth` (case-insensitive substring match). Everything else is simple.
+
+> **Naming matters.** The complex/simple decision is a substring match on the name. `email-imap` and `google-oauth` are complex; a credential you call `mailbox` or `gmail` is simple (just a password string) even if you fill in extra fields. Name OAuth credentials so the name contains `oauth`.
+
+### Where complex fields come from
+
+For a complex credential, the object is assembled from these NC Passwords fields:
+
+| Object field | Source NC Passwords field | Notes |
+|---|---|---|
+| `password` | Password | |
+| `username` / `user` | Username | `user` is an alias for `username` |
+| `host` | Website (URL) | Protocol stripped by `_extractHost` — `https://mail.example.com` becomes `mail.example.com` |
+| `url` | Website (URL) | The raw value, protocol intact |
+| `notes` | Notes | The raw text |
+| *extras* | Notes (if valid JSON) **and** Custom fields | See below |
+
+**Two surprising behaviors to know:**
+
+1. **The Notes field is only parsed as JSON.** If Notes contains valid JSON (e.g. `{"port": 993, "tls": true}`), each key is merged into the credential object. If it contains anything else — including `key=value` lines like `port=993` — it is kept as plain text and **ignored** for configuration. `key=value` notes do nothing.
+2. **Custom field values are always strings.** A custom field labelled `port` with value `993` arrives as the string `"993"`, not the number `993`. The consumers coerce as needed (`parseInt`, `=== 'true'`). Custom field labels are lower-cased before use, so `Port` and `port` are equivalent.
+
+Extras (Notes-JSON keys and custom fields) are merged **last**, so a custom field or JSON key named `host` or `url` overrides the value derived from the Website field. The Website field is the normal way to set the host; custom fields are the normal way to set everything else.
+
+---
+
+## Simple credentials
+
+For each of these, put the secret in the **Password** field and share the entry with `moltagent`. Username, Website, Notes, and custom fields are ignored.
+
+| Credential name | What goes in Password | Notes |
+|---|---|---|
+| `nc-talk-secret` | The 128-char hex secret from `talk:bot:install` | Must be byte-identical to the secret used when the Talk bot was registered (see [Quick Start](quickstart.md) Step 5) |
+| `nc-talk-room` | The Talk room token | The short string after `/call/` in the Talk URL when you are viewing the conversation. Tells the agent which room to listen in |
+| `claude-api-key` | Anthropic API key (starts with `sk-ant-`) | Only needed if a cloud role uses Anthropic |
+| `deepseek-api-key` | DeepSeek API key | Only needed if the DeepSeek provider is configured |
+
+Any other LLM provider key (OpenAI, Mistral, Groq, …) follows the same pattern: the entry name must match the `credentialName` in your `config/moltagent-providers.yaml` provider block, and the key goes in the Password field. See [Configuration](configuration.md) and [LLM Providers](providers.md).
+
+---
+
+## Complex credentials
+
+### `email-imap`
+
+Consumer: `src/lib/handlers/email-handler.js` (`_fetchEmails`).
+
+| NC Passwords field | Maps to | Example value | Required? |
+|---|---|---|---|
+| Password | `password` | (your IMAP password / app password) | Yes |
+| Username | `username` / `user` | `you@example.com` | Yes |
+| Website | `host` (protocol stripped) | `https://mail.example.com` | Yes |
+| Custom field `port` | `port` | `993` (TLS) or `143` (STARTTLS) | Recommended (defaults to 993) |
+| Custom field `starttls` | `starttls` | `true` | Only on port 143 |
+| Custom field `tls` | `tls` | `false` to force-disable TLS on 993 | Rarely needed |
+| Custom field `tlsSkipVerify` | `tlsSkipVerify` | `true` to accept a self-signed cert | Rarely needed |
+| Notes | reference only — **not** parsed unless valid JSON | — | No |
+
+**TLS is automatic from the port.** On port `993` the agent uses direct TLS without any extra field. On port `143` it uses STARTTLS automatically. You only need the `tls` / `starttls` fields to override these defaults.
+
+**Gmail:** host `imap.gmail.com`, port `993`, and use a Google [app password](https://support.google.com/accounts/answer/185833) (not your account password). **Outlook/Office 365:** host `outlook.office365.com`, port `993`.
+
+Equivalent configuration via JSON Notes instead of custom fields (either works):
+
+```json
+{"port": 993}
+```
+
+### `email-smtp`
+
+Consumer: `src/lib/handlers/email-handler.js` (`confirmSendEmail`).
+
+| NC Passwords field | Maps to | Example value | Required? |
+|---|---|---|---|
+| Password | `password` | (your SMTP password / app password) | Yes |
+| Username | `username` / `user` | `you@example.com` | Yes |
+| Website | `host` (protocol stripped) | `https://mail.example.com` | Yes |
+| Custom field `port` | `port` | `587` (STARTTLS) or `465` (implicit TLS) | Recommended (defaults to 587) |
+| Custom field `from` | `from` | `Your Name <you@example.com>` | No — defaults to the username |
+| Notes | reference only — **not** parsed unless valid JSON | — | No |
+
+**TLS is derived from the port.** Port `465` uses implicit TLS; port `587` uses STARTTLS. There is no separate field to set.
+
+**Gmail:** host `smtp.gmail.com`, port `587`. **Outlook/Office 365:** host `smtp.office365.com`, port `587`.
+
+### `caldav`
+
+**You normally do not create a `caldav` credential.** The calendar integration (`src/lib/integrations/caldav-client.js`) authenticates as the `moltagent` Nextcloud user itself — it reuses the NC account password that systemd loads from the credential store (`/etc/credstore/moltagent-nc-password`) and talks to `remote.php/dav/calendars/<moltagent-user>/`. No separate `caldav` entry in NC Passwords is read by the current code.
+
+`caldav` remains in the complex-credential list so that a future external-CalDAV consumer would receive the same `{password, username, host, url, …}` object shape as email. If that path is added, this section will document the fields it reads. For Nextcloud-hosted calendars today, just make sure the `moltagent` user's calendar is shared as described in the [Deployment Guide](deployment.md#calendar-setup).
+
+### `oauth`
+
+Consumer: `src/skill-forge/oauth-broker.js`. Used by SkillForge tools that call OAuth 2.0 APIs (Google, Microsoft, GitHub, …). The credential name is chosen per skill and **must contain the substring `oauth`** (e.g. `google-oauth`) so it is treated as complex.
+
+| NC Passwords field | Maps to | Example value | Required? |
+|---|---|---|---|
+| Password | `client_secret` | (the OAuth app client secret) | Yes |
+| Username | `client_id` (via `username` / `user`) | `1234567890-abc.apps.example.com` | Yes |
+| Website | `token_endpoint` (via the raw `url`) | `https://oauth2.example.com/token` | Yes |
+| Notes | token state, as JSON — **managed by the agent** | — | No (leave empty) |
+
+Note that OAuth reads the **raw `url`** (full token endpoint, protocol intact), not the protocol-stripped `host` that email uses. After the consent flow completes, the agent writes the access/refresh tokens back into the Notes field as JSON. Leave Notes empty when you create the entry; do not hand-edit it afterward.
+
+---
+
+## Sharing and access
+
+Every credential the agent uses must be **shared with the `moltagent` user** in NC Passwords. The agent can only see entries shared with it.
+
+Keep anything the agent should never touch (banking, admin passwords, HR systems) in folders that are **not** shared with `moltagent`. The trust boundary is enforced by sharing: what isn't shared can't be read.
+
+## Troubleshooting
+
+- **"Email not configured" / empty IMAP result, but the entry exists.** Most often the host is missing because the **Website** field is empty, or the port is missing because it was written as `key=value` lines in Notes (which are ignored). Set the Website field and add `port` as a custom field (or valid JSON in Notes).
+- **Credential not found at all.** Confirm the entry is shared with `moltagent` and that the name matches exactly (the lookup also matches the entry's Username and is case-insensitive on the label).
+- **OAuth credential "incomplete".** The broker needs all three of Username (`client_id`), Password (`client_secret`), and Website (`token_endpoint`).
+
+## See also
+
+- [Quick Start](quickstart.md) — initial credential setup
+- [Deployment Guide](deployment.md#credential-organization-in-nc-passwords) — credential organization and email setup
+- [Security Model](security-model.md) — trust boundaries and credential brokering

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,6 +40,8 @@ The agent probes each optional integration at startup. If the app or its credent
 
 Create the following entries in the Passwords app and share them with the `moltagent` user. The folder structure is optional but recommended for organization.
 
+For the exact field-by-field mapping of every credential — which NC Passwords fields the code reads and how — see the [Credential Format Reference](credentials.md). Read it before configuring `email-imap`, `email-smtp`, or `oauth`: the host and port do not go where you might expect, and `key=value` lines in the Notes field are silently ignored.
+
 **LLM Providers (share with moltagent):**
 
 | Entry name | Value | Notes |
@@ -54,8 +56,9 @@ Add entries for any additional providers you want to use (OpenAI, Mistral, Groq,
 | Entry name | Value | Notes |
 |-----------|-------|-------|
 | `nc-talk-secret` | The 128-char hex secret from Talk bot registration | Generated during setup |
-| `email-imap` | Your IMAP credentials | See Email Setup below |
-| `email-smtp` | Your SMTP credentials | See Email Setup below |
+| `nc-talk-room` | The Talk room token (the string after `/call/` in the room URL) | Tells the agent which conversation to listen in |
+| `email-imap` | Your IMAP credentials | See Email Setup below and the [Credential Format Reference](credentials.md#email-imap) |
+| `email-smtp` | Your SMTP credentials | See Email Setup below and the [Credential Format Reference](credentials.md#email-smtp) |
 
 **Never share with moltagent:**
 
@@ -281,36 +284,30 @@ engines:
 
 Moltagent can read and manage email via IMAP/SMTP. Store credentials in NC Passwords.
 
+> **Field placement matters.** The host goes in the **Website** field, and the port goes in a **custom field** named `port` (or as valid JSON in Notes). Plain `key=value` lines in the Notes field are **ignored** by the code — this is the most common email-setup mistake. The full field-by-field mapping is in the [Credential Format Reference](credentials.md#email-imap).
+
 ### Option A: Shared access (read your existing mailbox)
 
 Create two entries in NC Passwords:
 
 **Entry: `email-imap`**
-- Username: your email address
+- Username: your email address (e.g. `you@example.com`)
 - Password: your email password (or app password for Gmail/Outlook)
-- In the Notes field:
-  ```
-  host=imap.gmail.com
-  port=993
-  tls=true
-  ```
+- Website: `imap.example.com` (e.g. `imap.gmail.com` — the protocol is stripped automatically)
+- Custom field `port`: `993` (TLS is automatic on 993; use `143` with a custom field `starttls` = `true` for STARTTLS)
 
 **Entry: `email-smtp`**
 - Username: your email address
 - Password: same password
-- In the Notes field:
-  ```
-  host=smtp.gmail.com
-  port=587
-  tls=true
-  from=Your Name <you@gmail.com>
-  ```
+- Website: `smtp.example.com` (e.g. `smtp.gmail.com`)
+- Custom field `port`: `587` (STARTTLS) or `465` (implicit TLS)
+- Custom field `from` (optional): `Your Name <you@example.com>`
 
 Share both entries with the `moltagent` user.
 
-**Gmail users:** Create an app password at Google Account > Security > 2-Step Verification > App passwords.
+**Gmail users:** host `imap.gmail.com` / `smtp.gmail.com`. Create an app password at Google Account > Security > 2-Step Verification > App passwords.
 
-**Outlook users:** Use `outlook.office365.com` (IMAP) and `smtp.office365.com` (SMTP).
+**Outlook users:** Use `outlook.office365.com` (IMAP) and `smtp.office365.com` (SMTP), port `993` / `587`.
 
 ### Option B: Dedicated email for the agent
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,9 +78,11 @@ for dir in Moltagent Moltagent/Inbox Moltagent/Outbox Moltagent/Logs Moltagent/M
 done
 ```
 
-5. Store your LLM API keys in NC Passwords:
-   - Create entries named `claude-api-key`, `deepseek-api-key`, etc.
+5. Store your credentials in NC Passwords:
+   - Create entries named `claude-api-key`, `deepseek-api-key`, etc. for your LLM API keys
+   - You will also create `nc-talk-secret` and `nc-talk-room` in Step 5 (Talk bot registration)
    - Share each entry with the `moltagent` user
+   - See the [Credential Format Reference](credentials.md) for the exact fields each credential needs — especially for complex credentials like `email-imap` and `email-smtp`, where the host and port live in specific fields
 
 ## Step 3: Set Up Ollama VM
 
@@ -231,7 +233,8 @@ Once Hetzner confirms the bot is registered:
 1. Create a new Talk room in Nextcloud (or use an existing one)
 2. Add the Moltagent bot to the room
 3. Note the room token from the URL (the part after `/call/`)
-4. Ensure your Bot VM firewall allows inbound connections from the Storage Share IP on port 3000
+4. Store the room token as an `nc-talk-room` entry in NC Passwords (put the token in the Password field) and share it with the `moltagent` user. This tells the agent which conversation to listen in.
+5. Ensure your Bot VM firewall allows inbound connections from the Storage Share IP on port 3000
 
 ### Test
 


### PR DESCRIPTION
## What

Documents the contract between NC Passwords entries and the credential-loading code, and fixes the existing email setup docs that instructed a format the code ignores.

**Source:** a self-hoster configured `email-imap` with `host=`/`port=` as `key=value` lines in the Notes field — which `_parseExtras` silently ignores (it parses Notes only as JSON, or reads NC Passwords custom fields). The result was an empty IMAP error with no explanation. The existing `deployment.md` Email Setup actively taught this broken format.

## Changes (docs only)

- **New `docs/credentials.md`** — one section per credential, mapping each NC Passwords UI field to what the code reads. Verified against `credential-cache.js` (`_processCredential`, `_extractHost`, `_parseExtras`) and each consumer (`email-handler.js`, `oauth-broker.js`, `caldav-client.js`). Calls out the three surprising behaviors:
  - Notes is parsed **only** as JSON — `key=value` lines do nothing
  - custom-field values arrive as **strings**, not typed
  - the Website field's protocol is **stripped** for `host`
  - Documents honestly that **`caldav` reads no separate credential** today — the calendar client authenticates as the `moltagent` NC user via the standard NC request path.
- **`docs/deployment.md`** — replaced the broken `key=value` Notes instructions with the real format (host in Website, port as a custom field); linked the reference; added `nc-talk-room` to the credential table.
- **`docs/quickstart.md`** — added the `nc-talk-room` entry (previously never mentioned, so installers never created it) and linked the reference from Step 2.
- **`README.md`** — added Credentials to the docs index.

## Notes for reviewer

- The briefing attributed this to "Discussion #72," but that discussion is actually about the `config/` folder location. The credential-format gap is real and independent of the discussion number — verified directly against the code. Flagging the attribution mismatch for the record.
- Fixing the `deployment.md` Email Setup section goes slightly beyond "create a new page," but leaving it would have left two contradictory docs and perpetuated the root cause (Rule 2: fix the generator).

## Verification

- All credential names match `_processCredential`'s complex list (`email-imap`, `email-smtp`, `caldav`, `oauth`).
- Field mappings verified against `_extractHost` / `_parseExtras` and consumers.
- Cross-reference anchors resolve to real sections.
- Privacy pass: only `example.com` / `gmail.com` / `office365.com` placeholders, no real PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)