### PR TITLE
fix(llm): make Ollama keep_alive a per-provider knob, default to server policy (#124)

### DIFF
--- a/config/moltagent-providers.yaml.example
+++ b/config/moltagent-providers.yaml.example
@@ -10,6 +10,12 @@ providers:
     adapter: ollama
     endpoint: http://localhost:11434
     model: qwen3:8b
+    # keep_alive: how long Ollama keeps the model resident after a request.
+    # Omitted by default → the Ollama server's own setting governs (do not let
+    # the client override the box's resource policy). Set it only to pin a
+    # value: e.g. "30m", "2h", or -1 to keep the model loaded indefinitely
+    # (useful on a CPU-only host to avoid cold-start tool timeouts — see #124).
+    # keep_alive: -1
 
   # Premium tier - Claude Opus (deep reasoning, complex writing)
   anthropic-claude:

--- a/src/lib/agent/providers/ollama-tools.js
+++ b/src/lib/agent/providers/ollama-tools.js
@@ -21,6 +21,11 @@ class OllamaToolsProvider {
     this.model = config.model || 'phi4-mini';
     this.timeout = config.timeout || 300000;
     this.toolTimeout = config.toolTimeout || 60000;
+    // Per-provider model-lifetime knob (#124). Default: undefined → the
+    // keep_alive field is omitted from the request, so the Ollama server's own
+    // setting governs (the client must not override the box's resource policy —
+    // a hardcoded '10m' evicted indefinitely-pinned models on the DGX host).
+    this.keepAlive = config.keep_alive;
     this.logger = logger || console;
     this._fetch = globalThis.fetch;
   }
@@ -93,12 +98,15 @@ class OllamaToolsProvider {
       messages: ollamaMessages,
       stream: false,
       think: false,
-      keep_alive: '10m',
       options: {
         num_predict: 1024,
         ...(options || {})
       }
     };
+    // Only send keep_alive when configured; otherwise the server's setting wins (#124).
+    if (this.keepAlive !== undefined && this.keepAlive !== null) {
+      body.keep_alive = this.keepAlive;
+    }
 
     if (tools && tools.length > 0) {
       body.tools = tools;

--- a/src/lib/llm/providers/ollama-provider.js
+++ b/src/lib/llm/providers/ollama-provider.js
@@ -25,6 +25,10 @@ class OllamaProvider extends BaseProvider {
       model: config.model || 'phi4-mini',
       costModel: { type: 'free' }
     });
+    // Per-provider model-lifetime knob (#124), flows in via the createProvider
+    // config spread (router.js → providers/index.js). Default: undefined → the
+    // keep_alive field is omitted so the Ollama server's own setting governs.
+    this.keepAlive = config.keep_alive;
     this._fetch = globalThis.fetch;
   }
 
@@ -68,12 +72,15 @@ class OllamaProvider extends BaseProvider {
             model: this.model,
             messages,
             stream: false,
-            keep_alive: '10m',
             options: {
               temperature: options.temperature ?? 0.7,
               num_predict: options.maxTokens || 1024
             }
           };
+        // Only send keep_alive when configured; otherwise the server's setting wins (#124).
+        if (this.keepAlive !== undefined && this.keepAlive !== null) {
+          requestBody.keep_alive = this.keepAlive;
+        }
         if (options.format) requestBody.format = options.format;
 
         // Disable thinking mode for structured extraction (temperature 0).

--- a/test/unit/agent/providers/ollama-tools.test.js
+++ b/test/unit/agent/providers/ollama-tools.test.js
@@ -195,6 +195,53 @@ asyncTest('_fetchWithRetry does not retry HTTP errors (err.status set)', async (
 });
 
 // ============================================================
+// keep_alive knob (#124)
+// ============================================================
+
+console.log('\n--- keep_alive knob (#124) ---\n');
+
+// Override _fetch to capture the request body sent to /api/chat.
+function captureBody(provider) {
+  const captured = {};
+  provider._fetch = async (_url, opts) => {
+    captured.body = JSON.parse(opts.body);
+    return { ok: true, json: async () => ({ message: { role: 'assistant', content: 'ok' } }) };
+  };
+  return captured;
+}
+
+test('constructor: keepAlive is undefined by default', () => {
+  const provider = new OllamaToolsProvider({}, silentLogger);
+  assert.strictEqual(provider.keepAlive, undefined);
+});
+
+test('constructor: keepAlive reads config.keep_alive', () => {
+  const provider = new OllamaToolsProvider({ keep_alive: -1 }, silentLogger);
+  assert.strictEqual(provider.keepAlive, -1);
+});
+
+asyncTest('chat: omits keep_alive from the body when not configured (server governs)', async () => {
+  const provider = new OllamaToolsProvider({}, silentLogger);
+  const cap = captureBody(provider);
+  await provider.chat({ messages: [{ role: 'user', content: 'hi' }] });
+  assert.ok(!('keep_alive' in cap.body), 'keep_alive must be absent so the Ollama server setting wins');
+});
+
+asyncTest('chat: sends configured keep_alive (e.g. -1 = indefinite)', async () => {
+  const provider = new OllamaToolsProvider({ keep_alive: -1 }, silentLogger);
+  const cap = captureBody(provider);
+  await provider.chat({ messages: [{ role: 'user', content: 'hi' }] });
+  assert.strictEqual(cap.body.keep_alive, -1);
+});
+
+asyncTest('chat: sends a string keep_alive verbatim (e.g. "30m")', async () => {
+  const provider = new OllamaToolsProvider({ keep_alive: '30m' }, silentLogger);
+  const cap = captureBody(provider);
+  await provider.chat({ messages: [{ role: 'user', content: 'hi' }] });
+  assert.strictEqual(cap.body.keep_alive, '30m');
+});
+
+// ============================================================
 // Summary
 // ============================================================
 

