### PR TITLE
fix(skill-forge): health gate so a failed skill leaves no live tools (#127)

### DIFF
--- a/src/skill-forge/activator.js
+++ b/src/skill-forge/activator.js
@@ -476,14 +476,23 @@ class ToolActivator {
     const templateVersion = template.version || '1.0.0';
     const toolsRegistered = [];
 
+    // Health gate (#127): build EVERY operation's tool definition before
+    // registering ANY. The build helpers (_buildSchema / _buildOperationConfig)
+    // are where credentialed/OAuth templates throw `undefined.substring`; doing
+    // all the building first means a throw on a later operation can't leave the
+    // earlier operations live in the registry. Activation is all-or-nothing.
+    const pending = [];
     for (const operation of operations) {
       const toolName = `${skillId}_${this._slugify(operation.name)}`;
       const schema = this._buildSchema(operation);
       const opConfig = this._buildOperationConfig(template, operation, resolvedParams);
-
       // Capture opConfig in closure — each operation gets its own config snapshot
       const executeFn = async (params) => this.httpExecutor.execute(opConfig, params);
+      pending.push({ toolName, operation, schema, executeFn });
+    }
 
+    // Every operation built cleanly — commit them as a unit.
+    for (const { toolName, operation, schema, executeFn } of pending) {
       this.toolRegistry.register({
         name: toolName,
         description: operation.description || `${operation.name} operation from skill ${skillId}`,
@@ -496,7 +505,6 @@ class ToolActivator {
           activatedAt: new Date().toISOString(),
         },
       });
-
       toolsRegistered.push(toolName);
     }
 
@@ -572,6 +580,49 @@ class ToolActivator {
   }
 
   /**
+   * Unregister every live tool belonging to a skill, directly from the registry
+   * (no NC config required, unlike deactivate). Used by the activation rollback
+   * and the reconciliation pass to pull a skill whose discovery failed (#127).
+   *
+   * @param {string} skillId
+   * @returns {string[]} names of tools removed
+   */
+  _unregisterSkillTools(skillId) {
+    const removed = [];
+    if (!skillId || typeof this.toolRegistry.listBySource !== 'function') return removed;
+    for (const tool of this.toolRegistry.listBySource('skill-forge')) {
+      if (tool.metadata && tool.metadata.skillId === skillId) {
+        this.toolRegistry.unregister(tool.name);
+        removed.push(tool.name);
+      }
+    }
+    if (removed.length && this.egressGuard) {
+      this.egressGuard.removeBySource('skill-forge', skillId);
+    }
+    return removed;
+  }
+
+  /**
+   * Reconciliation pass (#127): after autoDiscover, pull any tools left live by
+   * a skill whose discovery failed. With the all-or-nothing activate() this is
+   * normally a no-op for build-time throws, but it closes the remaining gaps —
+   * a skill that registered through one path then failed another, or any future
+   * non-atomic site — so the failure signal in discovery.errors finally reaches
+   * the registry instead of being console.warn'd and discarded.
+   *
+   * @param {{ errorSkillIds?: string[] }} discoveryResult - result from autoDiscover
+   * @returns {Array<{ skillId: string, removed: string[] }>} skills whose live tools were pulled
+   */
+  reconcile(discoveryResult) {
+    const quarantined = [];
+    for (const skillId of (discoveryResult?.errorSkillIds || [])) {
+      const removed = this._unregisterSkillTools(skillId);
+      if (removed.length) quarantined.push({ skillId, removed });
+    }
+    return quarantined;
+  }
+
+  /**
    * Reload all persisted skill configs from NC — used on agent restart.
    *
    * Reads every JSON file in /Memory/SkillForge/active/ and re-activates
@@ -615,7 +666,9 @@ class ToolActivator {
     let yaml;
     try { yaml = require('js-yaml'); } catch { return { activated: [], metaTools: [], skipped: [], errors: ['js-yaml not available'] }; }
 
-    const results = { activated: [], metaTools: [], skipped: [], errors: [] };
+    // errorSkillIds: skillIds (where known) of templates that threw — fed to
+    // reconcile() so the reconciliation pass can pull any live tools they left.
+    const results = { activated: [], metaTools: [], skipped: [], errors: [], errorSkillIds: [] };
 
     let files;
     try {
@@ -626,6 +679,7 @@ class ToolActivator {
     }
 
     for (const file of files) {
+      let skillId = null;
       try {
         const raw = fs.readFileSync(path.join(templatesDir, file), 'utf8');
         const template = yaml.load(raw);
@@ -633,7 +687,7 @@ class ToolActivator {
           continue; // Not a new-format template
         }
 
-        const skillId = template.skill_id;
+        skillId = template.skill_id;
 
         // Skip if already activated (tools already in registry from reloadAll)
         const firstToolName = `${skillId}_${this._slugify(template.operations[0].name)}`;
@@ -697,6 +751,7 @@ class ToolActivator {
         }
       } catch (err) {
         results.errors.push(`${file}: ${err.message}`);
+        if (skillId) results.errorSkillIds.push(skillId);
       }
     }
 

--- a/test/unit/skill-forge/tool-activator.test.js
+++ b/test/unit/skill-forge/tool-activator.test.js
@@ -281,6 +281,51 @@ asyncTest('activate: fires audit log with skill_forge_activation action', async 
 });
 
 // -----------------------------------------------------------------------------
+// activate() health gate — atomicity & rollback (#127)
+// -----------------------------------------------------------------------------
+
+asyncTest('activate: a build throw on a later operation registers NOTHING (#127)', async () => {
+  const registry = mockToolRegistry();
+  const activator = makeActivator({ toolRegistry: registry });
+
+  // Reproduce the credentialed-template failure: a later operation throws
+  // undefined.substring while building. With all-or-nothing build, the earlier
+  // operation must not be left live.
+  const realBuild = activator._buildOperationConfig.bind(activator);
+  activator._buildOperationConfig = (template, operation, params) => {
+    if (operation.name === 'create item') {
+      throw new TypeError("Cannot read properties of undefined (reading 'substring')");
+    }
+    return realBuild(template, operation, params);
+  };
+
+  await assert.rejects(() => activator.activate(sampleTemplate, {}), /substring/);
+  assert.strictEqual(registry._tools.size, 0, 'no operation may be left live when a later one fails to build');
+});
+
+asyncTest('reconcile: pulls live tools for skillIds in errorSkillIds, leaves others (#127)', async () => {
+  const registry = mockToolRegistry();
+  const activator = makeActivator({ toolRegistry: registry });
+
+  registry.register({ name: 'ghost_op', metadata: { source: 'skill-forge', skillId: 'ghost' }, handler: async () => {} });
+  registry.register({ name: 'keep_op', metadata: { source: 'skill-forge', skillId: 'keep' }, handler: async () => {} });
+
+  const quarantined = activator.reconcile({ errorSkillIds: ['ghost'] });
+
+  assert.deepStrictEqual(quarantined, [{ skillId: 'ghost', removed: ['ghost_op'] }]);
+  assert.ok(!registry.has('ghost_op'), 'failed-skill tools must be pulled');
+  assert.ok(registry.has('keep_op'), 'unrelated skill must be untouched');
+});
+
+asyncTest('reconcile: clean (empty) when failed skills left no live tools (#127)', async () => {
+  const registry = mockToolRegistry();
+  const activator = makeActivator({ toolRegistry: registry });
+
+  const quarantined = activator.reconcile({ errorSkillIds: ['brave-search', 'google-calendar'] });
+  assert.deepStrictEqual(quarantined, [], 'nothing to pull when nothing leaked');
+});
+
+// -----------------------------------------------------------------------------
 // deactivate() tests
 // -----------------------------------------------------------------------------
 

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1881,6 +1881,16 @@ async function initialize() {
             }
             if (discovery.errors.length > 0) {
               console.warn(`[INIT] SkillForge discovery errors: ${discovery.errors.join('; ')}`);
+              // Reconciliation pass (#127): a skill that failed discovery must not
+              // leave live tools behind. Pull anything its failed activation left
+              // registered, so the failure signal reaches the registry instead of
+              // being logged and discarded.
+              const quarantined = toolActivator.reconcile(discovery);
+              if (quarantined.length > 0) {
+                console.warn(`[INIT] SkillForge reconciliation pulled live tools from failed skills: ${quarantined.map(q => `${q.skillId} (${q.removed.join(', ')})`).join('; ')}`);
+              } else {
+                console.log('[INIT] SkillForge reconciliation: failed skills left no live tools (clean)');
+              }
             }
           } catch (discErr) {
             console.warn(`[INIT] SkillForge auto-discovery failed: ${discErr.message}`);


### PR DESCRIPTION
## What & why

On every boot, `autoDiscover` logged a discovery error for the two parameterless credentialed templates (`brave-search.yaml`, `google-calendar.yaml`) **and** their tools stayed registered as live. Same skill, both states — the failure was computed (`discovery.errors`), `console.warn`'d, and discarded, while the half-registered tools reached the agent. Transcription without translation: the signal never reached the registry.

## Fix — a health gate, leak-proof regardless of where the throw lands

1. **All-or-nothing build.** `activate()` builds every operation's tool definition before registering any, so a throw during schema/config build can't leave earlier operations live.
2. **Reconciliation pass.** After `autoDiscover`, `activator.reconcile(discovery)` unregisters the tools of any skill in `discovery.errors`. `autoDiscover` now reports `errorSkillIds`; webhook-server logs what reconciliation pulled. This closes the **post-register** throw (the real #127 path) and any future non-atomic site.

## Diagnosis correction (recorded for the record)

The throw is **not** in the build / `generateToolDefinitions` path the issue suspected. The tools build and register fine; the throw is **post-registration, in the audit step** — `consoleAuditLog(event, data)` does `JSON.stringify(data).substring(...)`, but `activate()` calls `auditLog({event, skillId, …})` with one object → `data` undefined → `JSON.stringify(undefined)` is undefined → `.substring` throws. This PR makes that failure **clean** (no live tools); the signature mismatch itself is filed as **#152** (it also means skill activations are never audited).

## Tests

- Build-throw atomicity (a later op throwing registers nothing); reconcile pulls the right skill and leaves others; reconcile clean when nothing leaked.
- **221/221 unit files pass; lint 0 errors.**

## Live verification (BUILT ≠ VERIFIED) — two ways on Prime

**In-process** over the real templates with a faithful copy of `consoleAuditLog`: errors identical to production, **6 tools leak** before reconcile (`brave-search_web_search` … `google-calendar_delete_event`), reconcile pulls all 6, none remain.

**Scratch boot on this branch, real INIT path** — journal:

```
[INIT] SkillForge discovery errors: brave-search.yaml: Cannot read properties of undefined (reading 'substring'); google-calendar.yaml: …
[INIT] SkillForge reconciliation pulled live tools from failed skills: brave-search (brave-search_web_search, brave-search_news_search); google-calendar (google-calendar_list_events, google-calendar_create_event, google-calendar_update_event, google-calendar_delete_event)
```

Discovery errors **remain**; live tools no longer do. (Scratch ran `INITIATIVE_LEVEL=0`, made no proactive post, shut down clean.)

Closes #127. Root cause filed as #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
