### PR TITLE
fix(startup): bind HTTP listener before NC init so the port survives a stall (#97)

### DIFF
--- a/webhook-server.js
+++ b/webhook-server.js
@@ -513,6 +513,7 @@ let warmMemory = null; // Session M1: warm memory layer (WARM.md)
 let sessionCleanupTimer = null; // Periodic SessionManager cleanup
 let webhookErrorHandler = null;
 let serverComponents = null; // Decomposed server components (webhook, command, health, message processor)
+let initComplete = false; // #97: true once initialize() resolves. The open port carries reachability; this flag carries readiness.
 let heartbeatManager = null; // HeartbeatManager instance (proactive operations)
 let oauthBroker = null; // OAuth 2.0 broker for SkillForge token lifecycle
 let knowledgeBoard = null; // KnowledgeBoard for verification tracking
@@ -2429,12 +2430,15 @@ async function handleRequest(req, res) {
       serverComponents.healthHandler.handleHealth(req, res);
     } else {
       // Fallback if not initialized
+      // #97: the listener now binds before initialize(), so this fallback can be
+      // hit before signatureVerifier exists — guard the deref.
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         status: 'ok',
         service: 'moltagent-webhook',
         version: '2.0.0',
-        verifications: signatureVerifier.getStats().totalVerifications
+        initComplete,
+        verifications: signatureVerifier ? signatureVerifier.getStats().totalVerifications : 0
       }));
     }
     return;
