### PR TITLE
Release v0.1.4-beta - Cockpit reliability

### DIFF
--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -856,13 +856,9 @@ class CockpitManager {
           const hash = crypto.createHash('sha256').update(description).digest('hex');
           if (this._descriptionHashes.get(card.id) === hash) continue;
 
-          const updatePath = `/index.php/apps/deck/api/v1.0/boards/${this.boardId}/stacks/${this.stacks.status}/cards/${card.id}`;
-          await this.deck._request('PUT', updatePath, {
-            title: card.title,
-            description: description,
-            type: 'plain',
-            owner: card.owner || 'moltagent'
-          });
+          await this.deck.updateCardComplete(
+            this.boardId, this.stacks.status, card.id, card, { description }
+          );
           this._descriptionHashes.set(card.id, hash);
         } catch (err) {
           console.warn(`[CockpitManager] Failed to update ${card.title}:`, err.message);
@@ -1191,6 +1187,8 @@ class CockpitManager {
     // Store card metadata for heartbeat writeback
     result._cardId = card.id;
     result._cardDescription = card.description || '';
+    result._cardOrder = card.order;
+    result._cardOwner = card.owner;
     result._userConfig = configSection.trim() + '\n';
     result._cardLabels = (card.labels || []).map(l => l.title);
 
@@ -1711,13 +1709,9 @@ class CockpitManager {
     try {
       const stackId = this.stacks.system;
       if (stackId) {
-        const updatePath = `/index.php/apps/deck/api/v1.0/boards/${this.boardId}/stacks/${stackId}/cards/${card.id}`;
-        await this.deck._request('PUT', updatePath, {
-          title: card.title || 'Models',
-          description: newDescription,
-          type: 'plain',
-          owner: card.owner || 'moltagent'
-        });
+        await this.deck.updateCardComplete(
+          this.boardId, stackId, card.id, card, { description: newDescription }
+        );
         this._descriptionHashes.set(card.id, hash);
       }
     } catch (err) {

--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -250,13 +250,15 @@ class CockpitManager {
    * @param {string} [options.config.boardTitle] - Board title override
    * @param {number} [options.config.cacheTTLMs] - Cache TTL in ms (default: 300000 = 5 min)
    * @param {Function} [options.auditLog] - Audit logging function
+   * @param {Object} [options.boardRegistry] - Board registry (defaults to the module singleton; injectable for tests)
    */
-  constructor({ deckClient, config = {}, auditLog } = {}) {
+  constructor({ deckClient, config = {}, auditLog, boardRegistry: injectedRegistry } = {}) {
     if (!deckClient) {
       throw new Error('CockpitManager requires a deckClient instance');
     }
 
     this.deck = deckClient;
+    this.boardRegistry = injectedRegistry || boardRegistry;
     this.adminUser = config.adminUser || appConfig.cockpit?.adminUser || '';
     this.boardTitle = config.boardTitle || appConfig.cockpit?.boardTitle || BOARD_TITLE;
     this.auditLog = auditLog || (async () => {});
@@ -316,8 +318,10 @@ class CockpitManager {
    */
   async initialize() {
     try {
-      // Find existing board by role (survives renames)
-      const boardId = await boardRegistry.resolveBoard(this.deck, ROLES.cockpit, this.boardTitle);
+      // Find existing board by role (survives renames). `let` because a stale
+      // entry is cleared to null below, converging both failure modes on the
+      // self-heal path.
+      let boardId = await this.boardRegistry.resolveBoard(this.deck, ROLES.cockpit, this.boardTitle);
       let board = null;
 
       if (boardId) {
@@ -326,43 +330,46 @@ class CockpitManager {
         } catch (err) {
           if (err.statusCode === 404 || err.statusCode === 403 ||
               /Authentication error:\s*(401|403)/.test(err.message)) {
-            boardRegistry.invalidateBoard(ROLES.cockpit);
+            // Stale or forbidden registry entry — clear it and fall through to
+            // the self-heal below (treat exactly like a missing entry).
+            this.boardRegistry.invalidateBoard(ROLES.cockpit);
+            boardId = null;
           } else {
             throw err;
           }
         }
       }
 
-      if (!board && boardId) {
-        // Registry had an ID but getBoard returned 404/403 — board was deleted.
-        // Do NOT auto-create a replacement. The operator needs to decide.
-        throw new CockpitError(
-          `Cockpit board ${boardId} not found (deleted?). ` +
-          `Remove stale registry entry or create a new board manually.`,
-          'initialize'
-        );
-      }
-
+      // Self-heal (cold path only): no valid registry entry, but a cockpit-titled
+      // board already exists → adopt and register it. Covers both the missing-entry
+      // case and the just-invalidated stale-ID case (#141). This one-time title
+      // match lives here, off the hot path — resolveBoard itself never title-scans,
+      // so #137's canonical-registry invariant is preserved.
       if (!board && !boardId) {
-        // No registry entry AND no name match — true first boot OR renamed board.
-        // Only bootstrap if no boards exist at all (prevents duplicates).
         const allBoards = await this.deck.listBoards();
-        const hasCockpitLike = allBoards.some(b =>
+        const cockpitBoard = allBoards.find(b =>
           (b.title || '').toLowerCase().includes('cockpit')
         );
-        if (hasCockpitLike) {
-          throw new CockpitError(
-            `No cockpit board in registry, but a board with "cockpit" in the title exists. ` +
-            `Register it manually: node -e "require('./src/lib/integrations/deck-board-registry').registerBoard('cockpit', BOARD_ID)"`,
-            'initialize'
-          );
+        if (cockpitBoard) {
+          try {
+            board = await this.deck.getBoard(cockpitBoard.id);
+          } catch (_err) {
+            // Board vanished between listBoards and getBoard — fall through to
+            // bootstrap (treat as "no cockpit board exists").
+            board = null;
+          }
+          if (board) {
+            this.boardRegistry.registerBoard(ROLES.cockpit, board.id);
+            console.log(
+              `[CockpitManager] Upgrade migration: registered cockpit board ${board.id} ` +
+              `(title: "${cockpitBoard.title}"). One-time — the registry is now canonical.`
+            );
+          }
         }
-        const bootstrapResult = await this.bootstrap();
-        this.boardId = bootstrapResult.boardId;
-        this.stacks = bootstrapResult.stacks;
-        this.labels = bootstrapResult.labels;
-      } else {
-        // Board exists, resolve IDs
+      }
+
+      if (board) {
+        // Board resolved (from registry or self-heal) — shared post-resolution logic.
         this.boardId = board.id;
 
         // board already has full details from getBoard() above
@@ -393,6 +400,14 @@ class CockpitManager {
 
         // Remove obsolete cards from status stack (e.g. Tasks This Week, Knowledge, Recent Actions)
         await this._removeObsoleteCards(stacks);
+      } else {
+        // True first boot — no cockpit board exists anywhere. Bootstrap creates
+        // and registers it (prevents duplicates: only reached when self-heal
+        // found no cockpit-titled board).
+        const bootstrapResult = await this.bootstrap();
+        this.boardId = bootstrapResult.boardId;
+        this.stacks = bootstrapResult.stacks;
+        this.labels = bootstrapResult.labels;
       }
 
       this._initialized = true;
@@ -435,7 +450,7 @@ class CockpitManager {
         color: BOARD_COLOR
       });
       const boardId = board.id;
-      boardRegistry.registerBoard(ROLES.cockpit, boardId);
+      this.boardRegistry.registerBoard(ROLES.cockpit, boardId);
 
       // 2. Share with admin user (if configured)
       if (this.adminUser) {

--- a/src/lib/integrations/deck-board-registry.js
+++ b/src/lib/integrations/deck-board-registry.js
@@ -22,23 +22,22 @@
  * that does listBoards().find(b => b.title === name) is fragile.  A renamed
  * board becomes invisible until code is changed or a new board is created.
  *
- * Pattern: Role-to-ID registry persisted as a small JSON file.  On first
- * access per role the registry falls through: memory → disk → live name scan.
- * Once an ID is found it is stored and subsequent lookups are O(1) memory
- * reads, with no Deck API traffic at all.  Atomic writes (tmp + rename) keep
- * the file consistent even if the process crashes mid-write.
+ * Pattern: Role-to-ID registry persisted as a small JSON file, treated as the
+ * canonical source of truth.  resolveBoard falls through memory → disk → null;
+ * it never scans live Deck titles (#49), so an emoji-prefixed or renamed board
+ * cannot break resolution.  A cache miss re-reads disk, so a registerBoard run
+ * from a separate process is picked up without a restart.  Atomic writes (tmp +
+ * rename) keep the file consistent even if the process crashes mid-write.
  *
  * Key Dependencies:
  *   - fs (Node built-in) — file I/O, atomic rename
  *   - path (Node built-in) — cross-platform path resolution
- *   - DeckClient.listBoards() — fallback name scan (caller-supplied)
  *
  * Data Flow:
- *   resolveBoard(deckClient, role, fallbackTitle)
- *     -> _cache hit?          -> return boardId
- *     -> _loadFromDisk()      -> cache populated from file? -> return boardId
- *     -> deckClient.listBoards() -> name match? -> registerBoard() -> return boardId
- *     -> no match             -> return null
+ *   resolveBoard(role)
+ *     -> cold cache?          -> _loadFromDisk()
+ *     -> role still missing?  -> _loadFromDisk() again (picks up out-of-process writes)
+ *     -> return _cache[role]?.boardId ?? null   (no live title scan)
  *
  *   registerBoard(role, boardId)
  *     -> update _cache
@@ -81,53 +80,31 @@ class DeckBoardRegistry {
   // ---------------------------------------------------------------------------
 
   /**
-   * Resolve a board by role.  Falls through memory → disk → live name scan.
+   * Resolve a board by role.  The registry is canonical: memory → disk → null.
+   * It never scans live Deck titles (#49), so an emoji-prefixed or renamed board
+   * cannot break resolution.  An unregistered role returns null; the caller
+   * raises an actionable "register it" error.
    *
-   * @param {Object} deckClient - DeckClient instance (must expose listBoards())
+   * @param {Object} _deckClient - Unused; retained for signature stability (callers pass their DeckClient).
    * @param {string} role - One of ROLES.*
-   * @param {string} fallbackTitle - Board title used for the live name scan
-   * @returns {Promise<number|string|null>} boardId, or null if not found
+   * @param {string} _fallbackTitle - Unused; retained for signature stability (was the live-scan title).
+   * @returns {Promise<number|string|null>} boardId, or null if not registered
    */
-  async resolveBoard(deckClient, role, fallbackTitle) {
-    // 1. Memory hit
-    if (this._cache !== null && this._cache[role]) {
-      return this._cache[role].boardId;
-    }
-
-    // 2. Cold cache — load from disk first
+  // eslint-disable-next-line require-await -- async retained for the caller contract (callers await this); resolution is now a pure memory/disk read with no async work
+  async resolveBoard(_deckClient, role, _fallbackTitle) {
+    // Cold cache — load from disk once.
     if (this._cache === null) {
       this._loadFromDisk();
     }
 
-    if (this._cache[role]) {
-      return this._cache[role].boardId;
+    // Re-read disk on a miss so a registerBoard from a separate process is
+    // picked up without a restart (#49 Part B).  Skipped in test mode, where
+    // _reset() pins a clean in-memory slate and the disk must not be re-read.
+    if (!this._cache[role] && !this._testMode) {
+      this._loadFromDisk();
     }
 
-    // 3. First-boot migration: scan boards by name (runs once, then never again)
-    if (!deckClient || typeof deckClient.listBoards !== 'function') {
-      return null;
-    }
-
-    const boards = await deckClient.listBoards();
-    if (!Array.isArray(boards)) return null;
-
-    const needle = (fallbackTitle || '').trim().toLowerCase();
-    const match  = boards.find(b => (b.title || '').trim().toLowerCase() === needle);
-
-    if (match) {
-      this.registerBoard(role, match.id);
-      return match.id;
-    }
-
-    // No exact match — log what exists so the operator can resolve manually
-    const existing = boards.map(b => `  ${b.id}: "${b.title}"`).join('\n');
-    console.warn(
-      `[DeckBoardRegistry] No board matching "${fallbackTitle}" for role "${role}".\n` +
-      `Existing boards:\n${existing}\n` +
-      `If the board was renamed, register it manually:\n` +
-      `  node -e "require('./src/lib/integrations/deck-board-registry').registerBoard('${role}', BOARD_ID)"`
-    );
-    return null;
+    return this._cache[role]?.boardId ?? null;
   }
 
   /**

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -671,6 +671,59 @@ class DeckClient {
       updates);
   }
 
+  /**
+   * Build and PUT a complete, normalized card body — the single canonical
+   * card-update body builder for all CockpitManager writes.
+   *
+   * The Deck API rejects partial PUT bodies: every field must be present or the
+   * server clobbers missing fields with defaults. This helper resolves each
+   * required field from `changes` (caller intent) → `card` (current server
+   * state) → safe default, so callers never construct the body themselves.
+   *
+   * Key fix for #135: `owner` is normalized from an object (e.g. `{uid:'botuser'}`)
+   * to a bare uid string. Deck PUT rejects an owner-object in the body; the API
+   * only accepts the uid. Falls back to `this.username` (the deployment-aware bot
+   * uid read from NCRequestManager, never a hardcoded literal).
+   *
+   * `order` is included only when the resolved value is a finite number so that
+   * `order: undefined` / `order: null` are never serialized. `order: 0` is sent
+   * because 0 is a legitimate top-of-stack position.
+   *
+   * @param {number} boardId
+   * @param {number} stackId
+   * @param {number} cardId
+   * @param {Object} card    - Current card from getStacks (carries real order + owner)
+   * @param {Object} [changes={}] - Fields to override (title, description, type, owner, order)
+   * @returns {Promise<Object>} PUT response from the Deck API
+   */
+  async updateCardComplete(boardId, stackId, cardId, card, changes = {}) {
+    if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
+
+    // Resolve owner: normalize object → uid string at every level of the chain
+    const resolvedOwner =
+      changes.owner?.uid ?? changes.owner ??
+      card.owner?.uid ?? card.owner ??
+      this.username;
+
+    const body = {
+      title:       changes.title       ?? card.title,
+      type:        changes.type        ?? card.type  ?? 'plain',
+      description: changes.description ?? card.description ?? '',
+      owner:       resolvedOwner,
+      order:       changes.order       ?? card.order
+    };
+
+    // Omit order entirely when it is not a finite number (undefined, null, NaN).
+    // DO send order:0 — it is a valid top-of-stack position.
+    if (!Number.isFinite(body.order)) {
+      delete body.order;
+    }
+
+    return await this._request('PUT',
+      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
+      body);
+  }
+
   async deleteCardById(boardId, stackId, cardId) {
     if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
     await this._request('DELETE',

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -718,7 +718,7 @@ class HeartbeatManager {
                   const userConfig = mc._migratedConfig || mc._userConfig || `trust: ${mc.trust}\n`;
                   const newDesc = userConfig + this.cockpitManager._generateModelsCardDescription(mc.trust, mc.prefer || 'speed', infra);
                   this.cockpitManager._writeModelsCardDescription(
-                    { id: mc._cardId, description: mc._cardDescription, title: 'Models' },
+                    { id: mc._cardId, description: mc._cardDescription, title: 'Models', order: mc._cardOrder, owner: mc._cardOwner },
                     newDesc
                   ).catch(() => {});
                 }

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -2424,9 +2424,10 @@ Be thoughtful. Be honest. Be yourself.`;
     const now = new Date();
     const timeStr = `${now.toLocaleDateString('en-US', { weekday: 'long' })}, ${now.toISOString().split('T')[0]} ${now.toTimeString().split(' ')[0]} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`;
 
-    const prompt = `You are a KNOWLEDGE SYNTHESIZER. You can ONLY answer questions — you CANNOT perform actions.
-DO NOT claim you created a card, sent an email, booked a meeting, moved anything, or performed ANY action.
-If the user asked you to DO something, say what you FOUND, then say: "I couldn't complete that action — please ask me separately."
+    const prompt = `Role: knowledge synthesizer.
+Capabilities: answering questions from the provided data sources.
+Actions (creating cards, sending emails, booking meetings, moving items): not available in this mode.
+When the question includes an action request: present findings first, then state that the action requires a separate request.
 
 Current date/time: ${timeStr}
 ${conversationBlock}${indexBlock}

--- a/test/unit/ensure-meetings-board.test.js
+++ b/test/unit/ensure-meetings-board.test.js
@@ -15,6 +15,7 @@ const { test, asyncTest, summary, exitWithCode } = require('../helpers/test-runn
 
 const ensureMeetingsBoard = require('../../src/lib/calendar/ensure-meetings-board');
 const boardRegistry = require('../../src/lib/integrations/deck-board-registry');
+const { ROLES } = require('../../src/lib/integrations/deck-board-registry');
 
 // ============================================================
 // Test Fixtures
@@ -68,12 +69,13 @@ asyncTest('creates board when none exists — calls createNewBoard, createStack 
   assert.strictEqual(result.existed, false);
 });
 
-asyncTest('skips creation when board already exists — returns { existed: true }', async () => {
+asyncTest('skips creation when board is registered — returns { existed: true }', async () => {
   boardRegistry._reset();
+  // The registry is canonical: a registered role resolves without any title scan.
+  boardRegistry.registerBoard(ROLES.meetings, 42);
   let createNewBoardCalled = false;
 
   const deck = createMockDeck({
-    listBoards: async () => [{ id: 42, title: 'Pending Meetings' }],
     createNewBoard: async () => {
       createNewBoardCalled = true;
       return { id: 99, title: 'Pending Meetings' };
@@ -87,12 +89,16 @@ asyncTest('skips creation when board already exists — returns { existed: true 
   assert.strictEqual(result.boardId, 42);
 });
 
-asyncTest('case-insensitive matching — "pending meetings" matches', async () => {
+asyncTest('resolves a registered board regardless of its live title (#49 canonical)', async () => {
   boardRegistry._reset();
+  boardRegistry.registerBoard(ROLES.meetings, 77);
   let createNewBoardCalled = false;
 
+  // The live board carries a divergent/emoji-prefixed title that the old
+  // exact-title scan would miss (#99).  Resolution comes from the registry, so
+  // the live title is never consulted and creation is skipped.
   const deck = createMockDeck({
-    listBoards: async () => [{ id: 77, title: 'pending meetings' }],
+    listBoards: async () => [{ id: 77, title: '⭐ pending meetings' }],
     createNewBoard: async () => {
       createNewBoardCalled = true;
       return { id: 99, title: 'Pending Meetings' };
@@ -101,20 +107,15 @@ asyncTest('case-insensitive matching — "pending meetings" matches', async () =
 
   const result = await ensureMeetingsBoard(deck);
 
-  assert.strictEqual(createNewBoardCalled, false, 'should not create when lowercase match exists');
+  assert.strictEqual(createNewBoardCalled, false, 'registered board must not be re-created');
   assert.strictEqual(result.existed, true);
   assert.strictEqual(result.boardId, 77);
 });
 
-asyncTest('returns boardId from existing board', async () => {
+asyncTest('returns boardId from a registered board', async () => {
   boardRegistry._reset();
-  const deck = createMockDeck({
-    listBoards: async () => [
-      { id: 10, title: 'Some Other Board' },
-      { id: 55, title: 'Pending Meetings' },
-      { id: 20, title: 'Archive' }
-    ]
-  });
+  boardRegistry.registerBoard(ROLES.meetings, 55);
+  const deck = createMockDeck();
 
   const result = await ensureMeetingsBoard(deck);
 
@@ -176,8 +177,9 @@ asyncTest('workflow rules card has correct content', async () => {
 
 asyncTest('propagates errors thrown by DeckClient', async () => {
   boardRegistry._reset();
+  // Unregistered role → create path; the deck's create call is the failure point.
   const deck = createMockDeck({
-    listBoards: async () => { throw new Error('network failure'); }
+    createNewBoard: async () => { throw new Error('network failure'); }
   });
 
   let caught = null;

--- a/test/unit/integrations/cockpit-manager.test.js
+++ b/test/unit/integrations/cockpit-manager.test.js
@@ -51,6 +51,7 @@ function createMockDeckClient(overrides = {}) {
 
     getBoard: async (boardId) => {
       calls.push({ method: 'getBoard', boardId });
+      if (typeof overrides.getBoard === 'function') return overrides.getBoard(boardId);
       return overrides.getBoard || { id: boardId, title: BOARD_TITLE, stacks: [], labels: [] };
     },
 
@@ -1753,6 +1754,128 @@ test('_parseModelsCard: sets _cardOrder and _cardOwner from real card', () => {
   assert.strictEqual(result._cardId, 42, '_cardId should match card.id');
   assert.strictEqual(result._cardOrder, 7, '_cardOrder should be set from card.order');
   assert.deepStrictEqual(result._cardOwner, { uid: 'botuser', displayName: 'Bot User' }, '_cardOwner should be the full owner object');
+});
+
+// ============================================================
+// initialize() self-heal / upgrade-migration tests (#141)
+// ============================================================
+
+console.log('\n--- initialize() Registry Self-Heal Tests (issue #141) ---\n');
+
+/**
+ * Minimal in-memory board registry, injected per test so the concurrent runner
+ * never races the module singleton. Records register/invalidate/resolve calls.
+ */
+function createFakeRegistry(initial = {}) {
+  const store = { ...initial };
+  const calls = { register: [], invalidate: [], resolve: [] };
+  return {
+    _store: store,
+    _calls: calls,
+    // eslint-disable-next-line require-await
+    resolveBoard: async (_deck, role) => {
+      calls.resolve.push(role);
+      return (role in store) ? store[role] : null;
+    },
+    registerBoard: (role, boardId) => { calls.register.push({ role, boardId }); store[role] = boardId; },
+    invalidateBoard: (role) => { calls.invalidate.push(role); delete store[role]; },
+  };
+}
+
+function notFoundError(id) {
+  const e = new Error(`Board ${id} not found`);
+  e.statusCode = 404;
+  return e;
+}
+
+const BOARD_POST_PATH = '/index.php/apps/deck/api/v1.0/boards';
+const boardCreatePosts = (deck) => deck._calls.filter(c =>
+  c.method === '_request' && c.httpMethod === 'POST' && c.path === BOARD_POST_PATH);
+
+asyncTest('initialize(): stale registry id self-heals — getBoard 404 → invalidate → adopt cockpit-titled board (#141)', async () => {
+  const reg = createFakeRegistry({ cockpit: 999 }); // stale: board 999 no longer exists
+  const deck = createMockDeckClient({
+    getBoard: (id) => {
+      if (id === 999) throw notFoundError(999);
+      return { id, title: BOARD_TITLE, labels: [] };
+    },
+    listBoards: [{ id: 14, title: BOARD_TITLE }],
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14, 'should adopt the real cockpit board 14');
+  assert.strictEqual(reg._store.cockpit, 14, 'registry should be re-pointed to 14');
+  assert.deepStrictEqual(reg._calls.invalidate, ['cockpit'], 'stale entry invalidated exactly once');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 14 }], 'registers cockpit→14 exactly once (no duplicate)');
+  assert.strictEqual(boardCreatePosts(deck).length, 0, 'must NOT bootstrap a new board when one exists');
+});
+
+asyncTest('initialize(): missing registry entry self-heals — adopt cockpit-titled board (#141)', async () => {
+  const reg = createFakeRegistry({}); // no cockpit entry at all
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 14, title: BOARD_TITLE }],
+    getBoard: { id: 14, title: BOARD_TITLE, labels: [] },
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14, 'should adopt board 14');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 14 }], 'seeds cockpit→14 exactly once');
+  assert.strictEqual(reg._calls.invalidate.length, 0, 'nothing to invalidate when entry was already absent');
+  assert.strictEqual(boardCreatePosts(deck).length, 0, 'must NOT bootstrap');
+});
+
+asyncTest('initialize(): no cockpit board anywhere → bootstrap creates one (true first boot, unchanged) (#141)', async () => {
+  const reg = createFakeRegistry({});
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 5, title: 'Personal Tasks' }], // exists, but none cockpit-titled
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.ok(boardCreatePosts(deck).length >= 1, 'should bootstrap a new board when no cockpit board exists');
+  assert.strictEqual(cm.boardId, 99, 'boardId comes from bootstrap (mock POST /boards → id 99)');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 99 }], 'bootstrap registered the new board');
+});
+
+asyncTest('initialize(): cockpit board vanishes between listBoards and getBoard → falls through to bootstrap (#141)', async () => {
+  const reg = createFakeRegistry({}); // no entry → self-heal path
+  const deck = createMockDeckClient({
+    listBoards: [{ id: 14, title: BOARD_TITLE }], // appears in the list…
+    getBoard: (id) => { throw notFoundError(id); }, // …but getBoard 404s (deleted mid-flight)
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize(); // must not crash
+
+  assert.ok(boardCreatePosts(deck).length >= 1, 'should fall through to bootstrap when the found board vanished');
+  assert.strictEqual(cm.boardId, 99, 'boardId from bootstrap');
+  assert.deepStrictEqual(reg._calls.register, [{ role: 'cockpit', boardId: 99 }], 'only the bootstrapped board is registered');
+});
+
+asyncTest('initialize(): self-heal does NOT title-scan on the resolve hot path — only on the cold path (#141)', async () => {
+  // Registry resolves cleanly → listBoards must never be consulted (no title scan).
+  const reg = createFakeRegistry({ cockpit: 14 });
+  const deck = createMockDeckClient({
+    getBoard: { id: 14, title: BOARD_TITLE, labels: [] },
+    getStacks: createSampleStacks()
+  });
+  const cm = new CockpitManager({ deckClient: deck, boardRegistry: reg });
+
+  await cm.initialize();
+
+  assert.strictEqual(cm.boardId, 14);
+  assert.strictEqual(deck._calls.filter(c => c.method === 'listBoards').length, 0,
+    'listBoards (title scan) must NOT run when the registry resolves — canonical invariant preserved');
+  assert.strictEqual(reg._calls.register.length, 0, 'no re-register on the clean resolve path');
 });
 
 // ============================================================

--- a/test/unit/integrations/cockpit-manager.test.js
+++ b/test/unit/integrations/cockpit-manager.test.js
@@ -69,6 +69,16 @@ function createMockDeckClient(overrides = {}) {
       return overrides.shareBoard || { id: 1 };
     },
 
+    updateCardComplete: async (boardId, stackId, cardId, card, changes = {}) => {
+      calls.push({ method: 'updateCardComplete', boardId, stackId, cardId, card, changes });
+      if (overrides.updateCardComplete) {
+        return typeof overrides.updateCardComplete === 'function'
+          ? overrides.updateCardComplete(boardId, stackId, cardId, card, changes)
+          : overrides.updateCardComplete;
+      }
+      return { id: cardId, ...card, ...changes };
+    },
+
     _request: async (method, path, body) => {
       calls.push({ method: '_request', httpMethod: method, path, body });
       if (overrides._request) {
@@ -772,12 +782,13 @@ asyncTest('updateStatus() updates Health card description', async () => {
 
   await cm.updateStatus({ health: healthData });
 
+  // #135: writes now route through the canonical updateCardComplete helper
   const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
+    c.method === 'updateCardComplete' && c.changes && 'description' in c.changes
   );
 
-  // Should have at least one PUT call for updating card description
-  assert.ok(putCalls.length > 0, 'Should call PUT to update card');
+  // Should have at least one update call for the card description
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update card');
 });
 
 asyncTest('updateStatus() updates Costs card with monthly data', async () => {
@@ -799,15 +810,15 @@ asyncTest('updateStatus() updates Costs card with monthly data', async () => {
 
   await cm.updateStatus({ costs: costData });
 
-  const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
-  );
+  // #135: writes now route through the canonical updateCardComplete helper.
+  // Card identity is on call.card; the new body is in call.changes.description.
+  const putCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
 
-  assert.ok(putCalls.length > 0, 'Should call PUT to update Costs card');
-  const costsPut = putCalls.find(c => c.body?.title === 'Costs');
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update Costs card');
+  const costsPut = putCalls.find(c => c.card?.title === 'Costs');
   assert.ok(costsPut, 'Should update the Costs card');
-  assert.ok(costsPut.body.description.includes('12.50'), 'Should include monthly cost');
-  assert.ok(costsPut.body.description.includes('Local ratio: 83%'), 'Should include local ratio');
+  assert.ok(costsPut.changes.description.includes('12.50'), 'Should include monthly cost');
+  assert.ok(costsPut.changes.description.includes('Local ratio: 83%'), 'Should include local ratio');
 });
 
 asyncTest('updateStatus() updates Model Usage card with router stats', async () => {
@@ -826,15 +837,14 @@ asyncTest('updateStatus() updates Model Usage card with router stats', async () 
 
   await cm.updateStatus({ routerStats });
 
-  const putCalls = deck._calls.filter(c =>
-    c.method === '_request' && c.httpMethod === 'PUT' && c.path.includes('/cards/')
-  );
+  // #135: writes now route through the canonical updateCardComplete helper.
+  const putCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
 
-  assert.ok(putCalls.length > 0, 'Should call PUT to update Model Usage card');
-  const usagePut = putCalls.find(c => c.body?.title === 'Model Usage');
+  assert.ok(putCalls.length > 0, 'Should call updateCardComplete to update Model Usage card');
+  const usagePut = putCalls.find(c => c.card?.title === 'Model Usage');
   assert.ok(usagePut, 'Should update the Model Usage card');
-  assert.ok(usagePut.body.description.includes('100 requests'), 'Should include total requests');
-  assert.ok(usagePut.body.description.includes('ollama (local)'), 'Should label local providers');
+  assert.ok(usagePut.changes.description.includes('100 requests'), 'Should include total requests');
+  assert.ok(usagePut.changes.description.includes('ollama (local)'), 'Should label local providers');
 });
 
 // --- New formatter tests ---
@@ -1606,6 +1616,143 @@ asyncTest('_resolveCardValue() backward compat: Gen1 Option 1/2/3 labels still r
   assert.strictEqual(cm._resolveCardValue({ id: 2, labels: [opt2] }, PERSONA_VALUE_MAP.Humor).source, 'moderate');
   assert.strictEqual(cm._resolveCardValue({ id: 3, labels: [opt3] }, PERSONA_VALUE_MAP.Humor).value, 'playful');
   assert.strictEqual(cm._resolveCardValue({ id: 3, labels: [opt3] }, PERSONA_VALUE_MAP.Humor).source, 'on');
+});
+
+// ============================================================
+// updateCardComplete routing tests (#135)
+// ============================================================
+
+console.log('\n--- updateCardComplete Routing Tests (issue #135) ---\n');
+
+asyncTest('updateStatus: routes through updateCardComplete, NOT _request directly', async () => {
+  const deck = createMockDeckClient();
+  const cm = new CockpitManager({ deckClient: deck });
+
+  // Manually initialize to bypass bootstrap
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  cm._statusPulseCount = 0;
+
+  // Provide a status stack with a Health card with a real order + owner
+  const healthCard = { id: 201, title: 'Health', description: 'old', type: 'plain', owner: { uid: 'moltagent' }, order: 3 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+
+  const updateCalls = deck._calls.filter(c => c.method === 'updateCardComplete');
+  assert.ok(updateCalls.length >= 1, 'updateCardComplete should be called at least once for the Health card');
+
+  const requestCalls = deck._calls.filter(c => c.method === '_request' && c.httpMethod === 'PUT' && (c.path || '').includes('/cards/'));
+  assert.strictEqual(requestCalls.length, 0, 'direct _request PUT to card should NOT be called');
+});
+
+asyncTest('updateStatus: card.order is preserved from real card (not zeroed out)', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ boardId, stackId, cardId, card, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  cm._statusPulseCount = 0;
+
+  // Health card with order:3 — this should be threaded through, not overridden
+  const healthCard = { id: 201, title: 'Health', description: '', type: 'plain', owner: { uid: 'moltagent' }, order: 3 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+
+  const call = updateCompleteCalls.find(c => c.cardId === 201);
+  assert.ok(call, 'updateCardComplete should be called for the Health card');
+  assert.strictEqual(call.card.order, 3, 'original card.order=3 should be passed to helper, not 0');
+});
+
+asyncTest('updateStatus: unchanged description is skipped on repeat call (hash-skip intact)', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ cardId, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { status: 50 };
+  // Start at 0; first call (pulse 1) always writes, second call (pulse 2) throttle skips.
+  // Force _statusPulseCount so the 3rd pulse is "1 mod 3 == 1" which writes again.
+  // Easiest: just test within a single pulse and verify the hash-skip per-card.
+  cm._statusPulseCount = 0;
+
+  const healthCard = { id: 201, title: 'Health', description: '', type: 'plain', owner: 'moltagent', order: 1 };
+  deck.getStacks = async () => [{ id: 50, cards: [healthCard] }];
+
+  // First call — should write
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+  const firstWriteCount = updateCompleteCalls.length;
+  assert.ok(firstWriteCount >= 1, 'First pulse should write at least one card');
+
+  // Reset pulse count to 1 (bypass throttle) and call again — same content, hash-skip should fire
+  cm._statusPulseCount = 1;
+  await cm.updateStatus({ health: null, costs: null, costTracker: null, routerStats: null });
+  // 2nd pulse: throttle skips entirely (_statusPulseCount becomes 2, 2 % 3 !== 1)
+  // Total calls should not have increased for the throttled pulse
+  // The throttle fires at pulse 2 (count becomes 2, 2 > 1 and 2 % 3 != 1)
+  assert.strictEqual(updateCompleteCalls.length, firstWriteCount, 'Throttled pulse should not write additional cards');
+});
+
+asyncTest('_writeModelsCardDescription: routes through updateCardComplete with threaded order/owner', async () => {
+  const updateCompleteCalls = [];
+  const deck = createMockDeckClient({
+    updateCardComplete: (boardId, stackId, cardId, card, changes) => {
+      updateCompleteCalls.push({ boardId, stackId, cardId, card, changes });
+      return {};
+    }
+  });
+  const cm = new CockpitManager({ deckClient: deck });
+
+  cm._initialized = true;
+  cm.boardId = 14;
+  cm.stacks = { system: 60 };
+
+  // Card carries real order and owner (as threaded from _parseModelsCard)
+  const card = { id: 301, title: 'Models', description: 'old content', type: 'plain', owner: { uid: 'moltagent' }, order: 5 };
+
+  await cm._writeModelsCardDescription(card, 'new model description');
+
+  assert.strictEqual(updateCompleteCalls.length, 1, 'updateCardComplete should be called once');
+  assert.strictEqual(updateCompleteCalls[0].card.order, 5, 'original order should be threaded through');
+  assert.strictEqual(updateCompleteCalls[0].card.owner.uid, 'moltagent', 'owner object should be passed (helper normalizes it)');
+  assert.strictEqual(updateCompleteCalls[0].changes.description, 'new model description', 'new description should be in changes');
+
+  const requestCalls = deck._calls.filter(c => c.method === '_request' && c.httpMethod === 'PUT');
+  assert.strictEqual(requestCalls.length, 0, '_request PUT should not be called directly');
+});
+
+test('_parseModelsCard: sets _cardOrder and _cardOwner from real card', () => {
+  const deck = createMockDeckClient();
+  const cm = new CockpitManager({ deckClient: deck });
+
+  const card = {
+    id: 42,
+    description: `trust: cloud-ok\nprefer: speed\n\n---\n\nYour agent does six types of work.`,
+    labels: [],
+    order: 7,
+    owner: { uid: 'botuser', displayName: 'Bot User' }
+  };
+
+  const result = cm._parseModelsCard(card);
+
+  assert.strictEqual(result._cardId, 42, '_cardId should match card.id');
+  assert.strictEqual(result._cardOrder, 7, '_cardOrder should be set from card.order');
+  assert.deepStrictEqual(result._cardOwner, { uid: 'botuser', displayName: 'Bot User' }, '_cardOwner should be the full owner object');
 });
 
 // ============================================================

--- a/test/unit/integrations/deck-board-registry.test.js
+++ b/test/unit/integrations/deck-board-registry.test.js
@@ -19,12 +19,12 @@
  * Tests:
  * - TC-REG-001: ROLES exports all expected board roles
  * - TC-REG-002: resolveBoard returns null when no registry, no deckClient
- * - TC-REG-003: resolveBoard falls back to name match and registers
- * - TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)
+ * - TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards
+ * - TC-REG-004: resolveBoard returns registered ID without touching the deck client
  * - TC-REG-005: registerBoard + getAll round-trip
  * - TC-REG-006: invalidateBoard removes entry
- * - TC-REG-007: resolveBoard does case-insensitive title matching
- * - TC-REG-008: resolveBoard returns null when title doesn't match
+ * - TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)
+ * - TC-REG-008: resolveBoard returns null on a genuine miss, never scanning
  * - TC-REG-009: _reset clears all state
  *
  * Run: node test/unit/integrations/deck-board-registry.test.js
@@ -67,41 +67,41 @@ asyncTest('TC-REG-002: resolveBoard returns null when no registry, no deckClient
 });
 
 // ============================================================
-// TC-REG-003: resolveBoard falls back to name match and registers
+// TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards
 // ============================================================
 
-asyncTest('TC-REG-003: resolveBoard falls back to name match and registers', async () => {
+asyncTest('TC-REG-003: resolveBoard never scans live titles — null on miss, no listBoards', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 42, title: 'My Board' }],
+  // The registry is canonical: a cache miss returns null, it does NOT fall
+  // through to a live title scan.  A throwing deck client proves listBoards
+  // is never called.
+  const throwingDeck = {
+    listBoards: () => { throw new Error('listBoards must never be called — registry is canonical'); },
   };
 
-  // Use a unique role ('knowledge') so concurrent async tests targeting
-  // 'cockpit' (TC-REG-007) cannot collide with this one.
-  const id = await boardRegistry.resolveBoard(mockDeck, 'knowledge', 'My Board');
+  const id = await boardRegistry.resolveBoard(throwingDeck, 'knowledge', 'My Board');
 
-  assert.strictEqual(id, 42);
-  assert.strictEqual(boardRegistry.getAll().knowledge.boardId, 42);
+  assert.strictEqual(id, null);
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(boardRegistry.getAll(), 'knowledge'),
+    'a role must not be registered from a live title scan'
+  );
 });
 
 // ============================================================
-// TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)
+// TC-REG-004: resolveBoard returns registered ID without touching the deck client
 // ============================================================
 
-asyncTest('TC-REG-004: resolveBoard returns cached ID on second call (no listBoards)', async () => {
+asyncTest('TC-REG-004: resolveBoard returns registered ID without touching the deck client', async () => {
   boardRegistry._reset();
 
-  // Seed the cache using the 'meetings' role to avoid collision with other
-  // async tests that use 'cockpit' or 'knowledge'.
-  const seedDeck = {
-    listBoards: async () => [{ id: 42, title: 'Cache Test Board' }],
-  };
-  await boardRegistry.resolveBoard(seedDeck, 'meetings', 'Cache Test Board');
+  // Seed via registerBoard (the canonical path) rather than a title scan.
+  boardRegistry.registerBoard('meetings', 42);
 
-  // Second call: deckClient throws if listBoards is ever reached
+  // The deck client throws if resolveBoard ever reaches for listBoards.
   const throwingDeck = {
-    listBoards: async () => { throw new Error('listBoards must not be called on cache hit'); },
+    listBoards: () => { throw new Error('listBoards must not be called on a registered role'); },
   };
 
   const id = await boardRegistry.resolveBoard(throwingDeck, 'meetings', 'Cache Test Board');
@@ -144,36 +144,42 @@ test('TC-REG-006: invalidateBoard removes entry', () => {
 });
 
 // ============================================================
-// TC-REG-007: resolveBoard does case-insensitive title matching
+// TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)
 // ============================================================
 
-asyncTest('TC-REG-007: resolveBoard does case-insensitive title matching', async () => {
+asyncTest('TC-REG-007: registry resolution ignores live Deck titles (#99 emoji-prefix)', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 7, title: '⭐ Moltagent Cockpit' }],
+  // Board 14 is registered for 'cockpit'.  The live board carries an
+  // emoji-prefixed title ('⭐ Moltagent Cockpit') that the old exact-title scan
+  // missed (this was #99).  Resolution now comes from the registry and the
+  // title is never consulted, so the emoji prefix is irrelevant.
+  boardRegistry.registerBoard('cockpit', 14);
+
+  const throwingDeck = {
+    listBoards: () => { throw new Error('title scan must not run — registry is canonical'); },
   };
 
-  const id = await boardRegistry.resolveBoard(mockDeck, 'cockpit', '⭐ moltagent cockpit');
-  assert.strictEqual(id, 7);
+  const id = await boardRegistry.resolveBoard(throwingDeck, 'cockpit', 'Moltagent Cockpit');
+  assert.strictEqual(id, 14);
 });
 
 // ============================================================
-// TC-REG-008: resolveBoard returns null when title doesn't match
+// TC-REG-008: resolveBoard returns null on a genuine miss, never scanning
 // ============================================================
 
-asyncTest('TC-REG-008: resolveBoard returns null when title does not match', async () => {
+asyncTest('TC-REG-008: resolveBoard returns null on a genuine miss, never scanning', async () => {
   boardRegistry._reset();
 
-  const mockDeck = {
-    listBoards: async () => [{ id: 1, title: 'Unrelated Board' }],
+  const throwingDeck = {
+    listBoards: () => { throw new Error('listBoards must not be called on a miss'); },
   };
 
-  const result = await boardRegistry.resolveBoard(mockDeck, 'tasks', 'Moltagent Tasks');
+  const result = await boardRegistry.resolveBoard(throwingDeck, 'tasks', 'Moltagent Tasks');
   assert.strictEqual(result, null);
 
   const all = boardRegistry.getAll();
-  assert.ok(!Object.prototype.hasOwnProperty.call(all, 'tasks'), 'tasks entry should not be registered on title mismatch');
+  assert.ok(!Object.prototype.hasOwnProperty.call(all, 'tasks'), 'tasks entry must not be registered on a miss');
 });
 
 // ============================================================

--- a/test/unit/integrations/deck-client.test.js
+++ b/test/unit/integrations/deck-client.test.js
@@ -1570,6 +1570,112 @@ test('stackHasPausedConfig: leading whitespace on CONFIG title is tolerated', ()
   assert.strictEqual(DeckClient.stackHasPausedConfig(stack), true);
 });
 
+// --- updateCardComplete Tests (#135) ---
+console.log('\n--- updateCardComplete Tests ---\n');
+
+asyncTest('TC-UCC-001: owner object {uid} normalized to bare uid string, order and description passed through', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/30': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 30, title: 'Original', type: 'plain', description: 'old', owner: { uid: 'botuser', displayName: 'Bot' }, order: 7 };
+
+  await client.updateCardComplete(10, 20, 30, card, { description: 'new desc' });
+
+  assert.strictEqual(capturedBody.owner, 'botuser', 'owner should be bare uid string');
+  assert.strictEqual(capturedBody.order, 7, 'order should be threaded from card');
+  assert.strictEqual(capturedBody.description, 'new desc', 'description from changes should win');
+  assert.strictEqual(capturedBody.title, 'Original', 'title from card used when not in changes');
+  assert.strictEqual(capturedBody.type, 'plain', 'type from card');
+});
+
+asyncTest('TC-UCC-002: owner missing in card and changes → falls back to this.username', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/31': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 31, title: 'X', type: 'plain', description: '', owner: undefined, order: 1 };
+
+  await client.updateCardComplete(10, 20, 31, card, {});
+
+  assert.strictEqual(capturedBody.owner, 'testuser', 'should fall back to this.username (mockNC.ncUser)');
+});
+
+asyncTest('TC-UCC-003: owner already a bare string is passed through unchanged', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/32': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 32, title: 'Y', type: 'plain', description: '', owner: 'stringowner', order: 2 };
+
+  await client.updateCardComplete(10, 20, 32, card, {});
+
+  assert.strictEqual(capturedBody.owner, 'stringowner', 'bare string owner should pass through');
+});
+
+asyncTest('TC-UCC-004: order:5 is sent; order:0 is also sent (valid top-of-stack)', async () => {
+  const bodies = [];
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/33': (path, options) => {
+      bodies.push(options.body);
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card5 = { id: 33, title: 'A', type: 'plain', description: '', owner: 'u', order: 5 };
+  const card0 = { id: 33, title: 'A', type: 'plain', description: '', owner: 'u', order: 0 };
+
+  await client.updateCardComplete(10, 20, 33, card5, {});
+  await client.updateCardComplete(10, 20, 33, card0, {});
+
+  assert.strictEqual(bodies[0].order, 5);
+  assert.strictEqual(bodies[1].order, 0, 'order:0 is a valid top-of-stack position and must be sent');
+  assert.ok('order' in bodies[1], 'order key must be present when value is 0');
+});
+
+asyncTest('TC-UCC-005: order absent on card (undefined) → key omitted entirely from body', async () => {
+  let capturedBody = null;
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/34': (path, options) => {
+      capturedBody = options.body;
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 34, title: 'B', type: 'plain', description: '', owner: 'u' /* no order */ };
+
+  await client.updateCardComplete(10, 20, 34, card, {});
+
+  assert.ok(!('order' in capturedBody), 'order key must be absent when card.order is undefined');
+});
+
+asyncTest('TC-UCC-006: missing identifiers throw DeckApiError', async () => {
+  const mockNC = createDeckMockNC();
+  const client = new DeckClient(mockNC);
+  const card = { id: 1, title: 'X', owner: 'u' };
+
+  let threw = false;
+  try {
+    await client.updateCardComplete(null, 20, 30, card, {});
+  } catch (err) {
+    threw = true;
+    assert.ok(err.name === 'DeckApiError', 'should be DeckApiError');
+  }
+  assert.ok(threw, 'should throw when boardId is missing');
+});
+
 // --- Summary ---
 setTimeout(() => {
   summary();

--- a/test/unit/meeting-composer.test.js
+++ b/test/unit/meeting-composer.test.js
@@ -15,6 +15,14 @@ const assert = require('assert');
 const MeetingComposer = require('../../src/lib/calendar/meeting-composer');
 const boardRegistry = require('../../src/lib/integrations/deck-board-registry');
 
+// The board registry is a collaborator here, not the unit under test (its own
+// resolution is covered in deck-board-registry.test.js).  Stub resolveBoard to
+// resolve deterministically from the per-deck mock so the concurrently-run
+// asyncTests below never contend on the shared registry singleton.  Set once at
+// load, so it is itself race-free.
+boardRegistry.resolveBoard = async (deck) =>
+  (deck && deck.__meetingsBoardId != null) ? deck.__meetingsBoardId : null;
+
 // ---------------------------------------------------------------------------
 // Mock factories
 // ---------------------------------------------------------------------------
@@ -54,7 +62,10 @@ function createMocks(overrides = {}) {
     deckClient: {
       listBoards:       overrides.listBoards       || (async () => []),
       getBoard:         overrides.getBoard         || (async () => ({ stacks: [] })),
-      createCardOnBoard: overrides.createCardOnBoard || (async () => ({ id: 42 }))
+      createCardOnBoard: overrides.createCardOnBoard || (async () => ({ id: 42 })),
+      // Consumed by the stubbed boardRegistry.resolveBoard above to pick the
+      // meetings board id for this composer (undefined => not registered => null).
+      __meetingsBoardId: overrides.meetingsBoardId
     },
     emailHandler: {
       sendWithIcal: overrides.sendWithIcal || (async () => ({ success: true }))
@@ -506,10 +517,9 @@ asyncTest('meeting proceeds normally when rsvpTracker is absent', async () => {
 // --- 17. Deck tracking card ---
 
 asyncTest('deck card created on Pending Meetings board after meeting creation', async () => {
-  boardRegistry._reset();
   const createCardCalls = [];
   const composer = createComposer({
-    listBoards: async () => [{ id: 7, title: 'Pending Meetings' }],
+    meetingsBoardId: 7, // resolved via the stubbed registry; no title scan
     getBoard: async () => ({
       stacks: [{ id: 20, title: 'Invited' }]
     }),
@@ -548,10 +558,9 @@ asyncTest('meeting creation succeeds even when deck board is not found', async (
 });
 
 asyncTest('deck card falls back to first stack when no Invited stack exists', async () => {
-  boardRegistry._reset();
   const createCardCalls = [];
   const composer = createComposer({
-    listBoards: async () => [{ id: 8, title: 'Pending Meetings' }],
+    meetingsBoardId: 8, // resolved via the stubbed registry; no title scan
     getBoard: async () => ({
       stacks: [{ id: 30, title: 'Backlog' }, { id: 31, title: 'In Progress' }]
     }),


### PR DESCRIPTION
The Cockpit stops being fragile: it works on current Deck, survives upgrades, and resolves its own registry.

Shipping on the day Nextcloud turns 10 and Hub 26 goes live. The timing is fitting: Moltagent's Cockpit card-updates now speak the contract Hub 26's Deck expects.

### What's new since v0.1.3-beta

**Board registry is canonical** (#137, resolves #49, #99). `resolveBoard` no longer scans live Deck titles. Resolution reads the registry only (memory → disk → null). A cache miss re-reads disk, so an out-of-process `registerBoard` lands without a restart. Net -22 lines on the registry.

**Cockpit card-updates work on current Deck** (#140, addresses #135). Card-update writes now send a complete, normalized body through `DeckClient.updateCardComplete()`: bare-uid owner, real order, all required fields. Fixes the per-pulse HTTP 400 on Hub 26 Deck that left the Cockpit looking dead while the agent ran fine. Backward-safe on older Deck. The same divergent-PUT pattern at four other sites is tracked in #139.

**Upgrade-path self-heal** (#142, resolves #141). On first startup after upgrade, if the cockpit registry entry is stale or missing, Moltagent auto-detects the existing Cockpit board by title and registers it. A one-time, cold-path migration. The hot path never title-scans. Look for a single log line on first post-upgrade boot:

```
[CockpitManager] Upgrade migration: registered cockpit board <id> (title: "<title>").
One-time — the registry is now canonical.
```

No manual `registerBoard` needed.

**Synthesis preamble rewrite** (#131). The synthesis prompt's opening lines rewritten in declarative register, removing a verbatim escape phrase that small models echoed as a response. Per Mason ICLR 2026.

### Verification

All changes verified on production (Prime):

- Registry canonical: two-process re-read proven live; emoji-prefix warning gone; no duplicate board.
- Card-update helper: status cards update, order preserved, owner normalized, Deck 200.
- Upgrade self-heal: stale and missing entries both auto-register, clean init, registry settles.
- 220/220 unit test files, lint 0 errors.

**Note:** #135 stays open. Prime's older Deck cannot reproduce the 400. #135 closes when a current-Deck (Hub 26) deployment confirms the cards update. See Discussion #72.