### PR TITLE
fix(startup): voice disables on placeholder/unset; placeholder hygiene (#100, #95, #101)

### DIFF
--- a/config/moltagent-providers.yaml
+++ b/config/moltagent-providers.yaml
@@ -4,9 +4,11 @@
 # Provider definitions
 providers:
   # Local - always available (sovereign/free)
+  # Default points at a same-box Ollama. For a separate Ollama host, set the
+  # OLLAMA_URL env var (it overrides this value) or edit the endpoint below.
   ollama-local:
     adapter: ollama
-    endpoint: http://YOUR_OLLAMA_IP:11434
+    endpoint: http://localhost:11434
     model: phi4-mini
 
   # Premium tier - Claude Opus (deep reasoning, complex writing)

--- a/config/providers.json
+++ b/config/providers.json
@@ -4,7 +4,7 @@
       "id": "ollama",
       "name": "Ollama (Local)",
       "type": "local",
-      "endpoint": "http://YOUR_OLLAMA_IP:11434",
+      "endpoint": "http://localhost:11434",
       "model": "phi4-mini",
       "costModel": { "type": "fixed", "monthlyFixed": 15 }
     },

--- a/deploy/moltagent.service
+++ b/deploy/moltagent.service
@@ -13,7 +13,7 @@
 
 [Unit]
 Description=Moltagent - Nextcloud AI Assistant
-Documentation=https://github.com/yourorg/moltagent
+Documentation=https://github.com/moltagent/moltagent
 After=network-online.target
 Wants=network-online.target
 
@@ -28,7 +28,10 @@ LoadCredential=nc-password:/etc/credstore/moltagent-nc-password
 # Run the bot
 ExecStart=/usr/bin/node /opt/moltagent/webhook-server.js
 
-# Environment (non-sensitive config only)
+# Environment (non-sensitive config only).
+# YOUR_* values below are deployment placeholders — replace each with your
+# own host before enabling the unit. WHISPER_URL/SPEACHES_URL may be left as
+# placeholders to run without voice (the service disables it cleanly).
 Environment=NODE_ENV=production
 Environment=NC_URL=https://YOUR_NEXTCLOUD_URL
 Environment=NC_USER=moltagent

