### PR TITLE
fix(security): ungate HITL-marker guard, share across both engines (#85)

### DIFF
--- a/src/lib/agent/action-guard.js
+++ b/src/lib/agent/action-guard.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { HITL_PROMPT_MARKER } = require('./guardrail-enforcer');
+
+/**
+ * ActionGuard - Shared action-hallucination detection
+ *
+ * The HITL approval ceremony (the 🔐 marker codepoint) is owned exclusively by
+ * GuardrailEnforcer's Talk surface. When an LLM stages that ceremony in its own
+ * response *text* — instead of calling the destructive tool and letting the
+ * enforcer own the approval prompt — the user sees a fake approval that never
+ * executes (#81, #85).
+ *
+ * This module is the single structural predicate both execution engines
+ * (AgentLoop and MicroPipeline) share, so the detection is identical regardless
+ * of which engine produced the response or how the turn was gated. It is
+ * language-free: it keys only on the reserved marker codepoint, never on
+ * natural-language phrasing.
+ *
+ * A response staging the marker is *always* illegitimate — at any gate. A
+ * confirmation follow-up ("lösch den dritten") classifies as gate=confirmation,
+ * not gate=action, so a gate-conditional check would miss it; the marker check
+ * must therefore be unconditional. The "no tool call on an action turn" signal
+ * stays gate-conditional and lives in the caller.
+ *
+ * @module agent/action-guard
+ */
+
+/**
+ * True when a response stages the HITL approval ceremony in its own text
+ * instead of letting GuardrailEnforcer own that surface.
+ *
+ * @param {string} content - Rendered response text
+ * @returns {boolean}
+ */
+function stagesApprovalCeremony(content) {
+  return typeof content === 'string' && content.includes(HITL_PROMPT_MARKER);
+}
+
+/**
+ * Remove the reserved HITL marker codepoint from a response. Terminal
+ * belt-and-suspenders: the re-prompt should already have steered the model into
+ * calling the tool, but if a misbehaving model stages the marker again on the
+ * re-prompted pass, this guarantees the codepoint never reaches the user (the
+ * structural invariant the marker contract depends on). The deeper "don't emit
+ * the ceremony prose at all" fix is the structured-pending-action work.
+ *
+ * @param {string} content
+ * @returns {string} content with the marker removed (non-strings returned as-is)
+ */
+function stripApprovalMarker(content) {
+  return typeof content === 'string' ? content.split(HITL_PROMPT_MARKER).join('') : content;
+}
+
+/**
+ * Corrective directive injected when an action turn produced no state-changing
+ * tool call, or staged a fake approval ceremony. Shared so both engines speak
+ * with one voice when re-prompting.
+ */
+const ACTION_REPROMPT_DIRECTIVE =
+  '[SYSTEM] You were asked to perform an action but did not issue the state-changing tool call. ' +
+  'The guardrail system handles approval prompts on its own surface — do not stage them in your response. ' +
+  'If you can perform the action, call the appropriate tool now. If you cannot, explain what prevented you. ' +
+  'Do not describe a result the tool has not returned.';
+
+module.exports = { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE };

--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { extractArtifact } = require('./artifact-extractor');
-const { HITL_PROMPT_MARKER } = require('./guardrail-enforcer');
+const { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
 
 /**
  * AgentLoop - The Nervous System
@@ -322,9 +322,14 @@ class AgentLoop {
       // text-only refusals on the second pass ("I can't because…") are not
       // re-prompted again. maxIter is bumped to guarantee at least one more
       // iteration even when the short-message heuristic capped it at 2.
-      const responseStagesApproval = (response.content || '').includes(HITL_PROMPT_MARKER);
-      const noToolCallsYet = toolResultIndices.length === 0;
-      if (options.gate === 'action' && !actionGuardFired && (noToolCallsYet || responseStagesApproval)) {
+      // Marker staging is illegitimate at ANY gate — the 🔐 codepoint belongs to
+      // GuardrailEnforcer's Talk surface, never a model response. A confirmation
+      // follow-up ("lösch den dritten") classifies as gate=confirmation, so gating
+      // this on action would miss the #85 leak. The no-tool-call signal stays
+      // gate=action (a knowledge turn legitimately produces no tool call).
+      const responseStagesApproval = stagesApprovalCeremony(response.content);
+      const actionWithoutToolCall = options.gate === 'action' && toolResultIndices.length === 0;
+      if (!actionGuardFired && (actionWithoutToolCall || responseStagesApproval)) {
         actionGuardFired = true;
         maxIter = Math.max(maxIter, iteration + 1);
 
@@ -334,11 +339,13 @@ class AgentLoop {
         });
         messages.push({
           role: 'user',
-          content: '[SYSTEM] You were asked to perform an action but did not issue the state-changing tool call. The guardrail system handles approval prompts on its own surface — do not stage them in your response. If you can perform the action, call the appropriate tool now. If you cannot, explain what prevented you. Do not describe a result the tool has not returned.'
+          content: ACTION_REPROMPT_DIRECTIVE
         });
 
-        const reason = noToolCallsYet ? 'zero tool calls' : 'response staged HITL marker without destructive tool call';
-        this.logger.warn(`[AgentLoop] Action-hallucination guard fired at iteration ${iteration} — re-prompting (gate=action, ${reason})`);
+        const reason = responseStagesApproval
+          ? 'response staged HITL marker without destructive tool call'
+          : 'zero tool calls (gate=action)';
+        this.logger.warn(`[AgentLoop] Action-hallucination guard fired at iteration ${iteration} — re-prompting (${reason})`);
         continue;
       }
 
@@ -387,6 +394,15 @@ class AgentLoop {
         this.logger.warn(`[AgentLoop] SecretsGuard redacted ${scanResult.findings.length} finding(s)`);
         lastResponse = scanResult.sanitized;
       }
+    }
+
+    // Terminal HITL-marker strip: the re-prompt guard is bounded to one pass, so
+    // if a misbehaving model stages the 🔐 marker again afterward it would fall
+    // through. Strip it here so the reserved codepoint never reaches the user —
+    // the structural invariant the marker contract relies on (#85).
+    if (stagesApprovalCeremony(lastResponse)) {
+      this.logger.warn('[AgentLoop] HITL marker survived the re-prompt — stripping from final response (model staged ceremony twice)');
+      lastResponse = stripApprovalMarker(lastResponse);
     }
 
     const elapsed = Date.now() - startTime;

--- a/src/lib/agent/micro-pipeline.js
+++ b/src/lib/agent/micro-pipeline.js
@@ -15,6 +15,7 @@
 
 const { buildMicroContext } = require('./micro-pipeline-context');
 const { extractArtifact } = require('./artifact-extractor');
+const { stagesApprovalCeremony } = require('./action-guard');
 
 const INTENTS = Object.freeze({
   QUESTION: 'question',
@@ -181,6 +182,20 @@ class MicroPipeline {
         } else {
           result = { response: result, enrichmentBlock: _enrichmentBlock };
         }
+      }
+
+      // Action-hallucination guard (shared with AgentLoop): the 🔐 marker is
+      // reserved for GuardrailEnforcer's Talk surface and must never appear in a
+      // returned response. If a local handler staged the approval ceremony in
+      // prose instead of executing, escalate to AgentLoop — which has the real
+      // tool-calling loop and the same guard — rather than leaking the fake
+      // ceremony to the user (#85).
+      const responseText = (typeof result === 'object' && result !== null) ? result.response : result;
+      if (stagesApprovalCeremony(responseText)) {
+        this.logger.warn('[MicroPipeline] Action-hallucination guard fired — response staged HITL marker without executing; escalating to AgentLoop');
+        const escalateErr = new Error('Response staged HITL approval marker without executing the action');
+        escalateErr.code = 'DOMAIN_ESCALATE';
+        throw escalateErr;
       }
 
       return result;

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -774,6 +774,7 @@ class MessageProcessor {
               userName: extracted.user,
               roomToken: extracted.token,
               warmMemory: focusContext || '',
+              gate,
               onArtifact,
               getLastAction: session ? (dp) => this.sessionManager.getLastAction(session, dp) : undefined,
               getRecentActions: session ? (dp) => this.sessionManager.getRecentActions(session, dp) : undefined,

--- a/test/unit/agent/action-guard.test.js
+++ b/test/unit/agent/action-guard.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE } = require('../../../src/lib/agent/action-guard');
+const { HITL_PROMPT_MARKER } = require('../../../src/lib/agent/guardrail-enforcer');
+
+// -- Test 1: detects the reserved HITL marker anywhere in the content --
+test('stagesApprovalCeremony() is true when the response stages the 🔐 marker', () => {
+  const staged = `${HITL_PROMPT_MARKER} **Delete Deck card** — requires approval. Reply "approve".`;
+  assert.strictEqual(stagesApprovalCeremony(staged), true);
+});
+
+// -- Test 2: ordinary responses never trip the guard (no false positive) --
+test('stagesApprovalCeremony() is false for normal response text', () => {
+  assert.strictEqual(stagesApprovalCeremony('Deleted the card "Q3 planning".'), false);
+  assert.strictEqual(stagesApprovalCeremony('Ich habe die Karte gelöscht.'), false);
+  assert.strictEqual(stagesApprovalCeremony('Removi o cartão.'), false);
+});
+
+// -- Test 3: non-string inputs are safe (null/undefined/object) --
+test('stagesApprovalCeremony() is false for non-string inputs', () => {
+  assert.strictEqual(stagesApprovalCeremony(null), false);
+  assert.strictEqual(stagesApprovalCeremony(undefined), false);
+  assert.strictEqual(stagesApprovalCeremony({ response: 'x' }), false);
+  assert.strictEqual(stagesApprovalCeremony(42), false);
+});
+
+// -- Test 4: marker detection is language-free — only the codepoint matters --
+test('stagesApprovalCeremony() keys on the codepoint, not phrasing', () => {
+  // English ceremony phrasing WITHOUT the marker → not flagged (the marker, not
+  // the words, is the signal; word-matching would be a Rule 1 violation).
+  assert.strictEqual(stagesApprovalCeremony('This requires approval. Reply approve to allow.'), false);
+  // Marker with no surrounding ceremony words → still flagged.
+  assert.strictEqual(stagesApprovalCeremony(`x ${HITL_PROMPT_MARKER} y`), true);
+});
+
+// -- Test 5: the shared re-prompt directive is present and on-message --
+test('ACTION_REPROMPT_DIRECTIVE instructs calling the tool and not staging prompts', () => {
+  assert.strictEqual(typeof ACTION_REPROMPT_DIRECTIVE, 'string');
+  assert.ok(ACTION_REPROMPT_DIRECTIVE.length > 0);
+  assert.ok(ACTION_REPROMPT_DIRECTIVE.includes('[SYSTEM]'));
+  assert.ok(/tool/i.test(ACTION_REPROMPT_DIRECTIVE));
+});
+
+// -- Test 6: stripApprovalMarker removes every marker occurrence --
+test('stripApprovalMarker() removes the marker codepoint and leaves the rest', () => {
+  const dirty = `${HITL_PROMPT_MARKER} a ${HITL_PROMPT_MARKER} b`;
+  const cleaned = stripApprovalMarker(dirty);
+  assert.strictEqual(stagesApprovalCeremony(cleaned), false);
+  assert.ok(cleaned.includes('a') && cleaned.includes('b'));
+});
+
+// -- Test 7: stripApprovalMarker is a no-op on clean / non-string input --
+test('stripApprovalMarker() leaves clean strings and non-strings untouched', () => {
+  assert.strictEqual(stripApprovalMarker('all good'), 'all good');
+  assert.strictEqual(stripApprovalMarker(null), null);
+  assert.strictEqual(stripApprovalMarker(undefined), undefined);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1621,6 +1621,58 @@ asyncTest('action-hallucination guard does NOT fire when read-only tool runs and
   assert.strictEqual(provider._getCallCount(), 2);  // no re-prompt
 });
 
+asyncTest('action-hallucination guard: HITL marker fires at gate=confirmation (#85 — destructive intent via follow-up turn)', async () => {
+  // #85: a destructive follow-up ("lösch den dritten") classifies as
+  // gate=confirmation, NOT gate=action. The original guard gated the 🔐 marker
+  // check on gate==='action', so the staged ceremony leaked. The marker is
+  // reserved for GuardrailEnforcer's surface and is illegitimate at ANY gate —
+  // the check must fire here and re-prompt into a real tool call.
+  const provider = createMockProvider([
+    { content: '\u{1F510} **Delete Deck card** — requires approval\n\nCard: **#3 "third"**', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_delete_card', arguments: { card: '#3' } }] },
+    { content: 'Deleted card #3.', toolCalls: null }
+  ]);
+
+  let destructiveCalled = false;
+  const registry = createMockToolRegistry({
+    deck_delete_card: async () => { destructiveCalled = true; return { success: true, result: 'Deleted #3' }; }
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('lösch den dritten', 'room-abc', { gate: 'confirmation' });
+  assert.strictEqual(destructiveCalled, true, 'marker guard must fire at gate=confirmation and re-prompt into the tool call');
+  assert.strictEqual(response, 'Deleted card #3.');
+});
+
+asyncTest('terminal strip: 🔐 marker never reaches the user even if staged twice (re-prompt exhausted)', async () => {
+  // Worst case: the model stages the ceremony, gets re-prompted once, then stages
+  // it AGAIN. The guard is bounded to one re-prompt, so the second marker falls
+  // through — the terminal sanitizer must strip it so the codepoint never ships.
+  const marker = '\u{1F510}';
+  const provider = createMockProvider([
+    { content: `${marker} **Delete Deck card** — requires approval`, toolCalls: null },
+    { content: `${marker} Still waiting for your approval to delete.`, toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete card 3', 'room-abc', { gate: 'action' });
+  assert.ok(!response.includes(marker), 'final response must not contain the reserved HITL marker');
+});
+
 // ============================================================
 // Cleanup & Summary
 // ============================================================


### PR DESCRIPTION
Closes #85. Follow-up architecture work filed as #104.

## Diagnosis (corrected during read-only tracing)

#85's three hypotheses pointed at the MicroPipeline confirmation branch. Tracing the **live** production path (smart-mix mode — local + cloud Haiku both wired) showed something more precise:

- A destructive follow-up ("lösch den dritten") classifies as **`gate='confirmation'`** (intent-router), not `gate='action'`.
- `_smartMixClassify` routes confirmations with `useLocal:false` → **AgentLoop Path 5** (`message-processor.js:955`), passing `gate:'confirmation'`. (The `useLocal && useDomainTools && intent==='confirmation'` branch at 764 is unreachable in smart-mix.)
- AgentLoop's action-hallucination guard gated its 🔐-marker check behind **`gate === 'action'`** — so for confirmations it never fired. The model could stage a fake approval ceremony in prose and the destructive tool was never called.

**Root cause is altitude, not a missing guard.** The 🔐 codepoint is reserved for GuardrailEnforcer's Talk surface and is illegitimate in *any* rendered response, at any gate. Gating it on action was the bug.

## Fix (Option B — shared guard, ungate the marker check)

| File | Change |
|---|---|
| `action-guard.js` (new) | Shared, language-free `stagesApprovalCeremony()` + `stripApprovalMarker()` + `ACTION_REPROMPT_DIRECTIVE`. One predicate both engines use. |
| `agent-loop.js` | Marker check now **unconditional** (fires at any gate); no-tool-call signal stays `gate=action`. **Terminal strip** in the output-sanitize block so the marker never reaches the user even if staged again after the one-shot re-prompt. |
| `micro-pipeline.js` | Post-processing marker check → `DOMAIN_ESCALATE` to AgentLoop instead of returning a fake ceremony. |
| `message-processor.js` | Pass `gate` to the confirmation branch's `microPipeline.process()`. |

## Why no false positives

`HITL_PROMPT_MARKER` is only ever emitted via `talkSendQueue.enqueue()` (guardrail-enforcer.js:415,897) — its own surface. Returned `{allowed,reason}` objects carry plain-text reasons only. So a legitimate approval never puts the marker in `response.content`; the guard fires only on genuine prose-staging.

## Verification

- `npm run test:unit` → **219/219** files pass; `npx eslint` → 0 errors.
- New tests: marker fires at `gate=confirmation` (#85 regression); terminal strip when the model stages it twice; `stripApprovalMarker` unit coverage; language-free detection (Rule 1).
- Reviewer agent: PASS — flagged the second-pass residual, which the terminal strip now closes.
- **Live Talk confirmation in DE/PT still owed** (human Fu): multi-turn "what cards?" → "lösch den dritten" → card actually deletes or surfaces a real failure, no staged ceremony.

## Scope

Closes the #85 *symptom* (marker can no longer leak). The *root* — confirmations executing a structured pending tool call instead of re-interpreting offer prose, which also covers the "claims success without marker or tool call" residual — is filed as **#104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)