### PR TITLE
fix(security): log ToolGuard firing in executor guardrail path (#83)

### DIFF
--- a/src/lib/agent/executors/base-executor.js
+++ b/src/lib/agent/executors/base-executor.js
@@ -128,6 +128,7 @@ class BaseExecutor {
       const guardResult = this.toolGuard.evaluate(toolName);
       if (!guardResult.allowed) {
         if (guardResult.level === 'APPROVAL_REQUIRED' && this.guardrailEnforcer) {
+          this.logger.info(`[${this.constructor.name}] ToolGuard APPROVAL_REQUIRED → HITL: ${toolName}`);
           const approvalResult = await this.guardrailEnforcer.checkApproval(
             toolName, toolArgs, roomToken, []
           );
@@ -136,6 +137,7 @@ class BaseExecutor {
           }
           // Approved — fall through to GuardrailEnforcer.check()
         } else {
+          this.logger.warn(`[${this.constructor.name}] ToolGuard blocked: ${toolName} — ${guardResult.reason}`);
           return { allowed: false, reason: guardResult.reason || 'Blocked by security policy' };
         }
       }


### PR DESCRIPTION
Closes #83 (verification gap) — observability only, no control-flow change.

## Diagnosis (read-only first)

#83 worried ToolGuard was silently skipped for `deck_delete_card`, leaving the system reliant on prompt + structural-marker guards. Read-only trace + live evidence showed the opposite — **ToolGuard is wired and fires in all three agent execution paths**:

| Path | evaluate() before execute() | Logs when it fires? |
|---|---|---|
| `AgentLoop._executeWithGuards` | `agent-loop.js:598` → `:645` | ✅ 610/617/622 |
| `MicroPipeline._executeWithGuards` | `micro-pipeline.js:807` → `:835` | ✅ 814/819 |
| `BaseExecutor._checkGuardrails` (DeckExecutor etc.) | `base-executor.js:128` → `deck-executor.js:1267` | ❌ **silent** |

Live startup logs confirm `toolGuard` non-null on all three (`AgentLoop ready` + `Wired ToolGuard into MicroPipeline`). `_normalizeOperation('deck_delete_card')` maps cleanly into `REQUIRES_APPROVAL` → `APPROVAL_REQUIRED`.

So #83 was an **observability gap, not a wiring gap**: the structured executor path produced no signal, so verification couldn't see ToolGuard hit.

## Change

Two log lines in `BaseExecutor._checkGuardrails`, matching the sibling paths, prefixed with the subclass name (`[DeckExecutor]`):
- `ToolGuard APPROVAL_REQUIRED → HITL` — fires on every gated attempt (the grep-able "it fired" signal)
- `ToolGuard blocked` — hard block when no enforcer is present

## Verification

- `npm run test:unit` → **218/218** test files pass
- `npx eslint` on the file → 0 errors
- Acceptance for #83 becomes a log grep: a `deck_delete_card` attempt now emits `[DeckExecutor] ToolGuard APPROVAL_REQUIRED → HITL: deck_delete_card`. **Live Talk confirmation still owed** (no delete occurred in the last 15h uptime to mine retroactively).

## Scope

Observability only. The remaining defense-in-depth concern — the path where the agent emits hallucinated prose instead of a `deck_delete_card` tool call (nothing for any guard to evaluate) — is #85, handled next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)