### PR TITLE
chore: ignore .claude/settings.local.json at any depth (#94 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ Thumbs.db
 # But ignore ephemeral Claude state
 .claude/agent-memory/
 .claude/*.jsonl
-.claude/settings.local.json
+# Machine-local CC permission state — ignore at any depth (nested dirs get their own)
+**/.claude/settings.local.json
 
 # --- Test & Coverage ---
 coverage/


### PR DESCRIPTION
Follow-up to #94 (PR #94).

## Why

PR #94 was meant to do two things: remove the leaked nested `ansible/.claude/settings.local.json` **and** broaden the `.gitignore` pattern so nested CC permission files can't be committed again. Only the file removal actually merged — the `.gitignore` edit was never `git add`'d, so the merge commit contains just the 49-line deletion. The root-anchored pattern `.claude/settings.local.json` does not match nested paths; on the bot VM this is masked only by a machine-global `~/.config/git/ignore`, which a fresh contributor clone wouldn't have.

## Change

`.claude/settings.local.json` → `**/.claude/settings.local.json` (one line + a comment).

## Verification

```
$ git -c core.excludesfile=/dev/null check-ignore -v ansible/.claude/settings.local.json
.gitignore:55:**/.claude/settings.local.json	ansible/.claude/settings.local.json
$ git -c core.excludesfile=/dev/null check-ignore -v foo/bar/.claude/settings.local.json
.gitignore:55:**/.claude/settings.local.json	foo/bar/.claude/settings.local.json
```

The repo rule alone (global ignore disabled) now matches nested paths at any depth. No tracked files affected (`git ls-files | grep settings.local.json` → none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)