### PR TITLE
fix(deck): make board registry canonical — drop title-search fallback, re-read on cache miss (#49)

### DIFF
--- a/src/lib/integrations/deck-board-registry.js
+++ b/src/lib/integrations/deck-board-registry.js
@@ -22,23 +22,22 @@
  * that does listBoards().find(b => b.title === name) is fragile.  A renamed
  * board becomes invisible until code is changed or a new board is created.
  *
- * Pattern: Role-to-ID registry persisted as a small JSON file.  On first
- * access per role the registry falls through: memory → disk → live name scan.
- * Once an ID is found it is stored and subsequent lookups are O(1) memory
- * reads, with no Deck API traffic at all.  Atomic writes (tmp + rename) keep
- * the file consistent even if the process crashes mid-write.
+ * Pattern: Role-to-ID registry persisted as a small JSON file, treated as the
+ * canonical source of truth.  resolveBoard falls through memory → disk → null;
+ * it never scans live Deck titles (#49), so an emoji-prefixed or renamed board
+ * cannot break resolution.  A cache miss re-reads disk, so a registerBoard run
+ * from a separate process is picked up without a restart.  Atomic writes (tmp +
+ * rename) keep the file consistent even if the process crashes mid-write.
  *
  * Key Dependencies:
  *   - fs (Node built-in) — file I/O, atomic rename
  *   - path (Node built-in) — cross-platform path resolution
- *   - DeckClient.listBoards() — fallback name scan (caller-supplied)
  *
  * Data Flow:
- *   resolveBoard(deckClient, role, fallbackTitle)
- *     -> _cache hit?          -> return boardId
- *     -> _loadFromDisk()      -> cache populated from file? -> return boardId
- *     -> deckClient.listBoards() -> name match? -> registerBoard() -> return boardId
- *     -> no match             -> return null
+ *   resolveBoard(role)
+ *     -> cold cache?          -> _loadFromDisk()
+ *     -> role still missing?  -> _loadFromDisk() again (picks up out-of-process writes)
+ *     -> return _cache[role]?.boardId ?? null   (no live title scan)
  *
  *   registerBoard(role, boardId)
  *     -> update _cache
@@ -81,53 +80,31 @@ class DeckBoardRegistry {
   // ---------------------------------------------------------------------------
 
   /**
-   * Resolve a board by role.  Falls through memory → disk → live name scan.
+   * Resolve a board by role.  The registry is canonical: memory → disk → null.
+   * It never scans live Deck titles (#49), so an emoji-prefixed or renamed board
+   * cannot break resolution.  An unregistered role returns null; the caller
+   * raises an actionable "register it" error.
    *
-   * @param {Object} deckClient - DeckClient instance (must expose listBoards())
+   * @param {Object} _deckClient - Unused; retained for signature stability (callers pass their DeckClient).
    * @param {string} role - One of ROLES.*
-   * @param {string} fallbackTitle - Board title used for the live name scan
-   * @returns {Promise<number|string|null>} boardId, or null if not found
+   * @param {string} _fallbackTitle - Unused; retained for signature stability (was the live-scan title).
+   * @returns {Promise<number|string|null>} boardId, or null if not registered
    */
-  async resolveBoard(deckClient, role, fallbackTitle) {
-    // 1. Memory hit
-    if (this._cache !== null && this._cache[role]) {
-      return this._cache[role].boardId;
-    }
-
-    // 2. Cold cache — load from disk first
+  // eslint-disable-next-line require-await -- async retained for the caller contract (callers await this); resolution is now a pure memory/disk read with no async work
+  async resolveBoard(_deckClient, role, _fallbackTitle) {
+    // Cold cache — load from disk once.
     if (this._cache === null) {
       this._loadFromDisk();
     }
 
-    if (this._cache[role]) {
-      return this._cache[role].boardId;
+    // Re-read disk on a miss so a registerBoard from a separate process is
+    // picked up without a restart (#49 Part B).  Skipped in test mode, where
+    // _reset() pins a clean in-memory slate and the disk must not be re-read.
+    if (!this._cache[role] && !this._testMode) {
+      this._loadFromDisk();
     }
 
-    // 3. First-boot migration: scan boards by name (runs once, then never again)
-    if (!deckClient || typeof deckClient.listBoards !== 'function') {
-      return null;
-    }
-
-    const boards = await deckClient.listBoards();
-    if (!Array.isArray(boards)) return null;
-
-    const needle = (fallbackTitle || '').trim().toLowerCase();
-    const match  = boards.find(b => (b.title || '').trim().toLowerCase() === needle);
-
-    if (match) {
-      this.registerBoard(role, match.id);
-      return match.id;
-    }
-
-    // No exact match — log what exists so the operator can resolve manually
-    const existing = boards.map(b => `  ${b.id}: "${b.title}"`).join('\n');
-    console.warn(
-      `[DeckBoardRegistry] No board matching "${fallbackTitle}" for role "${role}".\n` +
-      `Existing boards:\n${existing}\n` +
-      `If the board was renamed, register it manually:\n` +
-      `  node -e "require('./src/lib/integrations/deck-board-registry').registerBoard('${role}', BOARD_ID)"`
-    );
-    return null;
+    return this._cache[role]?.boardId ?? null;
   }
 
   /**

--- a/test/unit/ensure-meetings-board.test.js
+++ b/test/unit/ensure-meetings-board.test.js
@@ -15,6 +15,7 @@ const { test, asyncTest, summary, exitWithCode } = require('../helpers/test-runn
 
 const ensureMeetingsBoard = require('../../src/lib/calendar/ensure-meetings-board');
 const boardRegistry = require('../../src/lib/integrations/deck-board-registry');
+const { ROLES } = require('../../src/lib/integrations/deck-board-registry');
 
 // ============================================================
 // Test Fixtures
@@ -68,12 +69,13 @@ asyncTest('creates board when none exists — calls createNewBoard, createStack 
   assert.strictEqual(result.existed, false);
 });
 
-asyncTest('skips creation when board already exists — returns { existed: true }', async () => {
+asyncTest('skips creation when board is registered — returns { existed: true }', async () => {
   boardRegistry._reset();
+  // The registry is canonical: a registered role resolves without any title scan.
+  boardRegistry.registerBoard(ROLES.meetings, 42);
   let createNewBoardCalled = false;
 
   const deck = createMockDeck({
-    listBoards: async () => [{ id: 42, title: 'Pending Meetings' }],
     createNewBoard: async () => {
       createNewBoardCalled = true;
       return { id: 99, title: 'Pending Meetings' };
@@ -87,12 +89,16 @@ asyncTest('skips creation when board already exists — returns { existed: true 
   assert.strictEqual(result.boardId, 42);
 });
 
-asyncTest('case-insensitive matching — "pending meetings" matches', async () => {
+asyncTest('resolves a registered board regardless of its live title (#49 canonical)', async () => {
   boardRegistry._reset();
+  boardRegistry.registerBoard(ROLES.meetings, 77);
   let createNewBoardCalled = false;
 
+  // The live board carries a divergent/emoji-prefixed title that the old
+  // exact-title scan would miss (#99).  Resolution comes from the registry, so
+  // the live title is never consulted and creation is skipped.
   const deck = createMockDeck({
-    listBoards: async () => [{ id: 77, title: 'pending meetings' }],
+    listBoards: async () => [{ id: 77, title: '⭐ pending meetings' }],
     createNewBoard: async () => {
       createNewBoardCalled = true;
       return { id: 99, title: 'Pending Meetings' };
@@ -101,20 +107,15 @@ asyncTest('case-insensitive matching — "pending meetings" matches', async () =
 
   const result = await ensureMeetingsBoard(deck);
 
-  assert.strictEqual(createNewBoardCalled, false, 'should not create when lowercase match exists');
+  assert.strictEqual(createNewBoardCalled, false, 'registered board must not be re-created');
   assert.strictEqual(result.existed, true);
   assert.strictEqual(result.boardId, 77);
 });
 
-asyncTest('returns boardId from existing board', async () => {
+asyncTest('returns boardId from a registered board', async () => {
   boardRegistry._reset();
-  const deck = createMockDeck({
-    listBoards: async () => [
-      { id: 10, title: 'Some Other Board' },
-      { id: 55, title: 'Pending Meetings' },
-      { id: 20, title: 'Archive' }
-    ]
-  });
+  boardRegistry.registerBoard(ROLES.meetings, 55);
+  const deck = createMockDeck();
 
   const result = await ensureMeetingsBoard(deck);
 
@@ -176,8 +177,9 @@ asyncTest('workflow rules card has correct content', async () => {
 
 asyncTest('propagates errors thrown by DeckClient', async () => {
   boardRegistry._reset();
+  // Unregistered role → create path; the deck's create call is the failure point.
   const deck = createMockDeck({
-    listBoards: async () => { throw new Error('network failure'); }
+    createNewBoard: async () => { throw new Error('network failure'); }
   });
 
   let caught = null;

--- a/test/unit/integrations/deck-board-registry.test.js
+++ b/test/unit/integrations/deck-board-registry.test.js
@@ -19,12 +19,12 @@
  * Tests:
  * - TC-REG-001: ROLES exports all expected board roles
  * - TC-REG-002: resolveBoard returns null when no registry, no deckClient
- * - TC-REG-003: resolveBoard falls back to name match and registers
- * - TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)
+ * - TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards
+ * - TC-REG-004: resolveBoard returns registered ID without touching the deck client
  * - TC-REG-005: registerBoard + getAll round-trip
  * - TC-REG-006: invalidateBoard removes entry
- * - TC-REG-007: resolveBoard does case-insensitive title matching
- * - TC-REG-008: resolveBoard returns null when title doesn't match
+ * - TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)
+ * - TC-REG-008: resolveBoard returns null on a genuine miss, never scanning
  * - TC-REG-009: _reset clears all state
  *
  * Run: node test/unit/integrations/deck-board-registry.test.js
@@ -67,41 +67,41 @@ asyncTest('TC-REG-002: resolveBoard returns null when no registry, no deckClient
 });
 
 // ============================================================
-// TC-REG-003: resolveBoard falls back to name match and registers
+// TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards
 // ============================================================
 
-asyncTest('TC-REG-003: resolveBoard falls back to name match and registers', async () => {
+asyncTest('TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 42, title: 'My Board' }],
+  // The registry is canonical: a cache miss returns null, it does NOT fall
+  // through to a live title scan.  A throwing deck client proves listBoards
+  // is never called.
+  const throwingDeck = {
+    listBoards: () => { throw new Error('listBoards must never be called — registry is canonical'); },
   };
 
-  // Use a unique role ('knowledge') so concurrent async tests targeting
-  // 'cockpit' (TC-REG-007) cannot collide with this one.
-  const id = await boardRegistry.resolveBoard(mockDeck, 'knowledge', 'My Board');
+  const id = await boardRegistry.resolveBoard(throwingDeck, 'knowledge', 'My Board');
 
-  assert.strictEqual(id, 42);
-  assert.strictEqual(boardRegistry.getAll().knowledge.boardId, 42);
+  assert.strictEqual(id, null);
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(boardRegistry.getAll(), 'knowledge'),
+    'a role must not be registered from a live title scan'
+  );
 });
 
 // ============================================================
-// TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)
+// TC-REG-004: resolveBoard returns registered ID without touching the deck client
 // ============================================================
 
-asyncTest('TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)', async () => {
+asyncTest('TC-REG-004: resolveBoard returns registered ID without touching the deck client', async () => {
   boardRegistry._reset();
 
-  // Seed the cache using the 'meetings' role to avoid collision with other
-  // async tests that use 'cockpit' or 'knowledge'.
-  const seedDeck = {
-    listBoards: async () => [{ id: 42, title: 'Cache Test Board' }],
-  };
-  await boardRegistry.resolveBoard(seedDeck, 'meetings', 'Cache Test Board');
+  // Seed via registerBoard (the canonical path) rather than a title scan.
+  boardRegistry.registerBoard('meetings', 42);
 
-  // Second call: deckClient throws if listBoards is ever reached
+  // The deck client throws if resolveBoard ever reaches for listBoards.
   const throwingDeck = {
-    listBoards: async () => { throw new Error('listBoards must not be called on cache hit'); },
+    listBoards: () => { throw new Error('listBoards must not be called on a registered role'); },
   };
 
   const id = await boardRegistry.resolveBoard(throwingDeck, 'meetings', 'Cache Test Board');
@@ -144,36 +144,42 @@ test('TC-REG-006: invalidateBoard removes entry', () => {
 });
 
 // ============================================================
-// TC-REG-007: resolveBoard does case-insensitive title matching
+// TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)
 // ============================================================
 
-asyncTest('TC-REG-007: resolveBoard does case-insensitive title matching', async () => {
+asyncTest('TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 7, title: '⭐ Moltagent Cockpit' }],
+  // Board 14 is registered for 'cockpit'.  The live board carries an
+  // emoji-prefixed title ('⭐ Moltagent Cockpit') that the old exact-title scan
+  // missed (this was #99).  Resolution now comes from the registry and the
+  // title is never consulted, so the emoji prefix is irrelevant.
+  boardRegistry.registerBoard('cockpit', 14);
+
+  const throwingDeck = {
+    listBoards: () => { throw new Error('title scan must not run — registry is canonical'); },
   };
 
-  const id = await boardRegistry.resolveBoard(mockDeck, 'cockpit', '⭐ moltagent cockpit');
-  assert.strictEqual(id, 7);
+  const id = await boardRegistry.resolveBoard(throwingDeck, 'cockpit', 'Moltagent Cockpit');
+  assert.strictEqual(id, 14);
 });
 
 // ============================================================
-// TC-REG-008: resolveBoard returns null when title doesn't match
+// TC-REG-008: resolveBoard returns null on a genuine miss, never scanning
 // ============================================================
 
-asyncTest('TC-REG-008: resolveBoard returns null when title does not match', async () => {
+asyncTest('TC-REG-008: resolveBoard returns null on a genuine miss, never scanning', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 1, title: 'Unrelated Board' }],
+  const throwingDeck = {
+    listBoards: () => { throw new Error('listBoards must not be called on a miss'); },
   };
 
-  const result = await boardRegistry.resolveBoard(mockDeck, 'tasks', 'Moltagent Tasks');
+  const result = await boardRegistry.resolveBoard(throwingDeck, 'tasks', 'Moltagent Tasks');
   assert.strictEqual(result, null);
 
   const all = boardRegistry.getAll();
-  assert.ok(!Object.prototype.hasOwnProperty.call(all, 'tasks'), 'tasks entry should not be registered on title mismatch');
+  assert.ok(!Object.prototype.hasOwnProperty.call(all, 'tasks'), 'tasks entry must not be registered on a miss');
 });
 
 // ============================================================

--- a/test/unit/meeting-composer.test.js
+++ b/test/unit/meeting-composer.test.js
@@ -15,6 +15,14 @@ const assert = require('assert');
 const MeetingComposer = require('../../src/lib/calendar/meeting-composer');
 const boardRegistry = require('../../src/lib/integrations/deck-board-registry');
 
+// The board registry is a collaborator here, not the unit under test (its own
+// resolution is covered in deck-board-registry.test.js).  Stub resolveBoard to
+// resolve deterministically from the per-deck mock so the concurrently-run
+// asyncTests below never contend on the shared registry singleton.  Set once at
+// load, so it is itself race-free.
+boardRegistry.resolveBoard = async (deck) =>
+  (deck && deck.__meetingsBoardId != null) ? deck.__meetingsBoardId : null;
+
 // ---------------------------------------------------------------------------
 // Mock factories
 // ---------------------------------------------------------------------------
@@ -54,7 +62,10 @@ function createMocks(overrides = {}) {
     deckClient: {
       listBoards:       overrides.listBoards       || (async () => []),
       getBoard:         overrides.getBoard         || (async () => ({ stacks: [] })),
-      createCardOnBoard: overrides.createCardOnBoard || (async () => ({ id: 42 }))
+      createCardOnBoard: overrides.createCardOnBoard || (async () => ({ id: 42 })),
+      // Consumed by the stubbed boardRegistry.resolveBoard above to pick the
+      // meetings board id for this composer (undefined => not registered => null).
+      __meetingsBoardId: overrides.meetingsBoardId
     },
     emailHandler: {
       sendWithIcal: overrides.sendWithIcal || (async () => ({ success: true }))
@@ -506,10 +517,9 @@ asyncTest('meeting proceeds normally when rsvpTracker is absent', async () => {
 // --- 17. Deck tracking card ---
 
 asyncTest('deck card created on Pending Meetings board after meeting creation', async () => {
-  boardRegistry._reset();
   const createCardCalls = [];
   const composer = createComposer({
-    listBoards: async () => [{ id: 7, title: 'Pending Meetings' }],
+    meetingsBoardId: 7, // resolved via the stubbed registry; no title scan
     getBoard: async () => ({
       stacks: [{ id: 20, title: 'Invited' }]
     }),
@@ -548,10 +558,9 @@ asyncTest('meeting creation succeeds even when deck board is not found', async (
 });
 
 asyncTest('deck card falls back to first stack when no Invited stack exists', async () => {
-  boardRegistry._reset();
   const createCardCalls = [];
   const composer = createComposer({
-    listBoards: async () => [{ id: 8, title: 'Pending Meetings' }],
+    meetingsBoardId: 8, // resolved via the stubbed registry; no title scan
     getBoard: async () => ({
       stacks: [{ id: 30, title: 'Backlog' }, { id: 31, title: 'In Progress' }]
     }),


### PR DESCRIPTION
## #49 — Make the deck board registry canonical

Treats `data/deck-board-registry.json` as the single source of truth for role → boardId: `resolveBoard` resolves **memory → disk → null**, never scanning live Deck titles. Closes #99 as a side effect once Prime's cockpit board is registered.

### Changes
**`deck-board-registry.js` (net −22 lines)**
- **Part A** — removed the live title-scan fallback and the "No board matching" warning. An emoji-prefixed or renamed board can no longer break resolution (#99: `⭐ Moltagent Cockpit` failed the exact-title match). `deckClient`/`fallbackTitle` retained as `_`-prefixed params for signature stability; `async` kept for the caller contract.
- **Part B** — re-read disk on a cache miss, gated by `!_testMode` so `_reset()` test isolation holds. A `registerBoard` from a separate process is now picked up **without a restart** (the Session-47 / #45 fix).
- Header doc (Architecture Brief / Data Flow / Key Dependencies) updated to match.

**Tests** — caller tests moved to the canonical contract (register instead of title-mock); registry tests rewritten to the registry-only contract; `meeting-composer`'s registry collaborator is stubbed per-deck, removing a latent concurrency race the old name-scan had masked.

### Deliberately out of scope
- **`cockpit-manager.js` `includes()` guard kept.** Archaeology confirms `bootstrap()` is the only cockpit creation path (no setup script registers it), so the guard prevents a duplicate-board orphan on restart. It no longer participates in resolution, so #49's thesis holds without removing it. (Comment to follow on #49.)
- `deck-client.js` `findBoard` name-scan and the executor / tool-registry `_resolveBoard` (user-named board resolution) — different mechanisms, untouched.

### Verification
- 220/220 unit files; registry 9/9; **lint 0 errors**.
- **Part B proven live** via a two-process re-read: a separate process registered a role, the long-running process resolved it on its next call (`null → 999`) with no restart.
- ⏳ **Merge gate (Prime):** deploy + `registerBoard('cockpit', 14)`, then within one heartbeat (no restart) confirm the "No cockpit board" warning stops, board 14 resolves, and no duplicate board is created.

Closes #99. Related: #45, #87 / #123 (single-source / signal-not-honored archetype). Distinct from #135 (cockpit card-update 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
