### PR TITLE
fix(prompt): rewrite synthesis preamble in declarative register — removes verbatim escape phrase

### DIFF
--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -2424,9 +2424,10 @@ Be thoughtful. Be honest. Be yourself.`;
     const now = new Date();
     const timeStr = `${now.toLocaleDateString('en-US', { weekday: 'long' })}, ${now.toISOString().split('T')[0]} ${now.toTimeString().split(' ')[0]} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`;
 
-    const prompt = `You are a KNOWLEDGE SYNTHESIZER. You can ONLY answer questions — you CANNOT perform actions.
-DO NOT claim you created a card, sent an email, booked a meeting, moved anything, or performed ANY action.
-If the user asked you to DO something, say what you FOUND, then say: "I couldn't complete that action — please ask me separately."
+    const prompt = `Role: knowledge synthesizer.
+Capabilities: answering questions from the provided data sources.
+Actions (creating cards, sending emails, booking meetings, moving items): not available in this mode.
+When the question includes an action request: present findings first, then state that the action requires a separate request.
 
 Current date/time: ${timeStr}
 ${conversationBlock}${indexBlock}


### PR DESCRIPTION
## Problem

`_synthesizeKnowledge` in `src/lib/server/message-processor.js` opened its prompt with three imperative lines, the third embedding a verbatim quotable sentence in quotes:

> If the user asked you to DO something, say what you FOUND, then say: \"I couldn't complete that action — please ask me separately.\"

When `qwen2.5:3b` receives this for a **non-action** question (e.g. \"What's on my board?\"), it pattern-matches the quoted string as the shortest valid response and emits it verbatim as a ~13-token answer. The safety scaffolding leaks into the user channel.

Per Mason ICLR 2026: imperative negation with an embedded example sentence is the highest-risk prompt shape for small models.

## Fix

Rewrite the synthesis preamble in **declarative register** — `Role / Capabilities / Actions: not available / When…action request`. No verbatim template sentence remains for the model to echo. The behavioral constraint is structurally unchanged: the synthesizer still doesn't claim actions; the encoding is just declarative rather than imperative-with-a-quoted-example.

```
Role: knowledge synthesizer.
Capabilities: answering questions from the provided data sources.
Actions (creating cards, sending emails, booking meetings, moving items): not available in this mode.
When the question includes an action request: present findings first, then state that the action requires a separate request.
```

## Scope held

Untouched, as briefed:
- RULES block (no quotable templates)
- `compoundFallbackPolicy` string (same family, no verbatim sentence, separate scope)
- code-appended `⚠️ I wasn't able to complete…` disclaimer (that's code, not prompt)
- synthesis routing / model selection

## Verification

- `grep -n "couldn't complete that action" src/lib/server/message-processor.js` → **zero matches** (the escape phrase is gone from the prompt entirely; the actual code-appended fallback disclaimer uses different wording and is out of scope).
- `npm run lint` → 0 errors.
- `npm run test:unit` → 220/220 test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)