### PR TITLE
fix(intent): trust decides the classification path, not the provider census (#132)

### DIFF
--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -318,18 +318,22 @@ class IntentRouter {
    * @param {Object} opts.provider - OllamaToolsProvider (uses .chat() with model override)
    * @param {Object} [opts.llmRouter] - LLMRouter instance for job-based routing
    * @param {Function} [opts.getLanguage] - Returns current cockpit language (e.g. 'EN', 'DE')
+   * @param {Function} [opts.getTrust] - Returns the trust verdict for classification
+   *   ('local-only' | 'cloud-ok'), sourced from the ModelResolver (the single
+   *   control). Null/undefined return → fall back to the provider census. See #132.
    * @param {Object} [opts.config]
    * @param {number} [opts.config.classifyTimeout=10000]
    * @param {string} [opts.config.fastModel='qwen2.5:3b'] - Fast model for explicit intents
    * @param {string} [opts.config.smartModel='qwen3:8b'] - Smart model for ambiguous intents
    */
-  constructor({ provider, config = {}, getLanguage, llmRouter } = {}) {
+  constructor({ provider, config = {}, getLanguage, getTrust, llmRouter } = {}) {
     this.provider = provider;
     this.llmRouter = llmRouter || null;
     this.timeout = config.classifyTimeout || 10000;
     this.fastModel = config.fastModel || 'qwen2.5:3b';
     this.smartModel = config.smartModel || 'qwen3:8b';
     this.getLanguage = getLanguage || (() => 'EN');
+    this.getTrust = getTrust || (() => null);
   }
 
   /**
@@ -348,9 +352,20 @@ class IntentRouter {
     message = message || '';
 
     try {
-      // Cloud-ok: Haiku classifies correctly every time. No escalation needed.
-      // Local-only: qwen3:8b first, qwen2.5:3b fallback, regex last resort.
-      const cloudOk = this.llmRouter?.hasCloudPlayers?.();
+      // The trust boundary is the single control (#132): the classification path
+      // follows the trust verdict, not the registered-provider census. Under
+      // trust:local-only the classifier is the local smart model (qwen3:8b)
+      // directly; a credential-less cloud entry in providers.json can no longer
+      // make hasCloudPlayers() true and degrade classification to qwen2.5:3b.
+      //   cloud-ok: Haiku via the router, classifies correctly every time.
+      //   local-only: qwen3:8b first, qwen2.5:3b fallback, regex last resort.
+      // The resolver is the trust authority; when it is absent (early boot or a
+      // direct test caller) fall back to the legacy provider census.
+      const trust = this.getTrust();
+      const cloudOk = trust
+        ? trust !== 'local-only'
+        : this.llmRouter?.hasCloudPlayers?.();
+      console.log(`[IntentRouter] Trust=${trust || 'census'} → classification path: ${cloudOk ? 'cloud/router (Haiku)' : 'local smart (qwen3:8b)'}`);
 
       if (cloudOk && this.llmRouter) {
         return await this._classifyViaRouter(message, recentContext);

--- a/test/unit/agent/trust-classifier-path.test.js
+++ b/test/unit/agent/trust-classifier-path.test.js
@@ -1,0 +1,107 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Trust-Decides-Classifier-Path Tests (#132)
+ *
+ * The classification path is chosen by the trust boundary (the single control),
+ * not by hasCloudPlayers() (a provider-type census). A credential-less cloud
+ * entry in providers.json makes hasCloudPlayers() return true but must NOT
+ * degrade classification away from the local smart model under trust:local-only.
+ *
+ *   trust 'cloud-ok'   → router path (Haiku via LLMRouter.route)
+ *   trust 'local-only' → local smart model (qwen3:8b) directly, regardless of census
+ *   trust null         → legacy fallback to hasCloudPlayers() (boot / direct callers)
+ *
+ * Run: node test/unit/agent/trust-classifier-path.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const IntentRouter = require('../../../src/lib/agent/intent-router');
+
+console.log('\n=== Trust-Decides-Classifier-Path Tests (#132) ===\n');
+
+/**
+ * Build an IntentRouter whose mocks record which classification path fired.
+ * @param {Object} opts
+ * @param {string|null} opts.trust   - getTrust() return ('local-only'|'cloud-ok'|null)
+ * @param {boolean} opts.hasCloud    - what hasCloudPlayers() reports (the census)
+ */
+function createRouter({ trust, hasCloud }) {
+  const path = { providerModel: null, routerJob: null };
+  const provider = {
+    chat: async ({ model }) => {
+      path.providerModel = model;
+      return { content: JSON.stringify({ intent: 'calendar_query' }) };
+    }
+  };
+  const llmRouter = {
+    hasCloudPlayers: () => hasCloud,
+    route: async ({ job }) => {
+      path.routerJob = job;
+      return { result: JSON.stringify({ intent: 'calendar_query' }) };
+    }
+  };
+  const router = new IntentRouter({
+    provider,
+    llmRouter,
+    getTrust: () => trust,
+    config: { classifyTimeout: 1000, fastModel: 'qwen2.5:3b', smartModel: 'qwen3:8b' }
+  });
+  return { router, path };
+}
+
+// -- trust cloud-ok → router path (Haiku) --
+asyncTest('trust:cloud-ok routes classification through the LLM router', async () => {
+  const { router, path } = createRouter({ trust: 'cloud-ok', hasCloud: true });
+  await router.classify('Do I have any appointments this week?');
+  assert.strictEqual(path.routerJob, 'classification', 'router path should fire');
+  assert.strictEqual(path.providerModel, null, 'local smart model should NOT fire');
+});
+
+// -- trust local-only → local smart model, never the router --
+asyncTest('trust:local-only classifies via the local smart model directly', async () => {
+  const { router, path } = createRouter({ trust: 'local-only', hasCloud: false });
+  await router.classify('Do I have any appointments this week?');
+  assert.strictEqual(path.providerModel, 'qwen3:8b', 'smart model should fire');
+  assert.strictEqual(path.routerJob, null, 'router path should NOT fire');
+});
+
+// -- THE #132 REGRESSION GUARD: phantom cloud entry (census=true) under local-only --
+asyncTest('phantom cloud entry does NOT degrade local-only classification', async () => {
+  // hasCloudPlayers() === true (a credential-less providers.json cloud entry),
+  // but trust is local-only. The verdict must win: local smart model, not the
+  // router roster that would fall to qwen2.5:3b.
+  const { router, path } = createRouter({ trust: 'local-only', hasCloud: true });
+  await router.classify('Do I have any open tasks?');
+  assert.strictEqual(path.providerModel, 'qwen3:8b', 'smart model wins over the phantom census');
+  assert.strictEqual(path.routerJob, null, 'router path must NOT fire under local-only');
+});
+
+// -- trust null + census true → legacy router path preserved --
+asyncTest('no resolver (trust null) falls back to the census: cloud present → router', async () => {
+  const { router, path } = createRouter({ trust: null, hasCloud: true });
+  await router.classify('Do I have any appointments this week?');
+  assert.strictEqual(path.routerJob, 'classification', 'census-true → router path');
+  assert.strictEqual(path.providerModel, null, 'local smart model should NOT fire');
+});
+
+// -- trust null + census false → legacy local path preserved --
+asyncTest('no resolver (trust null) falls back to the census: no cloud → local smart', async () => {
+  const { router, path } = createRouter({ trust: null, hasCloud: false });
+  await router.classify('Do I have any appointments this week?');
+  assert.strictEqual(path.providerModel, 'qwen3:8b', 'census-false → local smart model');
+  assert.strictEqual(path.routerJob, null, 'router path should NOT fire');
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1590,6 +1590,10 @@ async function initialize() {
         provider: intentProvider,
         llmRouter: llmRouter,
         getLanguage: () => cockpitManager?.cachedConfig?.persona?.language || 'EN',
+        // Trust is the single control for the classification path (#132). Lazy
+        // thunk: modelResolver is constructed later in this bootstrap, so read it
+        // at classify time, not now. Returns 'local-only' | 'cloud-ok' | null.
+        getTrust: () => modelResolver?.resolveTrust?.('classification') || null,
         config: {
           classifyTimeout: appConfig.ollama.classifyTimeout,
           fastModel: appConfig.ollama.classifyModel || 'qwen2.5:3b',


### PR DESCRIPTION
## #132 — trust decides the classification path, not the provider census

Phase B of the Verdict-Custody cluster (audit map: #133). Small, independent; merges before C/E/D.

### The wound
`IntentRouter.classify()` chose its path from `hasCloudPlayers()` — a provider-*type* census. A `providers.json` entry with an empty `credentialName` still registers (type `api`, `getCredential → null`), so `hasCloudPlayers()` returns `true` with **no** cloud capability. Under `trust: local-only` that phantom entry routed classification through the router's classification chain, which falls to `qwen2.5:3b` — silently degrading from the reliable `qwen3:8b` (the #125 non-determinism surface).

### The fix
The trust boundary is the single control. The path now derives from the **ModelResolver's** trust verdict (`resolveTrust('classification')`), wired as a lazy `getTrust` thunk (the resolver is constructed later in the bootstrap, mirroring the existing `getLanguage` thunk). Under `local-only` the classifier is `qwen3:8b` directly; the phantom-entry degradation disappears as a side effect. When the resolver is absent (early boot / a direct test caller) the legacy census remains the fallback, so nothing regresses.

This is a **trust-tightening** change (Rule 3): `local-only` now actually stays local. `hasCloudPlayers()` is unchanged for its other callers — this changes *who IntentRouter listens to*, not the function. A new `[IntentRouter] Trust=<verdict> → classification path: <choice>` line makes the decision attributable in the journal.

### Scope boundary
Touches only the path-choice site, the constructor thunk, the bootstrap wiring, and one new test. Domain custody, `_smartMixClassify`, and the `agent-loop.js:125` tool-scoping seam are **Phase D** and are untouched here.

### Tests
`test/unit/agent/trust-classifier-path.test.js` — path per trust value, the trust-null census fallback, and the **#132 regression guard** (phantom census `true` under `local-only` stays local). Full unit suite **223/223 files pass**; `dual-model-classifier` (12) unchanged.

### [VERIFIED]
Live on the bot box against **real qwen3:8b** on the remote Ollama (`OLLAMA_URL`). Real `IntentRouter`, three scenarios in one run:

```
SCENARIO 1: trust=cloud-ok
  [IntentRouter] Trust=cloud-ok → classification path: cloud/router (Haiku)
  routeCalled=true  gate=action domain=calendar

SCENARIO 2: trust=local-only + phantom cloud entry (hasCloudPlayers()=true)  [#132 regression]
  [IntentRouter] Trust=local-only → classification path: local smart (qwen3:8b)
  routeCalled=false gate=action domain=calendar conf=0.95   ← real qwen3:8b, NOT degraded to cloud roster

SCENARIO 3: trust=local-only
  [IntentRouter] Trust=local-only → classification path: local smart (qwen3:8b)
  routeCalled=false gate=action domain=calendar conf=0.95   ← real qwen3:8b
```

DE message `"Habe ich diese Woche Termine?"` (multilingual check). The phantom entry no longer degrades `local-only` classification — the verdict wins. Cloud-ok path *selection* is shown by the attribution line; real Haiku execution is the live service's standing `cloud-ok` behavior (the harness `route()` is a spy — no cloud creds are held in a harness).

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
