### PR TITLE
fix(skill-forge): conform ToolActivator audit calls to two-arg signature (#152)

### DIFF
--- a/src/skill-forge/activator.js
+++ b/src/skill-forge/activator.js
@@ -433,7 +433,7 @@ class ToolActivator {
    * @param {Object} options.toolRegistry - ToolRegistry with .register() and .unregister()
    * @param {Object} options.httpExecutor - HttpToolExecutor with .execute(opConfig, params)
    * @param {Object} options.ncFiles - NC file client: async .write(path, content), .read(path), .delete(path), .list(dir)
-   * @param {Function} options.auditLog - async (entry) => Promise audit log function
+   * @param {Function} options.auditLog - async (event, data) => Promise audit log function (event string, data object)
    * @param {Object} [options.egressGuard] - EgressGuard with .addAllowedDomain() and .removeBySource()
    */
   constructor({ toolRegistry, httpExecutor, ncFiles, auditLog, egressGuard = null }) {
@@ -521,8 +521,7 @@ class ToolActivator {
     await this._persistConfig(skillId, template, resolvedParams);
 
     // Audit log the activation
-    await this.auditLog({
-      event: 'skill_activated',
+    await this.auditLog('skill_activated', {
       skillId,
       templateVersion,
       toolsRegistered,
@@ -569,8 +568,7 @@ class ToolActivator {
     await this._removeConfig(skillId);
 
     // Audit log the deactivation
-    await this.auditLog({
-      event: 'skill_deactivated',
+    await this.auditLog('skill_deactivated', {
       skillId,
       toolsRemoved,
       timestamp: new Date().toISOString(),

--- a/test/unit/skill-forge/tool-activator.test.js
+++ b/test/unit/skill-forge/tool-activator.test.js
@@ -81,7 +81,9 @@ function mockNcFiles() {
 
 function mockAuditLog() {
   const entries = [];
-  const fn = async (entry) => { entries.push(entry); return entries; };
+  // Mirror the REAL consoleAuditLog(event, data) signature (#152). A mock that
+  // accepted a single object hid the activator's object-form bug.
+  const fn = async (event, data) => { entries.push({ event, data }); return entries; };
   fn._entries = entries;
   return fn;
 }
@@ -275,9 +277,9 @@ asyncTest('activate: fires audit log with skill_forge_activation action', async 
   assert.strictEqual(auditLog._entries.length, 1, 'exactly one audit entry must be written');
   const entry = auditLog._entries[0];
   assert.strictEqual(entry.event, 'skill_activated', 'audit event must be skill_activated');
-  assert.strictEqual(entry.skillId, 'test-skill');
-  assert.ok(Array.isArray(entry.toolsRegistered));
-  assert.ok(entry.timestamp, 'audit entry must have timestamp');
+  assert.strictEqual(entry.data.skillId, 'test-skill');
+  assert.ok(Array.isArray(entry.data.toolsRegistered));
+  assert.ok(entry.data.timestamp, 'audit entry must have timestamp');
 });
 
 // -----------------------------------------------------------------------------
@@ -391,9 +393,9 @@ asyncTest('deactivate: fires audit log with skill_forge_deactivation action', as
   assert.strictEqual(auditLog._entries.length, 1, 'exactly one audit entry for deactivation');
   const entry = auditLog._entries[0];
   assert.strictEqual(entry.event, 'skill_deactivated');
-  assert.strictEqual(entry.skillId, 'test-skill');
-  assert.ok(Array.isArray(entry.toolsRemoved));
-  assert.ok(entry.timestamp);
+  assert.strictEqual(entry.data.skillId, 'test-skill');
+  assert.ok(Array.isArray(entry.data.toolsRemoved));
+  assert.ok(entry.data.timestamp);
 });
 
 // -----------------------------------------------------------------------------
@@ -612,6 +614,31 @@ asyncTest('integration: full lifecycle — activate registers tools, handler exe
   assert.strictEqual(auditLog._entries.length, 2, 'must have one audit entry per lifecycle event');
   assert.strictEqual(auditLog._entries[0].event, 'skill_activated');
   assert.strictEqual(auditLog._entries[1].event, 'skill_deactivated');
+});
+
+// -----------------------------------------------------------------------------
+// Signature regression tests (#152)
+// -----------------------------------------------------------------------------
+
+asyncTest('activate: calls auditLog with two-arg (event, data) signature — not object-form (#152)', async () => {
+  const calls = [];
+  const auditLog = async (event, data) => { calls.push([event, data]); };
+  const activator = makeActivator({ auditLog });
+  await activator.activate(sampleTemplate, {});
+  assert.strictEqual(calls.length, 1, 'one audit call');
+  const [event, data] = calls[0];
+  assert.strictEqual(typeof event, 'string', 'first arg must be the event string, not an object');
+  assert.strictEqual(event, 'skill_activated');
+  assert.strictEqual(typeof data, 'object', 'second arg must be the data object');
+  assert.strictEqual(data.skillId, 'test-skill');
+});
+
+asyncTest('audit: a two-arg logger receiving undefined data must not throw (#152 chokepoint invariant)', async () => {
+  const safeLog = async (event, data) => {
+    const serialized = data === undefined ? '' : String(JSON.stringify(data)).substring(0, 200);
+    return `${event}:${serialized}`;
+  };
+  await assert.doesNotReject(() => safeLog('skill_activated', undefined));
 });
 
 // -----------------------------------------------------------------------------

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -546,8 +546,10 @@ let dailyDigest = null; // Episodic Memory: daily digest page generation
 
 // Simple console audit logger fallback
 async function consoleAuditLog(event, data) {
+  // Audit is observability; it must never throw and take down its caller (See #152, #127).
   const timestamp = new Date().toISOString();
-  console.log(`[AUDIT] ${timestamp} ${event}:`, JSON.stringify(data).substring(0, 200));
+  const serialized = data === undefined ? '' : String(JSON.stringify(data)).substring(0, 200);
+  console.log(`[AUDIT] ${timestamp} ${event}:`, serialized);
 }
 
 /**


### PR DESCRIPTION
## Problem

`consoleAuditLog(event, data)` is the real audit logger signature — a bare event string plus a data object — and every `auditLog` caller across `src/` uses that two-arg shape. `ToolActivator` was the **sole outlier**, calling it object-form `auditLog({ event: 'skill_activated', ...rest })`. That made `event` the whole object and `data` undefined, so skill activations and deactivations were logged malformed (`[AUDIT] … [object Object]:`).

## Why it shipped

The unit test's `mockAuditLog` also accepted a single object — the test mirrored the broken call shape, so test and bug agreed and nothing caught it. The load-bearing fix is rewriting the mock to the real `(event, data)` signature, which makes this whole class of mismatch catchable going forward.

## Changes

- **`src/skill-forge/activator.js`** — both audit call sites conformed to two-arg form; JSDoc corrected to `async (event, data) => Promise`.
- **`webhook-server.js`** — crash-safety guard at the `consoleAuditLog` chokepoint: undefined data must never throw and take down its caller (Rule 5 — guard where the pipe narrows; relates to #127).
- **`test/unit/skill-forge/tool-activator.test.js`** — mock rewritten to mirror the production signature; assertions updated to read `entry.data.*`; two regression tests added.

## Verification

- `npm run lint` → 0 errors (pre-existing warnings only, none in changed regions).
- `tool-activator.test.js` → 31/31 pass; `npm run test:unit` → 222/222 files pass.
- Reviewer pass → PASS, no critical/warning findings.
- **Runtime exercise** of the real `ToolActivator.activate()`/`deactivate()` against the verbatim `consoleAuditLog(event, data)` body emitted well-formed audit lines — bare-string event + parsed `data.skillId` with timestamp, zero `[object Object]`.
- Not yet live-verified via a real Skill Forge activation on the Bot VM (not triggerable from the control box) — deferred to post-merge.

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)