### PR TITLE
fix(deck): centralize all card-update PUTs through the canonical body builder (#139)

### DIFF
--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -3608,33 +3608,45 @@ class ToolRegistry {
       },
       handler: async (args) => {
         try {
-          const apiPath = `/index.php/apps/deck/api/v1.0/boards/${args.board_id}/stacks/${args.stack_id}/cards/${args.card_id}`;
+          // GET current card so the PUT carries a complete body. See #139.
+          const card = deck
+            ? await deck.getCardById(args.board_id, args.stack_id, args.card_id)
+            : (await nc.request(
+                `/index.php/apps/deck/api/v1.0/boards/${args.board_id}/stacks/${args.stack_id}/cards/${args.card_id}`,
+                { method: 'GET' }
+              )).body || {};
 
-          // Fetch current card to preserve unchanged fields
-          const cardData = deck
-            ? await deck._request('GET', apiPath)
-            : (await nc.request(apiPath, { method: 'GET' })).body || {};
-
-          const updates = {
-            title: args.title || cardData.title,
-            type: cardData.type || 'plain',
-            owner: cardData.owner?.uid || cardData.owner || '',
-            description: args.description !== undefined ? args.description : (cardData.description || ''),
-            duedate: args.duedate !== undefined ? args.duedate : (cardData.duedate || null)
-          };
+          const changes = {};
+          if (args.title !== undefined) changes.title = args.title;
+          if (args.description !== undefined) changes.description = args.description;
+          if (args.duedate !== undefined) changes.duedate = args.duedate;
 
           if (deck) {
-            await deck._request('PUT', apiPath, updates);
+            await deck.updateCardComplete(args.board_id, args.stack_id, args.card_id, card, changes);
           } else {
-            await nc.request(apiPath, { method: 'PUT', body: updates });
+            // Fallback when no DeckClient is available: replicate the complete-body
+            // logic inline, including the finite-number `order` gate.
+            const body = {
+              title:       changes.title       ?? card.title,
+              type:        card.type           ?? 'plain',
+              owner:       card.owner?.uid     ?? card.owner ?? '',
+              description: changes.description ?? card.description ?? '',
+              duedate:     changes.duedate     ?? card.duedate ?? null
+            };
+            const resolvedOrder = card.order;
+            if (Number.isFinite(resolvedOrder)) body.order = resolvedOrder;
+            await nc.request(
+              `/index.php/apps/deck/api/v1.0/boards/${args.board_id}/stacks/${args.stack_id}/cards/${args.card_id}`,
+              { method: 'PUT', body }
+            );
           }
 
-          const changes = [];
-          if (args.title) changes.push(`title: "${args.title}"`);
-          if (args.description !== undefined) changes.push('description updated');
-          if (args.duedate !== undefined) changes.push(`due: ${args.duedate}`);
+          const changeList = [];
+          if (args.title) changeList.push(`title: "${args.title}"`);
+          if (args.description !== undefined) changeList.push('description updated');
+          if (args.duedate !== undefined) changeList.push(`due: ${args.duedate}`);
 
-          return `Updated card ${args.card_id}.${changes.length ? ' Changes: ' + changes.join(', ') + '.' : ''}`;
+          return `Updated card ${args.card_id}.${changeList.length ? ' Changes: ' + changeList.join(', ') + '.' : ''}`;
         } catch (err) {
           this.logger.error(`[workflow_deck_update_card] ${err.message}`);
           return `Failed to update card: ${err.message}`;

--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -666,9 +666,11 @@ class DeckClient {
 
   async updateCardById(boardId, stackId, cardId, updates) {
     if (!boardId || !stackId || !cardId) throw new DeckApiError('boardId, stackId, cardId are required');
-    return await this._request('PUT',
-      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
-      updates);
+    // Read-modify-write: GET the current card, then delegate to the single
+    // canonical body builder so partial `updates` never produce a partial PUT
+    // body (NC 34+ Deck rejects a PUT missing `order` with HTTP 400). See #139.
+    const card = await this.getCardById(boardId, stackId, cardId);
+    return await this.updateCardComplete(boardId, stackId, cardId, card, updates);
   }
 
   /**
@@ -693,7 +695,7 @@ class DeckClient {
    * @param {number} stackId
    * @param {number} cardId
    * @param {Object} card    - Current card from getStacks (carries real order + owner)
-   * @param {Object} [changes={}] - Fields to override (title, description, type, owner, order)
+   * @param {Object} [changes={}] - Fields to override (title, description, type, owner, order, done, duedate)
    * @returns {Promise<Object>} PUT response from the Deck API
    */
   async updateCardComplete(boardId, stackId, cardId, card, changes = {}) {
@@ -709,14 +711,32 @@ class DeckClient {
       title:       changes.title       ?? card.title,
       type:        changes.type        ?? card.type  ?? 'plain',
       description: changes.description ?? card.description ?? '',
-      owner:       resolvedOwner,
-      order:       changes.order       ?? card.order
+      owner:       resolvedOwner
+      // order: handled below (finite-number gate)
+      // done: handled below (present-only gate)
+      // duedate: handled below (present-only gate)
     };
 
-    // Omit order entirely when it is not a finite number (undefined, null, NaN).
-    // DO send order:0 — it is a valid top-of-stack position.
-    if (!Number.isFinite(body.order)) {
-      delete body.order;
+    // order: omit when not a finite number (undefined, null, NaN).
+    // DO send order:0 — valid top-of-stack position.
+    const resolvedOrder = changes.order ?? card.order;
+    if (Number.isFinite(resolvedOrder)) {
+      body.order = resolvedOrder;
+    }
+
+    // done: include only when explicitly set in changes or present on card.
+    // Omit entirely when undefined — not every PUT is setting done.
+    if ('done' in changes) {
+      body.done = changes.done;
+    } else if (card.done !== undefined && card.done !== null) {
+      body.done = card.done;
+    }
+
+    // duedate: same present-only pattern as done.
+    if ('duedate' in changes) {
+      body.duedate = changes.duedate;
+    } else if (card.duedate !== undefined) {
+      body.duedate = card.duedate;
     }
 
     return await this._request('PUT',
@@ -1079,17 +1099,9 @@ class DeckClient {
     const stackId = await this._resolveStackId(stackName);
     const card = await this.getCard(cardId, stackName);
 
-    await this._request(
-      'PUT',
-      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
-      {
-        title: card.title,
-        type: card.type || 'plain',
-        owner: card.owner?.uid || card.owner || this.username,
-        description: card.description || '',
-        done: new Date().toISOString()
-      }
-    );
+    await this.updateCardComplete(boardId, stackId, cardId, card, {
+      done: new Date().toISOString()
+    });
     console.log(`[Deck] Card ${cardId} marked done`);
   }
 
@@ -1119,12 +1131,9 @@ class DeckClient {
   async updateCard(cardId, stackName, updates) {
     const { boardId } = await this._getIds();
     const stackId = await this._resolveStackId(stackName);
-
-    return await this._request(
-      'PUT',
-      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
-      updates
-    );
+    // Read-modify-write through the canonical body builder — see #139.
+    const card = await this.getCard(cardId, stackName);
+    return await this.updateCardComplete(boardId, stackId, cardId, card, updates);
   }
 
   /**
@@ -1401,17 +1410,10 @@ class DeckClient {
     // Build new description with original task + response
     const newDescription = `## Original Task\n\n${originalDescription || '(No description provided)'}\n\n---\n\n## Moltagent Response\n\n${llmResponse}`;
 
-    // Update card description (must include title and owner)
-    await this._request(
-      'PUT',
-      `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}`,
-      {
-        title: currentCard.title,
-        type: currentCard.type || 'plain',
-        owner: currentCard.owner?.uid || currentCard.owner || this.username,
-        description: newDescription
-      }
-    );
+    // Update card description through the canonical body builder — see #139.
+    await this.updateCardComplete(boardId, stackId, cardId, currentCard, {
+      description: newDescription
+    });
 
     // Add review comment
     try {

--- a/test/unit/integrations/deck-client.test.js
+++ b/test/unit/integrations/deck-client.test.js
@@ -1676,6 +1676,75 @@ asyncTest('TC-UCC-006: missing identifiers throw DeckApiError', async () => {
   assert.ok(threw, 'should throw when boardId is missing');
 });
 
+asyncTest('TC-UCC-007: done in changes is sent (incl. null to clear), present-only when absent (#139)', async () => {
+  const bodies = [];
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/35': (path, options) => {
+      bodies.push(options.body);
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 35, title: 'D', type: 'plain', description: '', owner: 'u', order: 0 };
+
+  // explicit done timestamp in changes
+  await client.updateCardComplete(10, 20, 35, card, { done: '2026-06-09T10:00:00Z' });
+  // explicit null clears done — must still be sent because 'done' in changes
+  await client.updateCardComplete(10, 20, 35, card, { done: null });
+  // done neither in changes nor on card → key omitted
+  await client.updateCardComplete(10, 20, 35, card, {});
+
+  assert.strictEqual(bodies[0].done, '2026-06-09T10:00:00Z', 'done from changes is sent');
+  assert.ok('done' in bodies[1] && bodies[1].done === null, 'done:null in changes is sent to clear');
+  assert.ok(!('done' in bodies[2]), 'done key omitted when absent from changes and card');
+});
+
+asyncTest('TC-UCC-008: done present on card is preserved; card.done null is omitted (#139)', async () => {
+  const bodies = [];
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/36': (path, options) => {
+      bodies.push(options.body);
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const doneCard = { id: 36, title: 'E', type: 'plain', description: '', owner: 'u', order: 0, done: '2026-06-01T00:00:00Z' };
+  const nullDoneCard = { id: 36, title: 'E', type: 'plain', description: '', owner: 'u', order: 0, done: null };
+
+  await client.updateCardComplete(10, 20, 36, doneCard, { description: 'x' });
+  await client.updateCardComplete(10, 20, 36, nullDoneCard, { description: 'x' });
+
+  assert.strictEqual(bodies[0].done, '2026-06-01T00:00:00Z', 'card.done preserved when not in changes');
+  assert.ok(!('done' in bodies[1]), 'card.done null is omitted (not a real completion timestamp)');
+});
+
+asyncTest('TC-UCC-009: duedate in changes is sent (incl. null to clear); card.duedate preserved (#139)', async () => {
+  const bodies = [];
+  const mockNC = createDeckMockNC({
+    'PUT:/index.php/apps/deck/api/v1.0/boards/10/stacks/20/cards/37': (path, options) => {
+      bodies.push(options.body);
+      return { status: 200, body: {}, headers: {} };
+    }
+  });
+  const client = new DeckClient(mockNC);
+  const card = { id: 37, title: 'F', type: 'plain', description: '', owner: 'u', order: 0, duedate: '2026-07-01T00:00:00Z' };
+  const noDueCard = { id: 37, title: 'F', type: 'plain', description: '', owner: 'u', order: 0 };
+
+  // explicit duedate in changes wins
+  await client.updateCardComplete(10, 20, 37, card, { duedate: '2026-08-15T00:00:00Z' });
+  // null in changes clears
+  await client.updateCardComplete(10, 20, 37, card, { duedate: null });
+  // not in changes → card.duedate preserved
+  await client.updateCardComplete(10, 20, 37, card, {});
+  // absent on both → key omitted
+  await client.updateCardComplete(10, 20, 37, noDueCard, {});
+
+  assert.strictEqual(bodies[0].duedate, '2026-08-15T00:00:00Z', 'duedate from changes wins');
+  assert.ok('duedate' in bodies[1] && bodies[1].duedate === null, 'duedate:null in changes clears');
+  assert.strictEqual(bodies[2].duedate, '2026-07-01T00:00:00Z', 'card.duedate preserved');
+  assert.ok(!('duedate' in bodies[3]), 'duedate omitted when undefined on both');
+});
+
 // --- Summary ---
 setTimeout(() => {
   summary();


### PR DESCRIPTION
Closes #139.

## Problem
`updateCardComplete()` (added in #135) builds a complete, normalized card PUT body, but six other card-update sites still sent partial or hand-rolled bodies. NC 34+ Deck rejects any card PUT missing `order` with **HTTP 400**; older Deck silently accepted partial bodies — so these are invisible until a user upgrades. Same single-source archetype as #123 (ModelResolver) and #49 (board registry): truth computed at many sites instead of one.

## Change — one builder, zero hand-rolled/passthrough card PUTs
- **`updateCardComplete`** — extended with present-only `done` and `duedate` gates (sent when in `changes`, incl. `null` to clear; otherwise preserved from the card). Rewrote the `order` gate to build-up instead of build-then-`delete`.
- **`updateCardById` / `updateCard`** — passthrough → read-modify-write (GET current card, then delegate). Partial caller bodies can no longer produce a partial PUT.
- **`markCardDone` / `submitForReview`** — dropped hand-rolled bodies; delegate with only the field each changes (`{done}` / `{description}`). `order`/`duedate` are now preserved instead of clobbered.
- **`workflow_deck_update_card`** (tool-registry) — routes through `updateCardComplete`; the no-DeckClient fallback replicates the complete-body logic inline, including the finite-number `order` gate.

`deck_update_card` and `deck_set_due_date` are fixed **transitively** — they call the now read-modify-write generic methods.

## Verification (static)
- ✅ Exactly one card-PUT site in `deck-client.js` (inside `updateCardComplete`)
- ✅ No `deck._request('PUT', …cards…)` in `tool-registry.js` (only the no-DeckClient `nc.request` fallback + out-of-scope `assignLabel`/`reorder`)
- ✅ Zero raw card PUTs across `src/`
- ✅ +3 tests for the done/duedate gates (TC-UCC-007..009) · **220/220 unit test files pass** · lint 0 errors

## Live Verification Gate (pending, on Bot VM after deploy)
- Conversational card edit via Talk → no HTTP 400, card updated
- `markCardDone` via workflow → no HTTP 400, done timestamp set
- CockpitManager heartbeat still writes cleanly (no #135 regression)
- A user on **NC 34** triggers a conversational card edit — the 400 that would have appeared is the real confirmation

**Merge:** squash into `next`.