### PR TITLE
fix(config): treat YOUR_* placeholders as empty at the env boundary (#148)

### DIFF
--- a/deploy/moltagent.service.example
+++ b/deploy/moltagent.service.example
@@ -49,7 +49,16 @@ Environment=SEARXNG_URL=http://localhost:8080
 # Primary Talk room for proactive messages (digest, alerts). Replies go to
 # whichever room the user messaged from; this room is for bot-initiated messages.
 # Environment=TALK_PRIMARY_ROOM=your-primary-room-token
-Environment=KNOWLEDGE_ADMIN_USER=YOUR_NC_ADMIN_USER
+# Admin-share targets — OPTIONAL, empty by default (leave commented for NO
+# sharing). When set to a real NC username, the agent shares its OWN control
+# surface to that user: ADMIN_USER grants edit/share/manage on the Cockpit,
+# Personal, and Tasks boards; KNOWLEDGE_ADMIN_USER adds them to the Knowledge
+# collective. Set these to your OWN NC admin only if you want a human co-owner;
+# a stranger's username here is a write-ACL on your control plane (#148). The
+# config boundary also treats a leftover YOUR_* value as empty, so an unedited
+# copy never shares.
+# Environment=ADMIN_USER=
+# Environment=KNOWLEDGE_ADMIN_USER=
 Environment=TEST_NC_PASSWORDS=false
 
 # Graceful shutdown: LLM summary + trust pipeline needs up to 90s per session

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,7 +10,9 @@
  * All configuration flows from this module; consumers import and use directly.
  *
  * Key Dependencies:
- * - None (leaf module - no internal dependencies)
+ * - shared/placeholder (a leaf): the canonical `YOUR_*` placeholder check, so
+ *   envStr collapses deployer-documentation placeholders to '' once, at the
+ *   boundary, instead of letting them reach a client as if configured (#148).
  *
  * Data Flow:
  * - Environment variables -> defaults -> frozen config object
@@ -21,6 +23,8 @@
  */
 
 'use strict';
+
+const { isPlaceholder } = require('./shared/placeholder');
 
 // -----------------------------------------------------------------------------
 // Helper Functions
@@ -56,14 +60,25 @@ function envBool(envVar, defaultValue) {
 }
 
 /**
- * Parse string from environment variable with fallback
+ * Parse string from environment variable with fallback.
+ *
+ * Placeholder-aware (#148): a `YOUR_*` value — whether it arrives from the env
+ * (an unedited deployment copies the `.example` unit verbatim) or from a
+ * deliberate documentation default below — is deployer documentation, not
+ * configuration. It collapses to '' here, once, at the boundary, so a
+ * placeholder never reaches a client: no ghost share-ACL to a nonexistent
+ * `YOUR_NC_ADMIN_USER`, no `YOUR_OLLAMA_IP` endpoint. Downstream truthiness /
+ * `isPlaceholder` guards already treat '' as "unset", so this only tightens an
+ * existing contract (same primitive the voice path uses). See shared/placeholder.
+ *
  * @param {string} envVar - Environment variable name
  * @param {string} defaultValue - Default if not set
  * @returns {string}
  */
 function envStr(envVar, defaultValue) {
   const value = process.env[envVar];
-  return (value !== undefined && value !== '') ? value : defaultValue;
+  const resolved = (value !== undefined && value !== '') ? value : defaultValue;
+  return isPlaceholder(resolved) ? '' : resolved;
 }
 
 /**
@@ -248,9 +263,9 @@ const config = {
   // Ollama LLM
   // -------------------------------------------------------------------------
   ollama: {
-    // The YOUR_* default is deliberate: it documents the env var for the
-    // deployer. At runtime resolveOllamaEndpoint() treats it as "unset" and
-    // falls back to localhost:11434, so the placeholder never reaches a client.
+    // The YOUR_* literal documents the env var for the deployer; envStr now
+    // collapses it to '' at the boundary (#148), and resolveOllamaEndpoint()
+    // falls back to localhost:11434 — so the placeholder never reaches a client.
     url: envStr('OLLAMA_URL', 'http://YOUR_OLLAMA_IP:11434'),
     model: envStr('OLLAMA_MODEL', 'phi4-mini'),
     modelCredential: envStr('OLLAMA_MODEL_CREDENTIAL', null) || envStr('OLLAMA_MODEL', 'phi4-mini'),
@@ -550,11 +565,11 @@ const config = {
   // Voice Pipeline (Whisper STT + call-aware routing)
   // -------------------------------------------------------------------------
   voice: {
-    // The YOUR_* voice defaults are deliberate env-var documentation. Unlike
-    // the LLM endpoint, voice is an optional dependency: webhook-server gates
-    // VoiceManager/WhisperClient construction on a configured URL, so a
-    // placeholder/unset value disables voice cleanly rather than building a
-    // client that fails on first use. See #100.
+    // The YOUR_* voice literals document the env vars. Voice is an optional
+    // dependency: envStr collapses the placeholder to '' (#148) and
+    // webhook-server gates VoiceManager/WhisperClient on a configured (truthy,
+    // non-placeholder) URL, so a placeholder/unset value disables voice cleanly
+    // rather than building a client that fails on first use. See #100.
     whisperUrl: envStr('WHISPER_URL', 'http://YOUR_OLLAMA_IP:8014'),
     whisperTimeout: envInt('WHISPER_TIMEOUT', 60000),
     whisperModel: envStr('WHISPER_MODEL', 'small'),
@@ -589,10 +604,12 @@ const config = {
     selfHealEnabled: envBool('INFRA_SELF_HEAL', true),
     notifyOnFailure: envBool('INFRA_NOTIFY_ON_FAILURE', true),
     heald: {
-      // Default is the placeholder sentinel. Downstream (webhook-server.js)
-      // treats this sentinel as "heald not deployed" and skips SelfHealClient
-      // construction so we don't log a credential-missing error every probe.
-      // See #26.
+      // Unset means "heald not deployed": envStr now collapses the YOUR_*
+      // default to '' (#148), and downstream (webhook-server.js) skips
+      // SelfHealClient construction on the falsy URL — so we don't log a
+      // credential-missing error every probe. See #26. `urlPlaceholder` below
+      // is the pre-#148 sentinel comparison, now belt-and-suspenders (the
+      // truthiness guard already covers the collapsed '').
       url: envStr('HEALD_URL', 'http://YOUR_OLLAMA_IP:7867'),
       urlPlaceholder: 'http://YOUR_OLLAMA_IP:7867',
       tokenCredential: envStr('HEALD_TOKEN_CREDENTIAL', 'heald-token'),

--- a/src/lib/shared/placeholder.js
+++ b/src/lib/shared/placeholder.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Placeholder detection — the canonical "is this value deployer documentation
+ * rather than configuration?" primitive.
+ *
+ * ARCHITECTURE BRIEF
+ * Problem: The repo ships `.example` configs and `YOUR_*` env-var defaults as
+ *   documentation for the deployer. Those literals are truthy, so an unedited
+ *   deployment reads a placeholder as a real value — local inference dies on a
+ *   `YOUR_OLLAMA_IP` host (#100), and a `YOUR_NC_ADMIN_USER` share grants a
+ *   write+manage ACL to a nonexistent user on the agent's own control surface
+ *   (#148). Same generating function as #146: deployment state leaking through
+ *   defaults.
+ * Pattern: One definition of "placeholder" so the rule travels canonically
+ *   (TAO: signals keep custody). A `YOUR_*` value is the ABSENCE of
+ *   configuration, treated identically everywhere — `config.js` collapses it to
+ *   '' at the env boundary, `resolveOllamaEndpoint` falls back to localhost, the
+ *   voice path disables. Adding a deployment language never edits this file: the
+ *   marker is a fixed code literal, not natural-language matching (Rule 1).
+ * Key deps: none — a true leaf, safe to require from `config.js` (itself a leaf)
+ *   and from `resolve-ollama-endpoint.js`.
+ * Data flow: callers pass a resolved value → isPlaceholder() → boolean.
+ * Dependency map: depended on by config.js (envStr) and
+ *   shared/resolve-ollama-endpoint.js (which re-exports `_isPlaceholder` for its
+ *   existing importers, e.g. the webhook-server voice path).
+ */
+
+'use strict';
+
+/**
+ * The marker that identifies a deployer-documentation placeholder. Any value
+ * containing it (e.g. `YOUR_OLLAMA_IP`, `YOUR_NC_ADMIN_USER`) is treated as
+ * unset rather than as configuration.
+ * @type {string}
+ */
+const PLACEHOLDER_MARKER = 'YOUR_';
+
+/**
+ * @param {*} value - any resolved config/env value
+ * @returns {boolean} true if the value is a `YOUR_*` placeholder
+ */
+function isPlaceholder(value) {
+  return typeof value === 'string' && value.includes(PLACEHOLDER_MARKER);
+}
+
+module.exports = { isPlaceholder, PLACEHOLDER_MARKER };

--- a/src/lib/shared/resolve-ollama-endpoint.js
+++ b/src/lib/shared/resolve-ollama-endpoint.js
@@ -21,14 +21,14 @@
 
 'use strict';
 
+// Canonical placeholder primitive lives in ./placeholder (a leaf shared with
+// config.js). Re-exported below as `_isPlaceholder` so existing importers
+// (webhook-server voice path) are unaffected.
+const { isPlaceholder: _isPlaceholder, PLACEHOLDER_MARKER } = require('./placeholder');
+
 const DEFAULT_FALLBACK = 'http://localhost:11434';
-const PLACEHOLDER_MARKER = 'YOUR_';
 
 const _warnedOnce = new Set();
-
-function _isPlaceholder(value) {
-  return typeof value === 'string' && value.includes(PLACEHOLDER_MARKER);
-}
 
 function _warnOnce(key, message, logger) {
   if (_warnedOnce.has(key)) return;

--- a/test/manual/knowledge-pipeline-tests.sh
+++ b/test/manual/knowledge-pipeline-tests.sh
@@ -26,7 +26,7 @@ send_message() {
   local random_hex=$(openssl rand -hex 32)
 
   local body=$(cat <<ENDJSON
-{"type":"Create","actor":{"type":"Person","id":"users/Funana","name":"Funana"},"object":{"type":"Note","id":"${msg_id}","name":"","content":"${message}","mediaType":"text/markdown","message":{"id":"${msg_id}","token":"${ROOM}","actorType":"users","actorId":"Funana","actorDisplayName":"Funana","message":"${message}","messageParameters":{}}},"target":{"type":"Collection","id":"${ROOM}","name":"Test Room"}}
+{"type":"Create","actor":{"type":"Person","id":"users/testuser","name":"testuser"},"object":{"type":"Note","id":"${msg_id}","name":"","content":"${message}","mediaType":"text/markdown","message":{"id":"${msg_id}","token":"${ROOM}","actorType":"users","actorId":"testuser","actorDisplayName":"testuser","message":"${message}","messageParameters":{}}},"target":{"type":"Collection","id":"${ROOM}","name":"Test Room"}}
 ENDJSON
 )
 

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -221,6 +221,38 @@ test('TC-CFG-033: Ports config has standard values', () => {
   assert.strictEqual(config.ports.smtpDefault, 587);
 });
 
+// --- Placeholder-aware envStr (#148) ---
+
+test('TC-CFG-040: ADMIN_USER=YOUR_* placeholder collapses to empty (no ghost share)', () => {
+  const config = loadConfigWithEnv({ ADMIN_USER: 'YOUR_NC_ADMIN_USER', KNOWLEDGE_ADMIN_USER: '' });
+  assert.strictEqual(config.cockpit.adminUser, '', 'placeholder ADMIN_USER must read as empty');
+});
+
+test('TC-CFG-041: a real ADMIN_USER value is preserved', () => {
+  const config = loadConfigWithEnv({ ADMIN_USER: 'alice', KNOWLEDGE_ADMIN_USER: '' });
+  assert.strictEqual(config.cockpit.adminUser, 'alice');
+});
+
+test('TC-CFG-042: KNOWLEDGE_ADMIN_USER=YOUR_* placeholder collapses to empty', () => {
+  const config = loadConfigWithEnv({ KNOWLEDGE_ADMIN_USER: 'YOUR_NC_ADMIN_USER', ADMIN_USER: '' });
+  assert.strictEqual(config.knowledge.adminUser, '');
+});
+
+test('TC-CFG-043: OLLAMA_URL placeholder env value collapses to empty', () => {
+  const config = loadConfigWithEnv({ OLLAMA_URL: 'http://YOUR_OLLAMA_IP:11434' });
+  assert.strictEqual(config.ollama.url, '', 'placeholder endpoint must read as empty so the resolver falls back');
+});
+
+test('TC-CFG-044: unset OLLAMA_URL (deliberate YOUR_* default) also collapses to empty', () => {
+  const config = loadConfigWithEnv({});  // OLLAMA_ keys are cleared by the helper
+  assert.strictEqual(config.ollama.url, '');
+});
+
+test('TC-CFG-045: a real OLLAMA_URL is preserved', () => {
+  const config = loadConfigWithEnv({ OLLAMA_URL: 'http://10.0.0.5:11434' });
+  assert.strictEqual(config.ollama.url, 'http://10.0.0.5:11434');
+});
+
 // --- Cleanup ---
 
 // Restore original environment

--- a/test/unit/shared/placeholder.test.js
+++ b/test/unit/shared/placeholder.test.js
@@ -1,0 +1,44 @@
+/**
+ * Placeholder primitive tests (#148)
+ *
+ * Run: node test/unit/shared/placeholder.test.js
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { isPlaceholder, PLACEHOLDER_MARKER } = require('../../../src/lib/shared/placeholder');
+
+console.log('\n=== Placeholder Primitive Tests ===\n');
+
+test('marker is YOUR_', () => {
+  assert.strictEqual(PLACEHOLDER_MARKER, 'YOUR_');
+});
+
+test('detects YOUR_* values anywhere in the string', () => {
+  assert.strictEqual(isPlaceholder('YOUR_NC_ADMIN_USER'), true);
+  assert.strictEqual(isPlaceholder('http://YOUR_OLLAMA_IP:11434'), true);
+  assert.strictEqual(isPlaceholder('https://YOUR_NEXTCLOUD_URL'), true);
+});
+
+test('real values are not placeholders', () => {
+  assert.strictEqual(isPlaceholder('alice'), false);
+  assert.strictEqual(isPlaceholder('http://10.0.0.5:11434'), false);
+  assert.strictEqual(isPlaceholder(''), false);
+});
+
+test('non-strings are not placeholders', () => {
+  assert.strictEqual(isPlaceholder(null), false);
+  assert.strictEqual(isPlaceholder(undefined), false);
+  assert.strictEqual(isPlaceholder(42), false);
+  assert.strictEqual(isPlaceholder({}), false);
+});
+
+// The canonical primitive is shared with resolveOllamaEndpoint, which re-exports
+// it as _isPlaceholder — same behaviour, one definition (TAO: signals keep custody).
+test('resolve-ollama-endpoint re-exports the same primitive', () => {
+  const { _isPlaceholder } = require('../../../src/lib/shared/resolve-ollama-endpoint');
+  assert.strictEqual(_isPlaceholder, isPlaceholder);
+});
+
+summary();
+exitWithCode();


### PR DESCRIPTION
## What & why

A deployment that copies the `.example` systemd unit verbatim inherits `ADMIN_USER=YOUR_NC_ADMIN_USER`. That literal is **truthy**, so the share guards (`if (adminUser)`) fire and the agent grants **edit/share/manage on its own control surface** — the Cockpit/Personal/Tasks boards and the Knowledge collective — to a username that exists on no install. A ghost write-ACL on the control plane. Observed on [BETA-1].

This is the **same generating function as #146** (deployment state leaking through defaults), one layer deeper: the placeholder itself.

## Generator fix — at the env boundary, not the instance

`envStr` becomes **placeholder-aware once**. A `YOUR_*` value — whether from the env or from a deliberate documentation default — is the *absence* of configuration and collapses to `''`.

- Converges on the **same primitive the voice path already uses** (no second pattern), extracted to a leaf `src/lib/shared/placeholder.js` so it has one canonical home (TAO: signals keep custody). `resolve-ollama-endpoint` delegates to it and re-exports `_isPlaceholder`, so its importers (the voice path) are untouched.
- Downstream truthiness / `isPlaceholder` guards already treat `''` as "unset", so this only **tightens an existing contract**. The deliberate `YOUR_*` defaults (OLLAMA/WHISPER/SPEACHES/HEALD) all route through those guards — collapsing them to `''` is equivalent, and in two cases strictly better (a truthiness guard now correctly skips the placeholder instead of propagating it).

## The two #146-class residues this issue named

- `test/manual/knowledge-pipeline-tests.sh`: the verbatim operator username in the simulated Talk webhook payload scrubbed to `testuser` (the `e1f2502` generic-example convention).
- `deploy/moltagent.service.example`: the share lines are now **commented-out and empty by default**, with the ACL semantics documented — an unedited copy shares with no one.

## Tests

- `shared/placeholder` units; config envStr placeholder-collapse cases (env value, deliberate default, real value preserved) for both admin-user and `OLLAMA_URL`.
- **222/222 unit files pass; lint 0 errors.**

## Live verification (BUILT ≠ VERIFIED)

In-process on the production host (real `config.js`, real deployed Node):

```
ADMIN_USER=YOUR_NC_ADMIN_USER  →  config.cockpit.adminUser   = ""   → cockpit shareBoard guard: SKIP
KNOWLEDGE_ADMIN_USER=YOUR_NC... →  config.knowledge.adminUser = ""   → wiki shareWithAdmin guard: SKIP
```

Both production share guards (`cockpit-manager.js:456`, `webhook-server.js:1015`) take the **SKIP** branch — no share. **Control:** a real username is preserved and the guard SHARES, so legitimate operator sharing is intact. Verified in-process rather than via a full scratch boot to avoid `CockpitManager` mutating the live cockpit board.

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