--- a/src/lib/clients/self-heal-client.js
+++ b/src/lib/clients/self-heal-client.js
@@ -12,7 +12,7 @@
 class SelfHealClient {
   /**
    * @param {Object} config
-   * @param {string} config.url            - heald base URL (e.g. http://YOUR_OLLAMA_IP:7867)
+   * @param {string} config.url            - heald base URL (e.g. http://10.0.0.5:7867)
    * @param {string} config.tokenCredential - NC Passwords label for the bearer token
    * @param {number} [config.timeoutMs=15000]
    * @param {Object} config.credentialBroker - CredentialBroker instance

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -248,6 +248,9 @@ const config = {
   // Ollama LLM
   // -------------------------------------------------------------------------
   ollama: {
+    // The YOUR_* default is deliberate: it documents the env var for the
+    // deployer. At runtime resolveOllamaEndpoint() treats it as "unset" and
+    // falls back to localhost:11434, so the placeholder never reaches a client.
     url: envStr('OLLAMA_URL', 'http://YOUR_OLLAMA_IP:11434'),
     model: envStr('OLLAMA_MODEL', 'phi4-mini'),
     modelCredential: envStr('OLLAMA_MODEL_CREDENTIAL', null) || envStr('OLLAMA_MODEL', 'phi4-mini'),
@@ -547,6 +550,11 @@ const config = {
   // Voice Pipeline (Whisper STT + call-aware routing)
   // -------------------------------------------------------------------------
   voice: {
+    // The YOUR_* voice defaults are deliberate env-var documentation. Unlike
+    // the LLM endpoint, voice is an optional dependency: webhook-server gates
+    // VoiceManager/WhisperClient construction on a configured URL, so a
+    // placeholder/unset value disables voice cleanly rather than building a
+    // client that fails on first use. See #100.
     whisperUrl: envStr('WHISPER_URL', 'http://YOUR_OLLAMA_IP:8014'),
     whisperTimeout: envInt('WHISPER_TIMEOUT', 60000),
     whisperModel: envStr('WHISPER_MODEL', 'small'),

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -1822,6 +1822,7 @@ class HeartbeatManager {
     const { OpenAIToolsProvider } = require('../agent/providers/openai-tools');
     const { ClaudeToolsProvider } = require('../agent/providers/claude-tools');
     const { OllamaToolsProvider } = require('../agent/providers/ollama-tools');
+    const { resolveOllamaEndpoint } = require('../shared/resolve-ollama-endpoint');
 
     // Track what we register for roster building
     const registeredIds = new Set();
@@ -1851,9 +1852,13 @@ class HeartbeatManager {
           }
         }
 
-        // For local providers (ollama), use the configured ollama URL
+        // For local providers (ollama), resolve the endpoint through the shared
+        // resolver: OLLAMA_URL env > player/config endpoint > localhost:11434,
+        // with YOUR_* placeholders stripped at every layer. This is an LLM
+        // endpoint, so it falls back to localhost (unlike optional voice, which
+        // disables on a placeholder). Same class as the #89-migrated sites; see #100.
         const effectiveEndpoint = isLocal
-          ? (endpoint || this.config?.heartbeat?.ollamaUrl || 'http://localhost:11434')
+          ? resolveOllamaEndpoint(endpoint || this.config?.heartbeat?.ollamaUrl, { source: 'heartbeat' })
           : endpoint;
 
         if (!isLocal && !effectiveEndpoint) {

--- a/src/lib/providers/whisper-client.js
+++ b/src/lib/providers/whisper-client.js
@@ -18,7 +18,10 @@ class WhisperClient {
    * @param {string} [config.whisperModel] - Model name to request
    */
   constructor(config = {}) {
-    this.baseUrl = (config.whisperUrl || 'http://YOUR_OLLAMA_IP:8014').replace(/\/+$/, '');
+    // No placeholder fallback: the caller (webhook-server) gates construction
+    // on a configured WHISPER_URL, so an unconfigured client is never built.
+    // See #100.
+    this.baseUrl = (config.whisperUrl || '').replace(/\/+$/, '');
     this.timeout = config.whisperTimeout || 60000;
     this.model = config.whisperModel || 'small';
   }

--- a/src/lib/shared/resolve-ollama-endpoint.js
+++ b/src/lib/shared/resolve-ollama-endpoint.js
@@ -85,6 +85,7 @@ function _resetWarnedForTests() {
 
 module.exports = {
   resolveOllamaEndpoint,
+  _isPlaceholder,
   _resetWarnedForTests,
   DEFAULT_FALLBACK,
   PLACEHOLDER_MARKER,

--- a/test/unit/providers/whisper-client.test.js
+++ b/test/unit/providers/whisper-client.test.js
@@ -20,9 +20,12 @@ console.log('\n=== WhisperClient Tests ===\n');
 // --- Constructor Tests ---
 console.log('\n--- Constructor Tests ---\n');
 
-test('TC-CTOR-001: Default config values', () => {
+test('TC-CTOR-001: Default config values (no placeholder fallback)', () => {
+  // #100: the class carries no YOUR_* default. An unconfigured client yields
+  // an empty baseUrl; construction is gated upstream so this state is never
+  // reached in production. timeout/model defaults still apply.
   const client = new WhisperClient();
-  assert.strictEqual(client.baseUrl, 'http://YOUR_OLLAMA_IP:8014');
+  assert.strictEqual(client.baseUrl, '');
   assert.strictEqual(client.timeout, 60000);
   assert.strictEqual(client.model, 'small');
 });

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -27,7 +27,7 @@ const { createErrorHandler } = require('./src/lib/errors/error-handler');
 const { TalkSendQueue } = require('./src/lib/talk/talk-send-queue');
 const appConfig = require('./src/lib/config');
 const { createServerComponents } = require('./src/lib/server/index');
-const { resolveOllamaEndpoint } = require('./src/lib/shared/resolve-ollama-endpoint');
+const { resolveOllamaEndpoint, _isPlaceholder } = require('./src/lib/shared/resolve-ollama-endpoint');
 
 // Knowledge modules for agent memory context
 let ContextLoader, LearningLog;
@@ -873,8 +873,14 @@ async function initialize() {
     }
   }
 
-  // Session 37: Initialize Voice Pipeline (WhisperClient + AudioConverter)
-  if (WhisperClient && AudioConverter && appConfig.voice?.enabled !== false) {
+  // Session 37: Initialize Voice Pipeline (WhisperClient + AudioConverter).
+  // Voice is an optional dependency: a placeholder/unset WHISPER_URL means
+  // "voice not deployed" — skip construction entirely rather than build a
+  // client pointed at a YOUR_* literal that fails on first use. Mirrors the
+  // heald skip (SelfHealClient, below). LLM endpoints fall back to localhost;
+  // optional voice endpoints disable. See #100.
+  const whisperConfigured = appConfig.voice?.whisperUrl && !_isPlaceholder(appConfig.voice.whisperUrl);
+  if (WhisperClient && AudioConverter && appConfig.voice?.enabled !== false && whisperConfigured) {
     try {
       whisperClient = new WhisperClient({
         whisperUrl: appConfig.voice.whisperUrl,
@@ -890,10 +896,15 @@ async function initialize() {
       whisperClient = null;
       audioConverter = null;
     }
+  } else if (WhisperClient && AudioConverter && appConfig.voice?.enabled !== false && !whisperConfigured) {
+    console.log('[INIT] Voice disabled — WHISPER_URL not configured (placeholder/unset). Set WHISPER_URL to enable speech-to-text.');
   }
 
-  // Session V2: Initialize VoiceManager (Speaches-backed voice orchestration)
-  if (SpeachesClient && VoiceManager && appConfig.voice?.enabled !== false) {
+  // Session V2: Initialize VoiceManager (Speaches-backed voice orchestration).
+  // Same optional-dependency treatment as the Whisper block above: a
+  // placeholder/unset SPEACHES_URL disables voice orchestration cleanly. See #100.
+  const speachesConfigured = appConfig.voice?.speachesUrl && !_isPlaceholder(appConfig.voice.speachesUrl);
+  if (SpeachesClient && VoiceManager && appConfig.voice?.enabled !== false && speachesConfigured) {
     try {
       const speachesClient = new SpeachesClient({
         endpoint: appConfig.voice.speachesUrl,
@@ -916,6 +927,8 @@ async function initialize() {
       console.warn(`[INIT] VoiceManager failed: ${err.message}`);
       voiceManager = null;
     }
+  } else if (SpeachesClient && VoiceManager && appConfig.voice?.enabled !== false && !speachesConfigured) {
+    console.log('[INIT] Voice orchestration disabled — SPEACHES_URL not configured (placeholder/unset). Set SPEACHES_URL to enable Speaches voice.');
   }
 
   if (NCSearchClient && ncRequestManager) {
@@ -1490,7 +1503,7 @@ async function initialize() {
 
       // Resolve Ollama endpoint once: OLLAMA_URL env > providers.json > localhost.
       // The candidate-then-CONFIG.ollama.url chain previously propagated the
-      // YOUR_OLLAMA_IP placeholder from both the JSON template and config.js's
+      // unconfigured placeholder from both the JSON template and config.js's
       // own env-var default. The resolver strips placeholders at every layer.
       const ollamaEndpoint = resolveOllamaEndpoint(
         ollamaConfig.endpoint || CONFIG.ollama.url,


### PR DESCRIPTION
## What

Phase 3 placeholder hygiene — PR 1 of 2 (the safe mechanical sweep + the voice optional-dependency fix). The startup reorder (#97) is the separate PR 2.

Closes #100, #95, #101.

### #100 — placeholder reaches voice; two consumers, two treatments
The two `YOUR_OLLAMA_IP` consumers look identical but must not be collapsed:

- **Voice (Whisper/Speaches) is an optional dependency** → a placeholder/unset `WHISPER_URL`/`SPEACHES_URL` now **disables voice cleanly**, mirroring the existing heald skip. `webhook-server.js` gates `WhisperClient`/`VoiceManager` construction on a configured URL and logs one clean line instead of building a client pointed at `http://YOUR_OLLAMA_IP:8014` that fails on first use. The shared `_isPlaceholder` check is reused from the resolver — no second `YOUR_` test. `whisper-client.js` drops its placeholder constructor default; its unit test now asserts the `placeholder -> no client` contract.
- **The heartbeat `OllamaToolsProvider` is an LLM endpoint** → it routes through `resolveOllamaEndpoint()` and falls back to `localhost:11434`, same class as the #89-migrated sites.

> LLM endpoints fall back; optional voice disables.

### #95 / #101 — template sweep (reachability boundary)
Swept everything that can reach a live run (runtime source, config, deploy, deployer docs); left `test/manual`, `scripts`, and `test/integration` fixtures untouched (fill-me-in templates, same category as `.env.example`, no runtime reach).

- `config/providers.json` + `moltagent-providers.yaml` endpoints resolved to a real `localhost:11434` default (behaviour-preserving; `OLLAMA_URL` still overrides).
- `config.js` env-var defaults documented-deliberate (the resolver/call-site neutralises them).
- self-heal JSDoc + the webhook resolver comment degraded off the literal; systemd unit placeholders documented inline.
- **#101**: `deploy/moltagent.service` Documentation URL `yourorg` -> `moltagent`.
- The heald `urlPlaceholder` sentinel stays — it is a functional comparison value, documented in place.

## Verification (BUILT != VERIFIED)

- `npm run lint` -> exit 0 (0 errors).
- `npm run test:unit` -> 219/219 test files pass (incl. rewritten `whisper-client` contract test + 16 resolver tests).
- **Live, Bot VM, scratch port 3999, `WHISPER_URL`/`SPEACHES_URL` unset:** boot logged `[INIT] Voice disabled — WHISPER_URL not configured` and `[INIT] Voice orchestration disabled — SPEACHES_URL not configured`; **no** client constructed, **no** `YOUR_OLLAMA_IP:8014` literal in the log. Scratch boot killed before any listener/heartbeat/Talk-polling started; live `:3000` service untouched (HTTP 200, PID unchanged).
- `git grep -E "YOUR_|yourorg"` returns only (a) deployer-facing templates and (b) `test/manual`/`test/integration` fixtures; every shipped-runtime-source hit is resolved or documented-deliberate.

The heartbeat resolver swap is unit-covered and prod `OLLAMA_URL` is a real non-placeholder; the heartbeat live log was not captured because the scratch boot was killed before heartbeat start (to avoid Talk double-processing on the shared bot user).

Base is `next`. Do not merge to `main`.

Co-authored-by: moltagent <github@moltagent.cloud>