### PR TITLE
fix(agent): route swallowed tool failures through the success/error contract (#70)

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -319,6 +319,7 @@ Never confirm an action based on intent ("I called the function"). Only confirm 
 - If a response is empty, null, or missing expected fields — report the failure honestly. Do not interpolate `undefined` into a success message.
 - Never rephrase a tool result to sound more confident than the evidence supports.
 - A false "Done" is worse than "I tried but it didn't work." Users can retry; they can't undo trust lost to a hallucinated confirmation.
+- **When a tool result is an error, report the failure — do not improvise around it.** A failed tool comes back framed as `Error: …`. Name what you tried to do and what the failure was ("I tried to delete card #12 but the board returned a permission error"). Do not paper over it with a generic explanation, a support lecture, or advice unrelated to the error. The error text is the evidence; relay it plainly, in the user's language, and stop. If a next step is genuinely possible (retry, a board you can write to), offer that — but never substitute it for disclosing that the action failed.
 
 ## Knowledge Honesty
 

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -4,6 +4,55 @@ const DECK = require('../../config/deck-names');
 const { isStructuralCard, hasLabel } = require('../integrations/deck-card-classifier');
 
 /**
+ * Migration seam for the success/error contract (#70).
+ *
+ * The target architecture (Option A) is that handlers THROW on failure and
+ * `execute()` is the single error chokepoint — its catch turns the throw into
+ * `{ success: false, error }`. But most handlers still swallow their own
+ * exceptions and RETURN a failure string (`catch (err) { return 'Failed to
+ * X: ${err.message}' }`). Such a string looks like a normal return, so
+ * `execute()` frames it as `{ success: true }` and the failure reaches the
+ * model wearing a success mask — the wound #70 documents (a 403 reported as a
+ * support lecture).
+ *
+ * Until every handler is converted to throw, this seam recognises the
+ * handlers' OWN failure-return convention at the chokepoint and re-frames it
+ * as a structured failure. These markers match code the registry itself
+ * emits — fixed English literals from `catch` blocks, invariant across the
+ * user's language — not user or model text. This is plumbing translating
+ * plumbing's legacy output, not the language layer (CLAUDE.md Rule 1): adding
+ * a language never edits this list.
+ *
+ * Scope is deliberately tight: the exception-swallow convention only.
+ *   - `Failed to …` — the 60+ `catch (err) { return 'Failed to …' }` sites.
+ *   - `… not found or inaccessible …` — the documented board-stack swallow
+ *     (tool-registry.js workflow_deck_create_card; see #70).
+ * Happy-path informational negatives ("No card found", "Could not assign —
+ * not a member") are NOT swept: they are business outcomes, not swallowed
+ * exceptions, and the model already reports them correctly. As handlers
+ * migrate to throwing, their markers retire from this list.
+ * @type {ReadonlyArray<RegExp>}
+ */
+const HANDLER_FAILURE_MARKERS = Object.freeze([
+  /^Failed to\b/,
+  /\bnot found or inaccessible\b/
+]);
+
+/**
+ * Detect a failure-shaped string returned by an unconverted handler.
+ * Inspects a raw string return, or the `.text` of a `{ text, ... }` return.
+ * @param {*} raw - the handler's return value
+ * @returns {string|null} the failure string if matched, else null
+ */
+function detectHandlerFailureString(raw) {
+  const text = typeof raw === 'string'
+    ? raw
+    : (raw && typeof raw === 'object' && typeof raw.text === 'string' ? raw.text : null);
+  if (!text) return null;
+  return HANDLER_FAILURE_MARKERS.some((re) => re.test(text)) ? text : null;
+}
+
+/**
  * ToolRegistry - Agent Tool Definition & Execution Layer
  *
  * Generates tool definitions (JSON schemas) from existing Moltagent clients
@@ -290,6 +339,18 @@ class ToolRegistry {
 
     try {
       const raw = await tool.handler(args || {});
+
+      // Migration seam (#70): an unconverted handler reports failure by
+      // RETURNING a failure string instead of throwing, so the catch below
+      // never fires and the failure would be framed as success. Re-frame it
+      // as a structured failure here, at the chokepoint, so the agent loop
+      // presents it as `Error: …` rather than a successful result.
+      const failureText = detectHandlerFailureString(raw);
+      if (failureText !== null) {
+        this.logger.warn(`[ToolRegistry] Tool ${name} returned a failure string (migration seam #70): ${failureText}`);
+        return { success: false, result: '', error: failureText };
+      }
+
       // Handlers may return {text, card} for structured data alongside the response.
       // The text goes to result (for display), the card object passes through directly.
       if (typeof raw === 'object' && raw !== null && raw.text) {
@@ -3817,4 +3878,4 @@ class ToolRegistry {
   }
 }
 
-module.exports = { ToolRegistry };
+module.exports = { ToolRegistry, detectHandlerFailureString, HANDLER_FAILURE_MARKERS };

--- a/test/unit/agent/orphan-tools.test.js
+++ b/test/unit/agent/orphan-tools.test.js
@@ -166,8 +166,10 @@ asyncTest('calendar_schedule_meeting fails without organizer email', async () =>
     end: '2026-03-01T11:00:00',
     attendees: ['alice@example.com']
   });
-  assert.ok(result.success);
-  assert.ok(result.result.includes('could not resolve organizer email'));
+  // #70 contract: the handler's "Failed to schedule meeting: …" guard string
+  // is re-framed by the execute() seam as a structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('could not resolve organizer email'));
 });
 
 // ============================================================

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -1617,7 +1617,7 @@ asyncTest('omitting board parameter still routes to default-board legacy methods
 // Tests - 403 Permission Error Handling
 // ============================================================
 
-asyncTest('403 error returns friendly error message in result', async () => {
+asyncTest('403 swallowed by handler is re-framed as structured failure (#70)', async () => {
   const deck = createMockDeckClient({
     inbox: [{ id: 10, title: 'Shared Card' }]
   });
@@ -1633,13 +1633,16 @@ asyncTest('403 error returns friendly error message in result', async () => {
     title: 'New Title'
   });
 
-  // Inner try/catch catches the error and returns a human-readable string
-  assert.strictEqual(result.success, true);
-  assert.ok(result.result.includes('Failed to update card'));
-  assert.ok(result.result.includes('Forbidden'));
+  // #70 contract: the handler swallows the 403 into a "Failed to update card"
+  // string; the execute() migration seam re-frames it as a structured failure
+  // so the agent loop presents it as `Error: …`, not a successful result.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed to update card'));
+  assert.ok(result.error.includes('Forbidden'));
+  assert.strictEqual(result.result, '');
 });
 
-asyncTest('non-403 error returns human-readable error in result', async () => {
+asyncTest('non-403 swallowed by handler is re-framed as structured failure (#70)', async () => {
   const deck = createMockDeckClient({
     inbox: [{ id: 10, title: 'Bad Card' }]
   });
@@ -1655,10 +1658,89 @@ asyncTest('non-403 error returns human-readable error in result', async () => {
     title: 'New Title'
   });
 
-  // Inner try/catch catches the error and returns a human-readable string
+  // #70 contract: swallowed non-403 failure is re-framed as structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed to update card'));
+  assert.ok(result.error.includes('Server error'));
+  assert.strictEqual(result.result, '');
+});
+
+// ============================================================
+// Tests - success/error contract migration seam (#70)
+// ============================================================
+
+const { detectHandlerFailureString } = require('../../../src/lib/agent/tool-registry');
+
+test('detectHandlerFailureString matches the Failed-to convention', () => {
+  assert.strictEqual(
+    detectHandlerFailureString('Failed to delete card: Forbidden'),
+    'Failed to delete card: Forbidden'
+  );
+  assert.strictEqual(
+    detectHandlerFailureString('Failed to schedule: time slot not available or event creation failed.'),
+    'Failed to schedule: time slot not available or event creation failed.'
+  );
+});
+
+test('detectHandlerFailureString matches the not-found-or-inaccessible swallow', () => {
+  assert.strictEqual(
+    detectHandlerFailureString('Board 48 not found or inaccessible: Forbidden'),
+    'Board 48 not found or inaccessible: Forbidden'
+  );
+});
+
+test('detectHandlerFailureString inspects the .text of object returns', () => {
+  assert.strictEqual(
+    detectHandlerFailureString({ text: 'Failed to create card: 500', card: null }),
+    'Failed to create card: 500'
+  );
+});
+
+test('detectHandlerFailureString does NOT sweep happy-path informational negatives', () => {
+  // These are business outcomes, not swallowed exceptions — they stay success:true.
+  assert.strictEqual(detectHandlerFailureString('No card found matching "ghost".'), null);
+  assert.strictEqual(detectHandlerFailureString('No board found for "Nope".'), null);
+  assert.strictEqual(detectHandlerFailureString('Could not assign "alice" to card #5 — user may not be a member of this board.'), null);
+  assert.strictEqual(detectHandlerFailureString('Could not find the knowledge wiki collective.'), null);
+});
+
+test('detectHandlerFailureString does not false-positive on mid-string content', () => {
+  // A legitimate success result that merely mentions "failed" must NOT be swept;
+  // the marker is anchored to the handlers' own leading convention.
+  assert.strictEqual(detectHandlerFailureString('Your search for "failed login" returned 3 results.'), null);
+  assert.strictEqual(detectHandlerFailureString('Created card #7: "Investigate failed deploy".'), null);
+  assert.strictEqual(detectHandlerFailureString(''), null);
+  assert.strictEqual(detectHandlerFailureString(null), null);
+  assert.strictEqual(detectHandlerFailureString({ text: 'Created card', card: { id: 7 } }), null);
+});
+
+asyncTest('execute re-frames a custom handler failure string as success:false (#70)', async () => {
+  const registry = new ToolRegistry({ logger: silentLogger });
+  registry.register({
+    name: 'swallows_403',
+    description: 'Swallows its own 403 into a string',
+    parameters: { type: 'object', properties: {} },
+    handler: async () => 'Failed to delete card #12: Forbidden'
+  });
+
+  const result = await registry.execute('swallows_403', {});
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.error, 'Failed to delete card #12: Forbidden');
+  assert.strictEqual(result.result, '');
+});
+
+asyncTest('execute leaves a genuine success string untouched (#70 no false-positive)', async () => {
+  const registry = new ToolRegistry({ logger: silentLogger });
+  registry.register({
+    name: 'reports_success',
+    description: 'Returns a normal success string',
+    parameters: { type: 'object', properties: {} },
+    handler: async () => 'Deleted card #12 from Inbox.'
+  });
+
+  const result = await registry.execute('reports_success', {});
   assert.strictEqual(result.success, true);
-  assert.ok(result.result.includes('Failed to update card'));
-  assert.ok(result.result.includes('Server error'));
+  assert.strictEqual(result.result, 'Deleted card #12 from Inbox.');
 });
 
 // ============================================================

--- a/test/unit/agent/tool-response-validation.test.js
+++ b/test/unit/agent/tool-response-validation.test.js
@@ -140,8 +140,11 @@ asyncTest('deck_create_card: empty body {success:true} from board-targeted path 
     title: 'Test Card', board: DECK.boards.tasks
   });
 
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
-  assert.ok(!result.result.includes('undefined'), `Should not contain "undefined", got: ${result.result}`);
+  // #70 contract: the handler's "Failed to create…" guard string is re-framed
+  // by the execute() seam as a structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
+  assert.ok(!result.error.includes('undefined'), `Should not contain "undefined", got: ${result.error}`);
 });
 
 asyncTest('deck_create_card: valid response with id returns success', async () => {
@@ -170,8 +173,10 @@ asyncTest('deck_create_card: null from default board path returns failure', asyn
 
   const result = await registry.execute('deck_create_card', { title: 'Test Card' });
 
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
-  assert.ok(!result.result.includes('undefined'), `Should not contain "undefined", got: ${result.result}`);
+  // #70 contract: re-framed as structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
+  assert.ok(!result.error.includes('undefined'), `Should not contain "undefined", got: ${result.error}`);
 });
 
 asyncTest('deck_create_card: {success:true} without id from default board returns failure', async () => {
@@ -184,7 +189,9 @@ asyncTest('deck_create_card: {success:true} without id from default board return
 
   const result = await registry.execute('deck_create_card', { title: 'Test Card' });
 
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
+  // #70 contract: re-framed as structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
 });
 
 // -- workflow_deck_create_card --
@@ -306,9 +313,11 @@ asyncTest('wiki_write: null from createPage returns failure', async () => {
     parent: 'Research'
   });
 
-  assert.ok(result.success);
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
-  assert.ok(!result.result.includes('undefined'), `Should not contain "undefined", got: ${result.result}`);
+  // #70 contract: the wiki "Failed to create page…" guard string is re-framed
+  // as a structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
+  assert.ok(!result.error.includes('undefined'), `Should not contain "undefined", got: ${result.error}`);
 });
 
 asyncTest('wiki_write: response without id returns failure', async () => {
@@ -327,7 +336,9 @@ asyncTest('wiki_write: response without id returns failure', async () => {
     parent: 'Research'
   });
 
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
+  // #70 contract: re-framed as structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
 });
 
 // -- mail_send --
@@ -345,9 +356,11 @@ asyncTest('mail_send: failed result returns failure message', async () => {
     to: 'test@example.com', subject: 'Hello', body: 'Test body'
   });
 
-  assert.ok(result.success, `execute should succeed, got: ${JSON.stringify(result)}`);
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
-  assert.ok(result.result.includes('SMTP timeout'), `Should contain error detail, got: ${result.result}`);
+  // #70 contract: the handler's "Failed to send email: …" guard string is
+  // re-framed by the execute() seam as a structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
+  assert.ok(result.error.includes('SMTP timeout'), `Should contain error detail, got: ${result.error}`);
 });
 
 asyncTest('mail_send: null result returns failure message', async () => {
@@ -360,7 +373,9 @@ asyncTest('mail_send: null result returns failure message', async () => {
     to: 'test@example.com', subject: 'Hello', body: 'Test body'
   });
 
-  assert.ok(result.result.includes('Failed'), `Should contain "Failed", got: ${result.result}`);
+  // #70 contract: re-framed as structured failure.
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('Failed'), `Should contain "Failed", got: ${result.error}`);
 });
 
 asyncTest('mail_send: success result returns success message', async () => {


### PR DESCRIPTION
## What & why

`ToolRegistry.execute()` is meant to be the single error chokepoint: a failing tool yields `{ success: false, error }`, and the agent loop frames it to the model as `Error: …`. But most handlers swallow their own exception and **return a failure string** (`catch (err) { return 'Failed to X: ${err.message}' }`). That string looks like a normal return, so `execute()` framed it as `{ success: true }` and the failure reached the model **wearing a success mask** — the wound #70 documents. Observed live on [BETA-1]: a 403 from a Deck tool surfaced as a generic support lecture; the model improvised around an error string instead of disclosing the failure.

The generator-level fix is **Option A** (handlers throw; `execute()`'s catch and its graceful 403 branch own failure). Converting 70+ handlers is a separate migration, so this PR lands the **chokepoint contract + a migration seam**, as scoped in the issue.

## Changes

- **`tool-registry.js` — migration seam.** `execute()` detects the handlers' own failure-return convention (`detectHandlerFailureString`) and re-frames it as `{ success: false, error }`. Markers match code the registry itself emits — fixed English literals from `catch` blocks, invariant across the user's language — **not** user or model text. This is plumbing translating plumbing's legacy output, not the language layer (CLAUDE.md Rule 1: adding a language never edits the marker list). Scope is the **exception-swallow convention only** (`Failed to …`, `… not found or inaccessible …`). Happy-path informational negatives ("No card found", "Could not assign — not a member") are **deliberately not swept** — they're business outcomes, not swallowed exceptions, and the model already reports them correctly. As handlers migrate to throwing, their markers retire from the list.
- **`SOUL.md` — the agent loop's system prompt** gains the target behavior for a failed tool (Verification Discipline): when a result is an `Error: …`, name what you tried and what failed, relay the error as evidence in the user's language, and stop — don't improvise a generic explanation around it.

## Tests

- New: `detectHandlerFailureString` units (matches the convention, inspects `.text`, does **not** sweep informational negatives, no mid-string false-positives) + `execute()` seam units.
- Updated: the two `execute()` tests that encoded the old success-masking contract, plus the `tool-response-validation` and `orphan-tools` suites — now assert `{ success:false, error }`. Their stated intent ("returns failure") is now structurally served.
- **221/221 unit files pass; lint 0 errors.**

## Live verification (BUILT ≠ VERIFIED)

Scratch instance on the production model (Haiku). A read-only tool was overridden to return a swallowed `Failed to get card #999: Forbidden (board shared read-only)` string:

```
[ToolRegistry] Tool deck_get_card returned a failure string (migration seam #70): Failed to get card #999: Forbidden (board shared read-only)
[AgentLoop] Tool deck_get_card failed (1x): Failed to get card #999: Forbidden (board shared read-only)
```

→ `success: false`, not the old silent success. The model then disclosed honestly, in the user's language:

> Die Karte #999 existiert, aber ich habe keine Berechtigung, sie zu lesen. Das Board … ist mit mir nur als Leseberechtigte geteilt ("shared read-only"). Kannst du mir sagen, auf welchem Board sich die Karte befindet? …

Named the failure, relayed the error as evidence, offered a real next step — **no improvised support lecture, no false success.** (Verify scaffold was env-gated and reverted before commit.)

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
