### PR TITLE
fix(cc): Phase 2 hooks — structural-only detector, wire Pre/PostToolUse (#32)

### DIFF
--- a/.claude/hooks/check-anti-patterns.js
+++ b/.claude/hooks/check-anti-patterns.js
@@ -1,24 +1,83 @@
 #!/usr/bin/env node
 
 /**
- * PostToolUse hook: scans edited/written files for anti-patterns
- * that violate Moltagent dev rules.
+ * PostToolUse hook: scans edited/written .js files for anti-patterns that can be
+ * detected mechanically and unambiguously.
  *
- * Runs after every Edit or Write tool call.
- * Exits 0 (pass) or 1 (fail with message).
+ * Wiring (.claude/settings.json): PostToolUse, matcher "Edit|Write".
+ * Claude Code passes the tool call as JSON on stdin; the edited file's path is
+ * at tool_input.file_path. For manual testing the path may be passed as argv[2].
+ *
+ * Exit codes (per the Claude Code hook contract):
+ *   0 — clean, or nothing to check.
+ *   2 — violation. PostToolUse cannot retroactively block an edit that already
+ *       ran, but exit 2 is the only code that feeds this hook's stderr back to
+ *       Claude as a correction signal. Any other non-zero code only surfaces the
+ *       first stderr line as a passive transcript notice. We want Claude to read
+ *       the full violation and reconsider, so violations exit 2.
+ *
+ * Scope — why this hook checks exactly one fixed string:
+ *   A mechanical hook can only enforce a rule whose violation has a STRUCTURAL
+ *   signature distinct from correct code. `role: 'sovereign'` qualifies: it
+ *   loosens trust toward the cloud from outside the roster, which is never
+ *   legitimate (JOBS.CREDENTIALS is key material, not a role override).
+ *
+ *   `forceLocal: true` does NOT qualify, despite looking like a fixed string.
+ *   It is a trust-*tightening* primitive (pin a call to local for sensitive
+ *   data) used pervasively and correctly — the roster mapper derives it from
+ *   MODEL directives, and components set it to keep client data off the cloud.
+ *   It can only narrow the boundary, never widen it, so it is not a Rule 6
+ *   violation; flagging it false-positives on correct code. See issue #32 and
+ *   the trust-boundary section of the dev-rules skill (tightening vs loosening).
+ *
+ *   A "natural-language word list" (Rule 1) does NOT qualify either. Its structural
+ *   signature — three or more short bare-token strings in a collection — is
+ *   shared by config enums (`new Set(['aggressive','balanced','relaxed'])`),
+ *   intent-gate enums (`new Set(['greeting','chitchat','selection'])`, the
+ *   CORRECT Rule 1 pattern), sentinels (`['null','none','undefined']`), unit
+ *   symbols, and object-property values. Telling a word list apart from an enum
+ *   requires knowing whether the tokens are matched against user language — a
+ *   SEMANTIC judgment, the same interpretive call that keeps message-content
+ *   matching out of this hook. Encoding it would require a list of allowed words
+ *   inside the Rule 1 enforcer, i.e. the very anti-pattern it exists to catch.
+ *   So the Rule 1 / Rule 8 word-list check lives in the human pre-commit
+ *   checklist (the Anti-Pattern Checklist in the dev-rules skill), not here.
+ *   Do not re-add a content-based word-list detector: it false-positives on
+ *   correct code and trains its reader to ignore it. See issue #32.
  */
 
 const fs = require('fs');
-const path = require('path');
 
-const filePath = process.argv[2];
+// ── Resolve the target file path: argv[2] (manual) or stdin JSON (real hook) ──
+function resolveFilePath() {
+  if (process.argv[2]) return process.argv[2];
+  let raw;
+  try {
+    raw = fs.readFileSync(0, 'utf-8');
+  } catch {
+    return null; // no stdin available
+  }
+  try {
+    const payload = JSON.parse(raw);
+    return payload?.tool_input?.file_path || null;
+  } catch {
+    return null; // not JSON we understand
+  }
+}
+
+const filePath = resolveFilePath();
 if (!filePath) process.exit(0);
 
-// Only check JS files
+// Only check JS files.
 if (!filePath.endsWith('.js')) process.exit(0);
 
-// Don't check test files (they may legitimately contain anti-patterns as test data)
+// Don't check test files (they legitimately contain anti-patterns as test data).
 if (filePath.includes('/test/') || filePath.includes('.test.')) process.exit(0);
+
+// Don't check the CC tooling itself. Hook scripts carry the marker strings as
+// detection logic and documentation, not as live trust decisions; the enforcer
+// must not enforce against the enforcement tooling.
+if (/(?:^|\/)\.claude\//.test(filePath)) process.exit(0);
 
 let content;
 try {
@@ -29,65 +88,17 @@ try {
 
 const violations = [];
 
-// ── RULE 1: No natural language Sets/Arrays/Maps ──
-// Detect: new Set(['word', 'word', ...]) with 3+ short string entries
-const setPattern = /new\s+Set\(\[([^\]]{20,})\]\)/g;
-let match;
-while ((match = setPattern.exec(content)) !== null) {
-  const inner = match[1];
-  const strings = inner.match(/'[^']{1,20}'/g) || [];
-  if (strings.length >= 3) {
-    // Check if entries look like natural language words (short, lowercase)
-    const nlWords = strings.filter(s => {
-      const word = s.replace(/'/g, '');
-      return word.length <= 15 && /^[a-züöäéèêàáãñç]+$/i.test(word);
-    });
-    if (nlWords.length >= 3) {
-      violations.push(
-        `⛔ ANTI-PATTERN: Set of natural language words detected at "${match[0].substring(0, 60)}...".\n` +
-        `   The LLM is the language layer: Use the LLM for language tasks, not word lists.\n` +
-        `   File: ${filePath}`
-      );
-    }
-  }
-}
-
-// ── RULE 1: No regex on user messages ──
-// Detect: message.match(/.../) or message.includes('...')
-const msgRegex = /(?:message|msg|text|input|content)\.(?:match|includes|startsWith)\(/g;
-while ((match = msgRegex.exec(content)) !== null) {
-  // Get surrounding context
-  const lineStart = content.lastIndexOf('\n', match.index) + 1;
-  const lineEnd = content.indexOf('\n', match.index);
-  const line = content.substring(lineStart, lineEnd).trim();
-
-  // Skip if it's clearly plumbing (JSON, URL, path checks)
-  if (line.includes('application/json') || line.includes('http') || line.includes('/')) continue;
-
-  violations.push(
-    `⚠️ WARNING: Possible natural language matching on user input.\n` +
-    `   "${line.substring(0, 80)}"\n` +
-    `   The LLM is the language layer: Use the LLM for language understanding, not string matching.\n` +
-    `   File: ${filePath}`
-  );
-}
-
-// ── RULE 6: No hardcoded sovereignty overrides ──
+// ── Trust boundary: no per-component override that loosens trust toward cloud ──
+// `role: 'sovereign'` routes to cloud from outside the roster. It is never
+// legitimate (JOBS.CREDENTIALS is key material, not a role). Fixed string, no
+// interpretation. Trust-tightening (`forceLocal: true`) is deliberately NOT
+// checked here — see the header note.
 const sovereignPattern = /role:\s*['"]sovereign['"]/g;
-while ((match = sovereignPattern.exec(content)) !== null) {
+while (sovereignPattern.exec(content) !== null) {
   violations.push(
     `⛔ ANTI-PATTERN: Hardcoded role: 'sovereign' detected.\n` +
-    `   Trust boundary is the single control: Use the trust boundary (roster chain), not per-component overrides.\n` +
-    `   The ONLY exception is JOBS.CREDENTIALS.\n` +
-    `   File: ${filePath}`
-  );
-}
-
-const forceLocalPattern = /forceLocal:\s*true/g;
-while ((match = forceLocalPattern.exec(content)) !== null) {
-  violations.push(
-    `⛔ ANTI-PATTERN: Hardcoded forceLocal: true detected.\n` +
-    `   Trust boundary is the single control: Use the trust boundary, not per-component overrides.\n` +
+    `   Trust boundary is the single control: a per-component override that loosens trust toward cloud\n` +
+    `   bypasses the roster chain. The ONLY exception is JOBS.CREDENTIALS.\n` +
     `   File: ${filePath}`
   );
 }
@@ -99,11 +110,11 @@ if (violations.length > 0) {
   console.error('='.repeat(60));
   violations.forEach(v => console.error('\n' + v));
   console.error('\n' + '='.repeat(60));
-  console.error('Read .moltagent-dev-rules.md for full details.');
+  console.error('Read .claude/skills/moltagent-dev-rules/SKILL.md for full details.');
   console.error('='.repeat(60) + '\n');
 
-  // Exit 1 to block the edit (CC will see the error and reconsider)
-  process.exit(1);
+  // Exit 2: surface the violation to Claude as a correction signal (see header).
+  process.exit(2);
 }
 
 // All clear

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,37 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-anti-patterns.js",
+            "description": "Flag hardcoded role: 'sovereign' trust-loosening overrides in edited .js files"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(rm *)",
+            "command": "echo '⚠️ Destructive command (rm). Confirm intent and target before proceeding.'",
+            "description": "Warn before rm; does not block (deny list already hard-blocks rm -rf)"
+          },
+          {
+            "type": "command",
+            "if": "Bash(sudo rm *)",
+            "command": "echo '⚠️ Destructive command (sudo rm). Confirm intent and target before proceeding.'",
+            "description": "Warn before sudo rm; does not block"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/moltagent-dev-rules/SKILL.md
+++ b/.claude/skills/moltagent-dev-rules/SKILL.md
@@ -71,7 +71,9 @@ In practice:
 
 `trust: local-only` or `trust: cloud-ok` is the one setting that decides what touches the cloud. The user sets it, and every component inherits it through the roster chain. That is the only place the decision lives.
 
-A per-component override (`role: 'sovereign'`, `forceLocal: true`, a module-level trust flag) is the failure mode, not a feature. The single exception is `JOBS.CREDENTIALS`: key material never leaves the box, regardless of the trust setting.
+Direction is everything. A per-component override that *loosens* trust toward the cloud — `role: 'sovereign'`, or any flag that routes to cloud outside the roster — is the failure mode, not a feature: it widens the boundary the user set, from a place that isn't the single control. Trust-*tightening* overrides are legitimate: `forceLocal: true` (pinning a call to local for sensitive data) can only narrow the boundary, never widen it, so it cannot violate the user's choice. The rule forbids widening, not narrowing.
+
+The single exception, independent of direction, is `JOBS.CREDENTIALS`: key material never leaves the box, regardless of the trust setting.
 
 ## The anti-pattern checklist
 
@@ -81,7 +83,7 @@ This is the checklist form of the rules above. Run it before every commit. Each 
 - [ ] A regex that matches message content? → The LLM is the language layer.
 - [ ] Code that only works in English? → Multilingual by default.
 - [ ] A post-classify guard that overrides the model? → Prompt updates, not code guards.
-- [ ] A hardcoded `role: 'sovereign'` or `forceLocal: true`? → Trust boundary is the single control.
+- [ ] A per-component override that loosens trust toward cloud (`role: 'sovereign'`, a flag routing to cloud outside the roster)? → Trust boundary is the single control. (Trust-*tightening* like `forceLocal: true` is fine.)
 - [ ] A commit that adds more lines than it removes? → Analysis before code (the altitude check).
 - [ ] Code that compensates for a weak model? → Strengthen the component instead.
 - [ ] Code that has to change when you add a language? → The LLM is the language layer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ A reported behavior bug (hallucinated roles, overconfidence under sparse data) a
 
 2. **Analysis before fix.** What class of problem is this? What generates it? Fix the generator, not the instance. Two instances of the same pattern mean stop patching. When the generator sits above the current scope, surface it as an issue rather than patching around it.
 
-3. **Trust boundary is the single control.** `trust: local-only` or `cloud-ok` decides every cloud-touching call, and the router is the only place that decision is made. A second trust flag on a component is the failure mode, not a feature.
+3. **Trust boundary is the single control.** `trust: local-only` or `cloud-ok` decides every cloud-touching call, and the router is the only place that decision is made. A per-component override that *loosens* trust toward cloud (`role: 'sovereign'`, a flag routing to cloud outside the roster) is the failure mode, not a feature. Trust-*tightening* overrides (`forceLocal: true`, pinning to local for sensitive data) are legitimate — they can only narrow the boundary, never widen it. `JOBS.CREDENTIALS` is exempt either way: key material never leaves the box.
 
 4. **BUILT ≠ VERIFIED.** A feature is complete only after its behavior is confirmed in production. Green tests are necessary, not sufficient. Close each session with a marker stating what you confirmed and how. See the Verification Gate in the dev-rules skill.
 


### PR DESCRIPTION
Closes #32.

## Context
PR #31 left `.claude/hooks/check-anti-patterns.js` in the tree as an unwired *specimen*. #32 is the proper briefing: critique it, ship a correct detector, add a PreToolUse warning, register both, verify end-to-end. The specimen was read with suspicion — and it had more wrong with it than #32 anticipated.

## The wiring was a no-op
The original registration passed `$FILE_PATH`, which **is not a Claude Code hook variable**. CC passes the tool call as JSON on **stdin**; the script read `process.argv[2]`, so it would have received nothing and `exit(0)`'d on every edit even if wired. The detector now reads `tool_input.file_path` from stdin (argv kept as a manual-testing fallback).

## Detectors removed (both were interpretive in disguise)
- **Word-list detector.** Its char class `/^[a-züöäéèêàáãñç]+$/i` was *itself* the Rule 1 violation it enforced — verified silent on a Set of Japanese/Arabic/Hebrew words (#32 primary finding, reproduced). A language-agnostic structural rewrite was built and measured: the signature *3+ short bare tokens in a collection* is shared by config enums, **intent-gate enums (the correct Rule 1 pattern)**, sentinels, unit symbols, and object-property values — **37 of 170 src files false-positived**. Word-list-vs-enum is a *semantic* distinction; encoding it needs a word list inside the Rule 1 enforcer. Moved to the human Rule 8 checklist (where #32's secondary finding already put message-parsing).
- **Message-parsing detector** — removed per #32's secondary finding.

## `forceLocal: true` detector removed + rule text corrected (one logical unit)
The inherited `forceLocal: true` detector fired on 2 files, both **correct**: the roster mapper (`workflow-engine._getRoleForCard`, derives it from MODEL directives) and client-data protection (`document-ingestor.js:1102`). `forceLocal` only *tightens* trust toward local — it can't widen the boundary, so it isn't a Rule 6 violation. The written rule was wrong about it, so this PR fixes the rule in the same change:
- **CLAUDE.md Rule 3** and **SKILL.md trust-boundary section + checklist** now distinguish **loosening** (`role: 'sovereign'`, the failure mode) from **tightening** (`forceLocal: true`, legitimate). `JOBS.CREDENTIALS` stays exempt either way.

## What ships
- **PostToolUse** (`Edit|Write`): one structural detector — `role: 'sovereign'` (loosening, never legitimate; **0 occurrences in src → 0 false positives**). Exit **2** (the only code that feeds stderr back to Claude — PostToolUse can't retroactively block). Footer points at the dev-rules **skill** (root `moltagent-dev-rules.md` is now a pointer stub). Skips `test/` and **`.claude/` tooling** — the enforcer must not enforce against itself (found live: the hook flagged its own report-message string).
- **PreToolUse** (`Bash`): non-blocking `echo` warning on `rm` / `sudo rm`, via the `if` content filter (matcher is tool-name-only). The deny list already hard-blocks `rm -rf`.

## Verification Gate
- Full `src/` sweep (170 files): **0 firings**.
- Targeted gate: `role:'sovereign'` → exit 2; `forceLocal:true`, word-list (Latin **and** non-Latin), `test/`, non-`.js`, and hook-self → exit 0.
- Real stdin-JSON contract → exit 2, correct path extracted.
- **Live in-session**: wired PostToolUse fired on a real edit (exit 2, full stderr surfaced to Claude) and correctly self-skipped after the `.claude/` guard.
- `npm run lint` → 0 errors. `npm run test:unit` → 219/219.

Note on altitude: +114/−70. Logic shrank (three detectors removed); the growth is header documentation explaining *why* each detector was dropped, to stop a future maintainer re-adding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)