### PR TITLE
fix(cockpit): warn when ADMIN_USER unset — Cockpit board silently unshared

### DIFF
--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -396,6 +396,10 @@ class CockpitManager {
       }
 
       this._initialized = true;
+
+      if (!this.adminUser) {
+        console.warn('[CockpitManager] ADMIN_USER not set — Cockpit board is not shared with the instance owner. Set ADMIN_USER in .env to your Nextcloud username to see and control the Cockpit.');
+      }
     } catch (err) {
       throw new CockpitError(
         `Failed to initialize CockpitManager: ${err.message}`,
@@ -438,7 +442,7 @@ class CockpitManager {
         try {
           await this.deck.shareBoard(boardId, this.adminUser, 0, true, true, true);
         } catch (err) {
-          // Non-critical, continue
+          console.warn(`[CockpitManager] Could not share Cockpit board with ${this.adminUser}: ${err.message}`);
         }
       }
 


### PR DESCRIPTION
## Problem

When `ADMIN_USER` is unset (empty string — the `.env.example` default), the Cockpit board is created but never shared with the instance owner, and **no log line fires**. The operator discovers the gap as the absence of a board they were never told exists.

When `ADMIN_USER` *is* set but `shareBoard()` fails, the error was swallowed with a `// Non-critical, continue` comment and no output.

Both are silent absorption.

## Fix

Two one-liners in `src/lib/integrations/cockpit-manager.js`:

1. `initialize()` — warn when `adminUser` is empty after init completes.
2. `bootstrap()` — replace the empty `catch` in the share block with a logged warning.

Sharing logic itself is unchanged (auto-detecting the owner is a separate feature). `PersonalBoardManager` (same pattern, separate scope) is untouched.

## Verification

- `grep -n 'ADMIN_USER not set' src/lib/integrations/cockpit-manager.js` → returns the line.
- `npm run lint` → 0 errors.
- `cockpit-manager.test.js` → 84/84 pass; the empty-`adminUser` fixtures exercise the new warning live, and the existing "shares board with admin user" test still passes (share-success path intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)