@@ -2445,9 +2449,9 @@ async function handleRequest(req, res) {
     if (serverComponents && serverComponents.healthHandler) {
       serverComponents.healthHandler.handleStats(req, res);
     } else {
-      // Fallback if not initialized
+      // Fallback if not initialized (#97: may run before signatureVerifier exists)
       const stats = {
-        verifier: signatureVerifier.getStats(),
+        verifier: signatureVerifier ? signatureVerifier.getStats() : null,
         ncRequestManager: ncRequestManager ? ncRequestManager.getMetrics() : null
       };
       res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -2519,9 +2523,10 @@ async function handleRequest(req, res) {
     if (serverComponents && serverComponents.webhookHandler) {
       await serverComponents.webhookHandler.handle(req, res);
     } else {
-      // Fallback if not initialized
+      // #97: listener is up but init is still settling (e.g. under NC backoff).
+      // The null-guard owns correctness; this body just tells the caller to retry.
       res.writeHead(503, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Server not ready' }));
+      res.end(JSON.stringify({ error: 'Server starting up — initialization in progress, retry shortly' }));
     }
     return;
   }
@@ -2633,9 +2638,12 @@ async function shutdown(signal) {
     console.log('[SHUTDOWN] Email Monitor stopped');
   }
 
-  // Log final stats
-  const stats = signatureVerifier.getStats();
-  console.log(`[SHUTDOWN] Final stats: ${stats.totalVerifications} verifications, ${stats.successRate} success rate`);
+  // Log final stats (#97: shutdown may run before signatureVerifier exists if a
+  // signal arrives during the pre-init window the listener-first reorder opens)
+  if (signatureVerifier) {
+    const stats = signatureVerifier.getStats();
+    console.log(`[SHUTDOWN] Final stats: ${stats.totalVerifications} verifications, ${stats.successRate} success rate`);
+  }
 
   // Log NCRequestManager metrics
   if (ncRequestManager) {
@@ -2685,11 +2693,21 @@ process.on('SIGTERM', () => shutdown('SIGTERM'));
  */
 async function start() {
   try {
-    await initialize();
-
+    // #97: Bind the HTTP listener BEFORE running initialize(). Reachability must
+    // not be coupled to full initialisation — a rate-limiting NC can stall init
+    // in backoff for a long time, and the port must open regardless so /health
+    // answers and /webhook returns a clean 503 (not a dead port). handleRequest
+    // already tolerates the uninitialised state (serverComponents === null).
     const server = http.createServer(handleRequest);
 
-    server.listen(CONFIG.port, '0.0.0.0', async () => {
+    // A genuine bind failure (port in use, EACCES) is fatal and distinct from an
+    // init stall: there is no listener to keep up, so log and exit.
+    server.on('error', (err) => {
+      console.error(`[FATAL] HTTP listener bind failed on :${CONFIG.port}: ${err.code || err.message}`);
+      process.exit(1);
+    });
+
+    server.listen(CONFIG.port, '0.0.0.0', () => {
       console.log('');
       console.log('======================================================================');
       console.log('           Moltagent Webhook Server Running!                          ');
@@ -2699,51 +2717,59 @@ async function start() {
       console.log(`Health check: http://0.0.0.0:${CONFIG.port}/health`);
       console.log(`Stats: http://0.0.0.0:${CONFIG.port}/stats`);
       console.log('');
-      console.log('Ready to receive NC Talk messages');
+      console.log(`[INIT] HTTP listener bound on :${CONFIG.port} — init in progress; /webhook returns 503 until ready`);
       console.log('Press Ctrl+C to stop');
       console.log('');
-
-      // Start HeartbeatManager after server is listening (NC API clients ready)
-      if (heartbeatManager) {
-        try {
-          console.log('[INIT] Starting heartbeat...');
-          await heartbeatManager.start();
-          console.log(`[INIT] Heartbeat running (interval: ${CONFIG.heartbeat.intervalMs / 1000}s, initiative: ${appConfig.proactive.initiativeLevel})`);
-        } catch (err) {
-          console.error(`[INIT] Heartbeat start failed: ${err.message}`);
-        }
-      }
-
-      // Start RoomMonitor (after heartbeat, so BotEnroller has initial data)
-      if (roomMonitor) {
-        try {
-          await roomMonitor.start();
-          console.log('[INIT] RoomMonitor started');
-        } catch (err) {
-          console.warn(`[INIT] RoomMonitor start failed: ${err.message}`);
-        }
-      }
-
-      // Start NC Flow modules
-      if (ncFlowWebhookReceiver) {
-        try {
-          await ncFlowWebhookReceiver.start();
-          console.log('[INIT] NC Flow WebhookReceiver started');
-        } catch (err) {
-          console.warn(`[INIT] NC Flow WebhookReceiver start failed: ${err.message}`);
-        }
-      }
-      if (ncFlowActivityPoller) {
-        ncFlowActivityPoller.start();
-        console.log('[INIT] NC Flow ActivityPoller started');
-      }
-
-      // Set status to ready after all initialization complete
-      if (ncStatusIndicator) {
-        await ncStatusIndicator.setStatus('ready');
-        console.log('[INIT] Status set to Ready');
-      }
     });
+
+    // Run the full NC init handshake AFTER the listener is up. If this stalls
+    // under backoff, the port stays open returning 503 — that is the whole point
+    // of #97. A hard throw still falls through to the fatal catch below.
+    await initialize();
+    initComplete = true;
+    console.log('[INIT] Initialization complete — webhook ready');
+
+    // Post-init starts: these depend on initialised NC clients, so they run only
+    // after initialize() resolves (previously nested in the listen callback).
+    if (heartbeatManager) {
+      try {
+        console.log('[INIT] Starting heartbeat...');
+        await heartbeatManager.start();
+        console.log(`[INIT] Heartbeat running (interval: ${CONFIG.heartbeat.intervalMs / 1000}s, initiative: ${appConfig.proactive.initiativeLevel})`);
+      } catch (err) {
+        console.error(`[INIT] Heartbeat start failed: ${err.message}`);
+      }
+    }
+
+    // Start RoomMonitor (after heartbeat, so BotEnroller has initial data)
+    if (roomMonitor) {
+      try {
+        await roomMonitor.start();
+        console.log('[INIT] RoomMonitor started');
+      } catch (err) {
+        console.warn(`[INIT] RoomMonitor start failed: ${err.message}`);
+      }
+    }
+
+    // Start NC Flow modules
+    if (ncFlowWebhookReceiver) {
+      try {
+        await ncFlowWebhookReceiver.start();
+        console.log('[INIT] NC Flow WebhookReceiver started');
+      } catch (err) {
+        console.warn(`[INIT] NC Flow WebhookReceiver start failed: ${err.message}`);
+      }
+    }
+    if (ncFlowActivityPoller) {
+      ncFlowActivityPoller.start();
+      console.log('[INIT] NC Flow ActivityPoller started');
+    }
+
+    // Set status to ready after all initialization complete
+    if (ncStatusIndicator) {
+      await ncStatusIndicator.setStatus('ready');
+      console.log('[INIT] Status set to Ready');
+    }
 
   } catch (error) {
     console.error('[FATAL] Failed to start:', error);


### PR DESCRIPTION
## What

Phase 3 startup resilience — PR 2 of 2 (the listener-bind reorder). PR 1 (#115) is the placeholder hygiene sweep.

Closes #97.

**Generating function:** the service coupled *reachability* to *full initialisation*. `start()` awaited `initialize()` before `listen()`, so a rate-limiting NC that stalls init in backoff meant port 3000 never opened and Talk could never reach the bot — a dead port with no obvious cause.

**Reorder:** create the server and `listen()` **first**, then `await initialize()`. A module-level `initComplete` flag (not the open port) carries readiness. The post-init starts (heartbeat, RoomMonitor, NC Flow, status=ready) move out of the listen callback to run after `initialize()` resolves, since they depend on initialised NC clients. `handleRequest` already tolerated `serverComponents === null`, so this is a **move, not new guards**.

Added (each required, not scope creep):
- `server.on('error')`: a genuine bind failure (EADDRINUSE/EACCES) is fatal and distinct from an init stall — log and `exit(1)`.
- Two log lines distinguishing "listener bound, init in progress" from "init complete, webhook ready".
- `/webhook` 503 body now says "starting up … retry shortly" (the null-guard still owns correctness).
- `signatureVerifier` null-guards in the pre-init `/health` and `/stats` fallbacks and in shutdown: the listener-first reorder opens a window where these run before `signatureVerifier` exists.

## Verification (BUILT != VERIFIED) — live, Bot VM, scratch port 3999

A clean boot proves nothing here (the #108 lesson). I injected a deterministic 20s stall at the top of `initialize()` (env-gated scaffold, **reverted, not committed** — confirmed absent from the diff) and exercised the stall path:

- **During the stall:** `[INIT] HTTP listener bound on :3999 — init in progress` logged; `GET /health` → **HTTP 200** `{"initComplete":false,"verifications":0}` (null-guard holds — `signatureVerifier` was null and it did not throw); `POST /webhook/nctalk` → **HTTP 503** `"Server starting up — initialization in progress, retry shortly"`.
- **The flip:** after `[INIT] Initialization complete — webhook ready`, `POST /webhook/nctalk` → **HTTP 401 "Signature verification failed"** — the real `webhookHandler` is engaged, no longer the 503 fallback.
- **Bind failure:** booting on the in-use `:3000` → `[FATAL] HTTP listener bind failed on :3000: EADDRINUSE`, **exit code 1**, zero NC init work (the stall held init so the bind-error path did nothing).
- Scratch boot killed before heartbeat/RoomMonitor/Talk-polling did any work; live `:3000` service untouched throughout (PID unchanged, HTTP 200).

`npm run lint` → exit 0. `npm run test:unit` → 219/219 test files pass.

Scope held: no #87 preflight, no #26 backoff retuning. Base is `next`. Do not merge to `main`.

Co-authored-by: moltagent <github@moltagent.cloud>