### PR TITLE
fix(deck): centralize card-update PUT into one complete-body helper (#135)

### DIFF
--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -856,13 +856,9 @@ class CockpitManager {
           const hash = crypto.createHash('sha256').update(description).digest('hex');
           if (this._descriptionHashes.get(card.id) === hash) continue;
 
-          const updatePath = `/index.php/apps/deck/api/v1.0/boards/${this.boardId}/stacks/${this.stacks.status}/cards/${card.id}`;
-          await this.deck._request('PUT', updatePath, {
-            title: card.title,
-            description: description,
-            type: 'plain',
-            owner: card.owner || 'moltagent'
-          });
+          await this.deck.updateCardComplete(
+            this.boardId, this.stacks.status, card.id, card, { description }
+          );
           this._descriptionHashes.set(card.id, hash);
         } catch (err) {
           console.warn(`[CockpitManager] Failed to update ${card.title}:`, err.message);
@@ -1191,6 +1187,8 @@ class CockpitManager {
     // Store card metadata for heartbeat writeback
     result._cardId = card.id;
     result._cardDescription = card.description || '';
+    result._cardOrder = card.order;
+    result._cardOwner = card.owner;
     result._userConfig = configSection.trim() + '\n';
     result._cardLabels = (card.labels || []).map(l => l.title);
 
@@ -1711,13 +1709,9 @@ class CockpitManager {
     try {
       const stackId = this.stacks.system;
       if (stackId) {
-        const updatePath = `/index.php/apps/deck/api/v1.0/boards/${this.boardId}/stacks/${stackId}/cards/${card.id}`;
-        await this.deck._request('PUT', updatePath, {
-          title: card.title || 'Models',
-          description: newDescription,
-          type: 'plain',
-          owner: card.owner || 'moltagent'
-        });
+        await this.deck.updateCardComplete(
+          this.boardId, stackId, card.id, card, { description: newDescription }
+        );
         this._descriptionHashes.set(card.id, hash);
       }
     } catch (err) {

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -671,6 +671,59 @@ class DeckClient {
       updates);
   }
 
+  /**
+   * Build and PUT a complete, normalized card body — the single canonical
+   * card-update body builder for all CockpitManager writes.
+   *
+   * The Deck API rejects partial PUT bodies: every field must be present or the
+   * server clobbers missing fields with defaults. This helper resolves each
+   * required field from `changes` (caller intent) → `card` (current server
+   * state) → safe default, so callers never construct the body themselves.
+   *
+   * Key fix for #135: `owner` is normalized from an object (e.g. `{uid:'botuser'}`)
+   * to a bare uid string. Deck PUT rejects an owner-object in the body; the API
+   * only accepts the uid. Falls back to `this.username` (the deployment-aware bot
+   * uid read from NCRequestManager, never a hardcoded literal).
+   *
+   * `order` is included only when the resolved value is a finite number so that
+   * `order: undefined` / `order: null` are never serialized. `order: 0` is sent
+   * because 0 is a legitimate top-of-stack position.
+   *
+   * @param {number} boardId
+   * @param {number} stackId
+   * @param {number} cardId
+   * @param {Object} card    - Current card from getStacks (carries real order + owner)
+   * @param {Object} [changes={}] - Fields to override (title, description, type, owner, order)
+   * @returns {Promise<Object>} PUT response from the Deck API
+   */
+  async updateCardComplete(boardId, stackId, cardId, card, changes = {}) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+
+    // Resolve owner: normalize object → uid string at every level of the chain
+    const resolvedOwner =
+      changes.owner?.uid ?? changes.owner ??
+      card.owner?.uid ?? card.owner ??
+      this.username;
+
+    const body = {
+      title:       changes.title       ?? card.title,
+      type:        changes.type        ?? card.type  ?? 'plain',
+      description: changes.description ?? card.description ?? '',
+      owner:       resolvedOwner,
+      order:       changes.order       ?? card.order
+    };
+
+    // Omit order entirely when it is not a finite number (undefined, null, NaN).
+    // DO send order:0 — it is a valid top-of-stack position.
+    if (!Number.isFinite(body.order)) {
+      delete body.order;
+    }
+
+    return await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
+      body);
+  }
+
   async deleteCardById(boardId, stackId, cardId) {
     if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
     await this._request('DELETE',

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -718,7 +718,7 @@ class HeartbeatManager {
                   const userConfig = mc._migratedConfig || mc._userConfig || `trust: ${mc.trust}\n`;
                   const newDesc = userConfig + this.cockpitManager._generateModelsCardDescription(mc.trust, mc.prefer || 'speed', infra);
                   this.cockpitManager._writeModelsCardDescription(
-                    { id: mc._cardId, description: mc._cardDescription, title: 'Models' },
+                    { id: mc._cardId, description: mc._cardDescription, title: 'Models', order: mc._cardOrder, owner: mc._cardOwner },
                     newDesc
                   ).catch(() => {});
                 }

--- a/test/unit/integrations/cockpit-manager.test.js
+++ b/test/unit/integrations/cockpit-manager.test.js
@@ -69,6 +69,16 @@ function createMockDeckClient(overrides = {}) {
       return overrides.shareBoard || { id: 1 };
     },
 
+    updateCardComplete: async (boardId, stackId, cardId, card, changes = {}) => {
+      calls.push({ method: 'updateCardComplete', boardId, stackId, cardId, card, changes });
+      if (overrides.updateCardComplete) {
+        return typeof overrides.updateCardComplete === 'function'
+          ? overrides.updateCardComplete(boardId, stackId, cardId, card, changes)
+          : overrides.updateCardComplete;
+      }
+      return { id: cardId, ...card, ...changes };
+    },
+
     _request: async (method, path, body) => {
       calls.push({ method: '_request', httpMethod: method, path, body });
       if (overrides._request) {
@@ -772,12 +782,13 @@ asyncTest('updateStatus() updates Health card description', async () => {
 
   await cm.updateStatus({ health: healthData });
 
+  // #135: writes now route through the canonical updateCardComplete helper
   const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
+    c.method === 'updateCardComplete' && c.changes && 'description' in c.changes
   );
 
-  // Should have at least one PUT call for updating card description
-  assert.ok(putCalls.length > 0, 'Should call PUT to update card');
+  // Should have at least one update call for the card description
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update card');
 });
 
 asyncTest('updateStatus() updates Costs card with monthly data', async () => {
@@ -799,15 +810,15 @@ asyncTest('updateStatus() updates Costs card with monthly data', async () => {
 
   await cm.updateStatus({ costs: costData });
 
-  const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
-  );
+  // #135: writes now route through the canonical updateCardComplete helper.
+  // Card identity is on call.card; the new body is in call.changes.description.
+  const putCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
 
-  assert.ok(putCalls.length > 0, 'Should call PUT to update Costs card');
-  const costsPut = putCalls.find(c => c.body?.title === 'Costs');
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update Costs card');
+  const costsPut = putCalls.find(c => c.card?.title === 'Costs');
   assert.ok(costsPut, 'Should update the Costs card');
-  assert.ok(costsPut.body.description.includes('12.50'), 'Should include monthly cost');
-  assert.ok(costsPut.body.description.includes('Local ratio: 83%'), 'Should include local ratio');
+  assert.ok(costsPut.changes.description.includes('12.50'), 'Should include monthly cost');
+  assert.ok(costsPut.changes.description.includes('Local ratio: 83%'), 'Should include local ratio');
 });
 
 asyncTest('updateStatus() updates Model Usage card with router stats', async () => {
@@ -826,15 +837,14 @@ asyncTest('updateStatus() updates Model Usage card with router stats', async () 
 
   await cm.updateStatus({ routerStats });
 
-  const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
-  );
+  // #135: writes now route through the canonical updateCardComplete helper.
+  const putCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
 
-  assert.ok(putCalls.length > 0, 'Should call PUT to update Model Usage card');
-  const usagePut = putCalls.find(c => c.body?.title === 'Model Usage');
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update Model Usage card');
+  const usagePut = putCalls.find(c => c.card?.title === 'Model Usage');
   assert.ok(usagePut, 'Should update the Model Usage card');
-  assert.ok(usagePut.body.description.includes('100 requests'), 'Should include total requests');
-  assert.ok(usagePut.body.description.includes('ollama (local)'), 'Should label local providers');
+  assert.ok(usagePut.changes.description.includes('100 requests'), 'Should include total requests');
+  assert.ok(usagePut.changes.description.includes('ollama (local)'), 'Should label local providers');
 });
 
 // --- New formatter tests ---
@@ -1606,6 +1616,143 @@ asyncTest('_resolveCardValue() backward compat: Gen1 Option 1/2/3 labels still r
   assert.strictEqual(cm._resolveCardValue({ id: 2, labels: [opt2] }, PERSONA_VALUE_MAP.Humor).source, 'moderate');
   assert.strictEqual(cm._resolveCardValue({ id: 3, labels: [opt3] }, PERSONA_VALUE_MAP.Humor).value, 'playful');
   assert.strictEqual(cm._resolveCardValue({ id: 3, labels: [opt3] }, PERSONA_VALUE_MAP.Humor).source, 'on');
+});
+
+// ============================================================
+// updateCardComplete routing tests (#135)
+// ============================================================
+
+console.log('\n--- updateCardComplete Routing Tests (issue #135) ---\n');
+
+asyncTest('updateStatus: routes through updateCardComplete, NOT _request directly', async () => {
+  const deck = createMockDeckClient();
+  const cm = new CockpitManager({ deckClient: deck });
+
+  // Manually initialize to bypass bootstrap
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  cm._statusPulseCount = 0;
+
+  // Provide a status stack with a Health card with a real order + owner
+  const healthCard = { id: 201, title: 'Health', description: 'old', type: 'plain', owner: { uid: 'moltagent' }, order: 3 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+
+  const updateCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
+  assert.ok(updateCalls.length >= 1, 'updateCardComplete should be called at least once for the Health card');
+
+  const requestCalls = deck._calls.filter(c => c.method === '_request' && c.httpMethod === 'PUT' && (c.path || '').includes('/cards/'));
+  assert.strictEqual(requestCalls.length, 0, 'direct _request PUT to card should NOT be called');
+});
+
+asyncTest('updateStatus: card.order is preserved from real card (not zeroed out)', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ boardId, stackId, cardId, card, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  cm._statusPulseCount = 0;
+
+  // Health card with order:3 — this should be threaded through, not overridden
+  const healthCard = { id: 201, title: 'Health', description: '', type: 'plain', owner: { uid: 'moltagent' }, order: 3 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+
+  const call = updateCompleteCalls.find(c => c.cardId === 201);
+  assert.ok(call, 'updateCardComplete should be called for the Health card');
+  assert.strictEqual(call.card.order, 3, 'original card.order=3 should be passed to helper, not 0');
+});
+
+asyncTest('updateStatus: unchanged description is skipped on repeat call (hash-skip intact)', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ cardId, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  // Start at 0; first call (pulse 1) always writes, second call (pulse 2) throttle skips.
+  // Force _statusPulseCount so the 3rd pulse is "1 mod 3 == 1" which writes again.
+  // Easiest: just test within a single pulse and verify the hash-skip per-card.
+  cm._statusPulseCount = 0;
+
+  const healthCard = { id: 201, title: 'Health', description: '', type: 'plain', owner: 'moltagent', order: 1 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  // First call — should write
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+  const firstWriteCount = updateCompleteCalls.length;
+  assert.ok(firstWriteCount >= 1, 'First pulse should write at least one card');
+
+  // Reset pulse count to 1 (bypass throttle) and call again — same content, hash-skip should fire
+  cm._statusPulseCount = 1;
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+  // 2nd pulse: throttle skips entirely (_statusPulseCount becomes 2, 2 % 3 !== 1)
+  // Total calls should not have increased for the throttled pulse
+  // The throttle fires at pulse 2 (count becomes 2, 2 > 1 and 2 % 3 != 1)
+  assert.strictEqual(updateCompleteCalls.length, firstWriteCount, 'Throttled pulse should not write additional cards');
+});
+
+asyncTest('_writeModelsCardDescription: routes through updateCardComplete with threaded order/owner', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ boardId, stackId, cardId, card, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { system: 60 };
+
+  // Card carries real order and owner (as threaded from _parseModelsCard)
+  const card = { id: 301, title: 'Models', description: 'old content', type: 'plain', owner: { uid: 'moltagent' }, order: 5 };
+
+  await cm._writeModelsCardDescription(card, 'new model description');
+
+  assert.strictEqual(updateCompleteCalls.length, 1, 'updateCardComplete should be called once');
+  assert.strictEqual(updateCompleteCalls[0].card.order, 5, 'original order should be threaded through');
+  assert.strictEqual(updateCompleteCalls[0].card.owner.uid, 'moltagent', 'owner object should be passed (helper normalizes it)');
+  assert.strictEqual(updateCompleteCalls[0].changes.description, 'new model description', 'new description should be in changes');
+
+  const requestCalls = deck._calls.filter(c => c.method === '_request' && c.httpMethod === 'PUT');
+  assert.strictEqual(requestCalls.length, 0, '_request PUT should not be called directly');
+});
+
+test('_parseModelsCard: sets _cardOrder and _cardOwner from real card', () => {
+  const deck = createMockDeckClient();
+  const cm = new CockpitManager({ deckClient: deck });
+
+  const card = {
+    id: 42,
+    description: `trust: cloud-ok\nprefer: speed\n\n---\n\nYour agent does six types of work.`,
+    labels: [],
+    order: 7,
+    owner: { uid: 'botuser', displayName: 'Bot User' }
+  };
+
+  const result = cm._parseModelsCard(card);
+
+  assert.strictEqual(result._cardId, 42, '_cardId should match card.id');
+  assert.strictEqual(result._cardOrder, 7, '_cardOrder should be set from card.order');
+  assert.deepStrictEqual(result._cardOwner, { uid: 'botuser', displayName: 'Bot User' }, '_cardOwner should be the full owner object');
 });
 
 // ============================================================

--- a/test/unit/integrations/deck-client.test.js
+++ b/test/unit/integrations/deck-client.test.js
@@ -1570,6 +1570,112 @@ test('stackHasPausedConfig: leading whitespace on CONFIG title is tolerated', ()
   assert.strictEqual(DeckClient.stackHasPausedConfig(stack), true);
 });
 
+// --- updateCardComplete Tests (#135) ---
+console.log('\n--- updateCardComplete Tests ---\n');
+
+asyncTest('TC-UCC-001: owner object {uid} normalized to bare uid string, order and description passed through', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/30': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 30, title: 'Original', type: 'plain', description: 'old', owner: { uid: 'botuser', displayName: 'Bot' }, order: 7 };
+
+  await client.updateCardComplete(10, 20, 30, card, { description: 'new desc' });
+
+  assert.strictEqual(capturedBody.owner, 'botuser', 'owner should be bare uid string');
+  assert.strictEqual(capturedBody.order, 7, 'order should be threaded from card');
+  assert.strictEqual(capturedBody.description, 'new desc', 'description from changes should win');
+  assert.strictEqual(capturedBody.title, 'Original', 'title from card used when not in changes');
+  assert.strictEqual(capturedBody.type, 'plain', 'type from card');
+});
+
+asyncTest('TC-UCC-002: owner missing in card and changes → falls back to this.username', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/31': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 31, title: 'X', type: 'plain', description: '', owner: undefined, order: 1 };
+
+  await client.updateCardComplete(10, 20, 31, card, {});
+
+  assert.strictEqual(capturedBody.owner, 'testuser', 'should fall back to this.username (mockNC.ncUser)');
+});
+
+asyncTest('TC-UCC-003: owner already a bare string is passed through unchanged', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/32': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 32, title: 'Y', type: 'plain', description: '', owner: 'stringowner', order: 2 };
+
+  await client.updateCardComplete(10, 20, 32, card, {});
+
+  assert.strictEqual(capturedBody.owner, 'stringowner', 'bare string owner should pass through');
+});
+
+asyncTest('TC-UCC-004: order:5 is sent; order:0 is also sent (valid top-of-stack)', async () => {
+  const bodies = [];
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/33': (path, options) => {
+      bodies.push(options.body);
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card5 = { id: 33, title: 'A', type: 'plain', description: '', owner: 'u', order: 5 };
+  const card0 = { id: 33, title: 'A', type: 'plain', description: '', owner: 'u', order: 0 };
+
+  await client.updateCardComplete(10, 20, 33, card5, {});
+  await client.updateCardComplete(10, 20, 33, card0, {});
+
+  assert.strictEqual(bodies[0].order, 5);
+  assert.strictEqual(bodies[1].order, 0, 'order:0 is a valid top-of-stack position and must be sent');
+  assert.ok('order' in bodies[1], 'order key must be present when value is 0');
+});
+
+asyncTest('TC-UCC-005: order absent on card (undefined) → key omitted entirely from body', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/34': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 34, title: 'B', type: 'plain', description: '', owner: 'u' /* no order */ };
+
+  await client.updateCardComplete(10, 20, 34, card, {});
+
+  assert.ok(!('order' in capturedBody), 'order key must be absent when card.order is undefined');
+});
+
+asyncTest('TC-UCC-006: missing identifiers throw DeckApiError', async () => {
+  const mockNC = createDeckMockNC();
+  const client = new DeckClient(mockNC);
+  const card = { id: 1, title: 'X', owner: 'u' };
+
+  let threw = false;
+  try {
+    await client.updateCardComplete(null, 20, 30, card, {});
+  } catch (err) {
+    threw = true;
+    assert.ok(err.name === 'DeckApiError', 'should be DeckApiError');
+  }
+  assert.ok(threw, 'should throw when boardId is missing');
+});
+
 // --- Summary ---
 setTimeout(() => {
   summary();


### PR DESCRIPTION
## What

CockpitManager status-card and Models-card writes fail with HTTP 400 on current Deck (Hub 26 / NC 34) because the hand-rolled PUT bodies were partial and divergent: they sent `owner` as an object (Deck rejects it — only a bare uid is accepted) and omitted `order`. Older Deck (Prime) silently accepts these, which is why the bug only surfaces for current-Deck users (Antonio).

Closes #135 **only after live current-Deck confirmation** (see Verification below — do not auto-close; squash to `next` won't close it anyway).

## How

- **`DeckClient.updateCardComplete()`** — the single canonical card-update body builder. Normalizes `owner` to a bare uid (object → uid, string passthrough, fallback to `this.username`, never a hardcoded literal) and threads the card's real `order`. Sends `order: 0` (valid top-of-stack) but omits `order` when non-finite via `Number.isFinite` — so we never reorder the operator's cards as a side effect (the `??`-not-`||` trap).
- Both CockpitManager writes (status cards, `_writeModelsCardDescription`) migrated to the helper. No ad-hoc card-update PUT remains in `cockpit-manager.js`.
- `_parseModelsCard` now sets `_cardOrder`/`_cardOwner`; the heartbeat writeback threads them so the synthetic Models card carries real order/owner (cache-hit path included).
- The `_descriptionHashes` skip stays **before** the helper call at both sites — no GET+PUT on unchanged cards per heartbeat.

A complete body is a superset older Deck still accepts → backward-safe.

## Scope

Narrow (CockpitManager's two writes), per the briefing. The same divergent-PUT class at four other sites (`deck_update_card`, `markCardDone`, `updateCardById`, `updateCard`) is filed as the generator follow-up: #139.

## Verification

- `npm run lint` → 0 errors.
- `npm run test:unit` → 220/220 test files pass. New: 6 helper unit tests (owner object/string/fallback, order 5/0/omitted, identifier guard) + 5 routing tests; 3 pre-existing status-card tests updated to assert via the helper.
- Reviewer (opus) verdict: **APPROVE** — owner normalization, order preservation, both sites migrated, hash-skip intact, backward-safe, no Rule 1 concern.

**BUILT ≠ VERIFIED — pending merge gate:**
- [ ] Prime no-regression + **no-reorder** check after deploy+restart (Prime can't reproduce the 400; this proves backward-safety).
- [ ] Live current-Deck confirmation (Antonio's Cockpit cards update; the true async gate that closes #135). Prime becomes a second repro env post-NC-34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)