--- a/test/unit/llm/providers/ollama-provider.test.js
+++ b/test/unit/llm/providers/ollama-provider.test.js
@@ -140,4 +140,38 @@ asyncTest('_fetchWithRetry does not retry HTTP errors (err.status set)', async (
   }
 });
 
+// --- keep_alive knob (#124) ---
+
+test('constructor: keepAlive is undefined by default', () => {
+  const provider = new OllamaProvider({ id: 'test', logger: silentLogger });
+  assert.strictEqual(provider.keepAlive, undefined);
+});
+
+test('constructor: keepAlive reads config.keep_alive', () => {
+  const provider = new OllamaProvider({ id: 'test', keep_alive: -1, logger: silentLogger });
+  assert.strictEqual(provider.keepAlive, -1);
+});
+
+asyncTest('generate: omits keep_alive when not configured (server governs)', async () => {
+  const provider = new OllamaProvider({ id: 'test', logger: silentLogger });
+  let capturedBody;
+  provider._fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return { ok: true, json: async () => ({ message: { content: 'ok' }, prompt_eval_count: 1, eval_count: 1 }) };
+  };
+  await provider.generate('summarize', 'hello world', {});
+  assert.ok(!('keep_alive' in capturedBody), 'keep_alive must be absent so the Ollama server setting wins');
+});
+
+asyncTest('generate: sends configured keep_alive', async () => {
+  const provider = new OllamaProvider({ id: 'test', keep_alive: '2h', logger: silentLogger });
+  let capturedBody;
+  provider._fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return { ok: true, json: async () => ({ message: { content: 'ok' }, prompt_eval_count: 1, eval_count: 1 }) };
+  };
+  await provider.generate('summarize', 'hello world', {});
+  assert.strictEqual(capturedBody.keep_alive, '2h');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1546,7 +1546,8 @@ async function initialize() {
           endpoint: ollamaEndpoint,
           model: ollamaConfig.model || CONFIG.ollama.model,
           timeout: CONFIG.ollama.timeout,
-          toolTimeout: CONFIG.ollama.toolTimeout
+          toolTimeout: CONFIG.ollama.toolTimeout,
+          keep_alive: ollamaConfig.keep_alive  // #124: per-provider knob; undefined → server governs
         });
         console.log(`[INIT] OllamaToolsProvider ready (${ollamaEndpoint}, ${ollamaConfig.model || CONFIG.ollama.model})`);
       }
@@ -1558,7 +1559,8 @@ async function initialize() {
           endpoint: ollamaEndpoint,
           model: CONFIG.ollama.modelCredential,
           timeout: CONFIG.ollama.timeout,
-          toolTimeout: CONFIG.ollama.toolTimeout
+          toolTimeout: CONFIG.ollama.toolTimeout,
+          keep_alive: ollamaConfig.keep_alive  // #124
         });
         console.log(`[INIT] OllamaToolsProvider (credential) ready (${CONFIG.ollama.modelCredential})`);
       }
@@ -1572,7 +1574,8 @@ async function initialize() {
           endpoint: ollamaEndpoint,
           model: fastModel,
           timeout: 30000,
-          toolTimeout: 30000
+          toolTimeout: 30000,
+          keep_alive: ollamaConfig.keep_alive  // #124
         });
         console.log(`[INIT] OllamaToolsProvider (fast) ready (${fastModel})`);
       }


### PR DESCRIPTION
## What & why

Both Ollama request builders hardcoded `keep_alive: '10m'` — `OllamaToolsProvider.chat()` (src/lib/agent/providers/ollama-tools.js) and `OllamaProvider.generate()` (src/lib/llm/providers/ollama-provider.js). That literal is sent on every request and **overrides the Ollama server's own model-lifetime setting**, so on a host whose models were pinned for indefinite retention the client still evicted them — the 4–7 minute eviction window observed on the DGX host. The client shouldn't dictate the box's resource policy.

## Fix — per-provider knob, default = server governs

- Both constructors read `config.keep_alive` into `this.keepAlive`. **Default undefined → the `keep_alive` field is omitted** from the request body, so the Ollama server's own setting (or `OLLAMA_KEEP_ALIVE`, or `-1` indefinite) governs.
- `OllamaProvider` gets it free through the `createProvider` config spread (router.js:150 → providers/index.js). `OllamaToolsProvider` is built explicitly in webhook-server, so the three construction sites now pass `keep_alive: ollamaConfig.keep_alive`.
- Documented on the `ollama-local` block in `moltagent-providers.yaml.example` (commented, with the `-1` = indefinite note for CPU-only cold-start hosts). The JSON example stays clean — absence is the default, and JSON can't carry the comment that explains it.

This is the **keep_alive slice** of #124 — it shrinks the eviction-driven cold-start window. It does **not** address the very first turn after boot; the pre-warm/probe directions in the issue remain open.

## Tests

Constructor reads the knob (undefined default, configured value); `chat()` and `generate()` omit `keep_alive` when unset and send it verbatim (`"30m"`, `"2h"`, `-1`) when configured. **221/221 unit files pass; lint 0 errors.**

## Live verification (BUILT ≠ VERIFIED)

Real call to the production Ollama (`qwen2.5:3b`) with the default provider:

```
provider.keepAlive (default) = undefined
keep_alive present in body sent to live Ollama? false
live Ollama responded: "ok"
```

The request body sent to the **live** server had no `keep_alive` field (server governs) and the server accepted it. A provider constructed with `keep_alive: -1` sends `keep_alive: -1`. Default omits, configured value flows through.

Addresses the keep_alive portion of #124 (issue stays open for the cold-start pre-warm work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
