### PR TITLE
fix(cockpit): self-heal stale/missing board registry entry on upgrade (#141)

### DIFF
--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -250,13 +250,15 @@ class CockpitManager {
    * @param {string} [options.config.boardTitle] - Board title override
    * @param {number} [options.config.cacheTTLMs] - Cache TTL in ms (default: 300000 = 5 min)
    * @param {Function} [options.auditLog] - Audit logging function
+   * @param {Object} [options.boardRegistry] - Board registry (defaults to the module singleton; injectable for tests)
    */
-  constructor({ deckClient, config = {}, auditLog } = {}) {
+  constructor({ deckClient, config = {}, auditLog, boardRegistry: injectedRegistry } = {}) {
     if (!deckClient) {
       throw new Error('CockpitManager requires a deckClient instance');
     }
 
     this.deck = deckClient;
+    this.boardRegistry = injectedRegistry || boardRegistry;
     this.adminUser = config.adminUser || appConfig.cockpit?.adminUser || '';
     this.boardTitle = config.boardTitle || appConfig.cockpit?.boardTitle || BOARD_TITLE;
     this.auditLog = auditLog || (async () => {});
@@ -316,8 +318,10 @@ class CockpitManager {
    */
   async initialize() {
     try {
-      // Find existing board by role (survives renames)
-      const boardId = await boardRegistry.resolveBoard(this.deck, ROLES.cockpit, this.boardTitle);
+      // Find existing board by role (survives renames). `let` because a stale
+      // entry is cleared to null below, converging both failure modes on the
+      // self-heal path.
+      let boardId = await this.boardRegistry.resolveBoard(this.deck, ROLES.cockpit, this.boardTitle);
       let board = null;
 
       if (boardId) {
@@ -326,43 +330,46 @@ class CockpitManager {
         } catch (err) {
           if (err.statusCode === 404 || err.statusCode === 403 ||
               /Authentication error:\s*(401|403)/.test(err.message)) {
-            boardRegistry.invalidateBoard(ROLES.cockpit);
+            // Stale or forbidden registry entry — clear it and fall through to
+            // the self-heal below (treat exactly like a missing entry).
+            this.boardRegistry.invalidateBoard(ROLES.cockpit);
+            boardId = null;
           } else {
             throw err;
           }
         }
       }
 
-      if (!board && boardId) {
-        // Registry had an ID but getBoard returned 404/403 — board was deleted.
-        // Do NOT auto-create a replacement. The operator needs to decide.
-        throw new CockpitError(
-          `Cockpit board ${boardId} not found (deleted?). ` +
-          `Remove stale registry entry or create a new board manually.`,
-          'initialize'
-        );
-      }
-
+      // Self-heal (cold path only): no valid registry entry, but a cockpit-titled
+      // board already exists → adopt and register it. Covers both the missing-entry
+      // case and the just-invalidated stale-ID case (#141). This one-time title
+      // match lives here, off the hot path — resolveBoard itself never title-scans,
+      // so #137's canonical-registry invariant is preserved.
       if (!board && !boardId) {
-        // No registry entry AND no name match — true first boot OR renamed board.
-        // Only bootstrap if no boards exist at all (prevents duplicates).
         const allBoards = await this.deck.listBoards();
-        const hasCockpitLike = allBoards.some(b =>
+        const cockpitBoard = allBoards.find(b =>
           (b.title || '').toLowerCase().includes('cockpit')
         );
-        if (hasCockpitLike) {
-          throw new CockpitError(
-            `No cockpit board in registry, but a board with "cockpit" in the title exists. ` +
-            `Register it manually: node -e "require('./src/lib/integrations/deck-board-registry').registerBoard('cockpit', BOARD_ID)"`,
-            'initialize'
-          );
+        if (cockpitBoard) {
+          try {
+            board = await this.deck.getBoard(cockpitBoard.id);
+          } catch (_err) {
+            // Board vanished between listBoards and getBoard — fall through to
+            // bootstrap (treat as "no cockpit board exists").
+            board = null;
+          }
+          if (board) {
+            this.boardRegistry.registerBoard(ROLES.cockpit, board.id);
+            console.log(
+              `[CockpitManager] Upgrade migration: registered cockpit board ${board.id} ` +
+              `(title: "${cockpitBoard.title}"). One-time — the registry is now canonical.`
+            );
+          }
         }
-        const bootstrapResult = await this.bootstrap();
-        this.boardId = bootstrapResult.boardId;
-        this.stacks = bootstrapResult.stacks;
-        this.labels = bootstrapResult.labels;
-      } else {
-        // Board exists, resolve IDs
+      }
+
+      if (board) {
+        // Board resolved (from registry or self-heal) — shared post-resolution logic.
         this.boardId = board.id;
 
         // board already has full details from getBoard() above
@@ -393,6 +400,14 @@ class CockpitManager {
 
         // Remove obsolete cards from status stack (e.g. Tasks This Week, Knowledge, Recent Actions)
         await this._removeObsoleteCards(stacks);
+      } else {
+        // True first boot — no cockpit board exists anywhere. Bootstrap creates
+        // and registers it (prevents duplicates: only reached when self-heal
+        // found no cockpit-titled board).
+        const bootstrapResult = await this.bootstrap();
+        this.boardId = bootstrapResult.boardId;
+        this.stacks = bootstrapResult.stacks;
+        this.labels = bootstrapResult.labels;
       }
 
       this._initialized = true;
@@ -435,7 +450,7 @@ class CockpitManager {
         color: BOARD_COLOR
       });
       const boardId = board.id;
-      boardRegistry.registerBoard(ROLES.cockpit, boardId);
+      this.boardRegistry.registerBoard(ROLES.cockpit, boardId);
 
       // 2. Share with admin user (if configured)
       if (this.adminUser) {

--- a/test/unit/integrations/cockpit-manager.test.js
+++ b/test/unit/integrations/cockpit-manager.test.js
@@ -51,6 +51,7 @@ function createMockDeckClient(overrides = {}) {
 
     getBoard: async (boardId) => {
       calls.push({ method: 'getBoard', boardId });
+      if (typeof overrides.getBoard === 'function') return overrides.getBoard(boardId);
       return overrides.getBoard || { id: boardId, title: BOARD_TITLE, stacks: [], labels: [] };
     },
 
@@ -1753,6 +1754,128 @@ test('_parseModelsCard: sets _cardOrder and _cardOwner from real card', () => {
   assert.strictEqual(result._cardId, 42, '_cardId should match card.id');
   assert.strictEqual(result._cardOrder, 7, '_cardOrder should be set from card.order');
   assert.deepStrictEqual(result._cardOwner, { uid: 'botuser', displayName: 'Bot User' }, '_cardOwner should be the full owner object');
+});
+
+// ============================================================
+// initialize() self-heal / upgrade-migration tests (#141)
+// ============================================================
+
+console.log('\n--- initialize() Registry Self-Heal Tests (issue #141) ---\n');
+
+/**
+ * Minimal in-memory board registry, injected per test so the concurrent runner
+ * never races the module singleton. Records register/invalidate/resolve calls.
+ */
+function createFakeRegistry(initial = {}) {
+  const store = { ...initial };
+  const calls = { register: [], invalidate: [], resolve: [] };
+  return {
+    _store: store,
+    _calls: calls,
+    // eslint-disable-next-line require-await
+    resolveBoard: async (_deck, role) => {
+      calls.resolve.push(role);
+      return (role in store) ? store[role] : null;
+    },
+    registerBoard: (role, boardId) => { calls.register.push({ role, boardId }); store[role] = boardId; },
+    invalidateBoard: (role) => { calls.invalidate.push(role); delete store[role]; },
+  };
+}
+
+function notFoundError(id) {
+  const e = new Error(`Board ${id} not found`);
+  e.statusCode = 404;
+  return e;
+}
+
+const BOARD_POST_PATH = '/index.php/apps/deck/api/v1.0/boards';
+const boardCreatePosts = (deck) => deck._calls.filter(c =>
+  c.method === '_request' && c.httpMethod === 'POST' && c.path === BOARD_POST_PATH);
+
+asyncTest('initialize(): stale registry id self-heals — getBoard 404 → invalidate → adopt cockpit-titled board (#141)', async () => {
+  const reg = createFakeRegistry({ cockpit: 999 }); // stale: board 999 no longer exists
+  const deck = createMockDeckClient({
+    getBoard: (id) => {
+      if (id === 999) throw notFoundError(999);
+      return { id, title: BOARD_TITLE, labels: [] };
+    },
+    listBoards: [{ id: 14, title: BOARD_TITLE }],
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14, 'should adopt the real cockpit board 14');
+  assert.strictEqual(reg._store.cockpit, 14, 'registry should be re-pointed to 14');
+  assert.deepStrictEqual(reg._calls.invalidate, ['cockpit'], 'stale entry invalidated exactly once');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 14 }], 'registers cockpit→14 exactly once (no duplicate)');
+  assert.strictEqual(boardCreatePosts(deck).length, 0, 'must NOT bootstrap a new board when one exists');
+});
+
+asyncTest('initialize(): missing registry entry self-heals — adopt cockpit-titled board (#141)', async () => {
+  const reg = createFakeRegistry({}); // no cockpit entry at all
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 14, title: BOARD_TITLE }],
+    getBoard: { id: 14, title: BOARD_TITLE, labels: [] },
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14, 'should adopt board 14');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 14 }], 'seeds cockpit→14 exactly once');
+  assert.strictEqual(reg._calls.invalidate.length, 0, 'nothing to invalidate when entry was already absent');
+  assert.strictEqual(boardCreatePosts(deck).length, 0, 'must NOT bootstrap');
+});
+
+asyncTest('initialize(): no cockpit board anywhere → bootstrap creates one (true first boot, unchanged) (#141)', async () => {
+  const reg = createFakeRegistry({});
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 5, title: 'Personal Tasks' }], // exists, but none cockpit-titled
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.ok(boardCreatePosts(deck).length >= 1, 'should bootstrap a new board when no cockpit board exists');
+  assert.strictEqual(cm.boardId, 99, 'boardId comes from bootstrap (mock POST /boards → id 99)');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 99 }], 'bootstrap registered the new board');
+});
+
+asyncTest('initialize(): cockpit board vanishes between listBoards and getBoard → falls through to bootstrap (#141)', async () => {
+  const reg = createFakeRegistry({}); // no entry → self-heal path
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 14, title: BOARD_TITLE }], // appears in the list…
+    getBoard: (id) => { throw notFoundError(id); }, // …but getBoard 404s (deleted mid-flight)
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize(); // must not crash
+
+  assert.ok(boardCreatePosts(deck).length >= 1, 'should fall through to bootstrap when the found board vanished');
+  assert.strictEqual(cm.boardId, 99, 'boardId from bootstrap');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 99 }], 'only the bootstrapped board is registered');
+});
+
+asyncTest('initialize(): self-heal does NOT title-scan on the resolve hot path — only on the cold path (#141)', async () => {
+  // Registry resolves cleanly → listBoards must never be consulted (no title scan).
+  const reg = createFakeRegistry({ cockpit: 14 });
+  const deck = createMockDeckClient({
+    getBoard: { id: 14, title: BOARD_TITLE, labels: [] },
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14);
+  assert.strictEqual(deck._calls.filter(c => c.method === 'listBoards').length, 0,
+    'listBoards (title scan) must NOT run when the registry resolves — canonical invariant preserved');
+  assert.strictEqual(reg._calls.register.length, 0, 'no re-register on the clean resolve path');
 });
 
 // ============================================================


### PR DESCRIPTION
## What

#137 made the board registry canonical and removed the live title-search fallback from `resolveBoard`. That fallback was silently self-healing stale/missing cockpit entries on existing deployments. With it gone, `CockpitManager.initialize()` hard-fails on **upgrade** — the Cockpit goes silently dead, recoverable only by a manual `registerBoard`. Caught live on Prime during the #135 deploy (stale `cockpit→99`). 0.1.4-beta ships #137, so other upgrading operators would hit this.

Closes #141 (verifiable directly on Prime — unlike #135, no current-Deck dependency).

## How

- **One-time self-heal on the COLD path** of `initialize()`: no valid registry entry but a cockpit-titled board exists → adopt and register it, then flow into the normal post-resolution logic. The **hot path (`resolveBoard`, every heartbeat) still never title-scans** — #137's canonical invariant is preserved; the title match lives only on the cold/error path and fires once per deployment.
- **Both failure modes converge.** The stale-ID case (`getBoard` 404 → `invalidateBoard`) previously left the local `boardId` set and hit a *separate* "board N not found" throw, never reaching the self-heal — so the briefing's literal "fix the missing-entry branch" would **not** have fixed Prime's actual regression. Set `boardId = null` after invalidate so stale-ID and missing-entry both reach the single self-heal.
- **Shared downstream logic.** Restructured the if/else so adopted and resolved boards run the same getStacks / resolveIds / label-migration / missing-cards path. Bootstrap still fires only when no cockpit board exists at all (duplicate-prevention intact).
- **Registry injectable** into CockpitManager (default = module singleton) so the self-heal paths are testable without racing the shared singleton under the concurrent test runner.

## Verification

- `npm run lint` → 0 errors. `npm run test:unit` → 220/220 files. 94/94 cockpit unit tests (5 new #141 cases: stale-ID, missing-entry, no-board→bootstrap, found-board-vanishes→bootstrap, clean-resolve-no-title-scan).
- Reviewer (opus): **APPROVE**, all 8 criteria PASS.
- **Live on Prime (the production gate):**
  - Stale `cockpit→999` + restart → `[CockpitManager] Upgrade migration: registered cockpit board 14 (title: "⭐ Moltagent Cockpit")` → `Cockpit manager initialized`, registry self-heals to 14. (Prime's exact original regression.)
  - Cleared entry + restart → same self-heal to 14.
  - No-regression: status cards update post-self-heal (Health card `lastModified` fresh post-restart, `order=0` preserved), no cockpit/card errors, registry settles at `cockpit→14`.

[VERIFIED on Prime — see commit body and PR description.]

## Scope

`resolveBoard` and `bootstrap()` internals untouched (#137 invariant + first-boot path preserved). Match criteria kept as `includes('cockpit')` per briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)