### PR TITLE
fix(intent): classify deck reads as action/deck, symmetric with calendar reads (#134)

### DIFF
--- a/.claude/skills/public-content-discipline/SKILL.md
+++ b/.claude/skills/public-content-discipline/SKILL.md
@@ -39,6 +39,8 @@ Screen the draft and any source material being quoted for:
 
 6. **Log excerpts with user content.** Command outputs, journald lines, stack traces may contain usernames, paths with personal names, query text with private information. Redact or abstract before including. CostTracker lines are typically safe (cost numbers, model names) — user-facing response logs are not.
 
+7. **Infrastructure addresses in commit messages and `[VERIFIED]` blocks.** A commit message is a public surface on `next`/`main`. Live verification evidence often names the host it ran against — write it as a placeholder (`[OLLAMA_HOST]`, `[NC_HOST]`), never a literal IP or hostname. A production IP in a public commit message is a permanent leak (commit `23a5496` carries one — history stays; the rule prevents the next).
+
 ## Response hierarchy when something is caught
 
 1. **Abstract.** Replace the specific with a placeholder that preserves the structural point. Prefer this — the diagnostic or narrative value usually survives abstraction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The full rule set is the auto-loaded skill at `.claude/skills/moltagent-dev-rule
 - **Read before writing.** Paths, names, and API shapes come from the codebase, not memory. Search first.
 - **Run the pre-commit checklist** (the Anti-Pattern Checklist in the dev-rules skill) before any commit.
 - **Run the Verification Gate** (in the dev-rules skill) before declaring a session done.
-- **Run the privacy pass** (see `.claude/skills/public-content-discipline/SKILL.md`) before drafting any content bound for a public surface: GitHub issues, PRs, README, docs, external communications. Abstract named individuals, client organizations, internal codenames, and knowledge-base quotes before they enter a public draft, not after.
+- **Run the privacy pass** (see `.claude/skills/public-content-discipline/SKILL.md`) before drafting any content bound for a public surface: GitHub issues, PRs, README, docs, external communications, **and commit messages** (they are public on `next`/`main`). Abstract named individuals, client organizations, internal codenames, and knowledge-base quotes before they enter a public draft, not after. In `[VERIFIED]` blocks, name hosts as placeholders (`[OLLAMA_HOST]`, `[NC_HOST]`) — never literal IPs or hostnames; a production IP in a public commit message is a leak (commit `23a5496` carries one).
 - **File issues for anything outside the current briefing.** Scope is the briefing.
 - **Small commits over large ones.** If a commit adds more lines than it removes, question whether the altitude is right.
 

--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -64,6 +64,10 @@ const CLASSIFICATION_EXAMPLES = {
   "Move the onboarding card to Done" → action, domain: deck
   "Give it the due date tomorrow" → action, domain: deck
   "Set the deadline to Friday" → action, domain: deck
+  "Do I have any open tasks?" → action, domain: deck
+  "What's on my board?" → action, domain: deck
+  "Which boards do I have?" → action, domain: deck
+  "Show me overdue tasks" → action, domain: deck
   "Save this to the wiki" → action, domain: wiki
   "Upload the report" → action, domain: file`,
     compound: `
@@ -77,7 +81,6 @@ const CLASSIFICATION_EXAMPLES = {
   Examples (ALL factual questions are knowledge — "What is X?", "Who does X?", "How does X work?"):
   "Who is Alex?" → knowledge
   "What's the status of onboarding?" → knowledge
-  "What boards do I have?" → knowledge
   "What's the weather in Lisbon?" → knowledge
   "What is HeartbeatManager?" → knowledge
   "Who works on Moltagent?" → knowledge
@@ -110,6 +113,10 @@ const CLASSIFICATION_EXAMPLES = {
   "Verschiebe die Onboarding-Karte nach Erledigt" → action, domain: deck
   "Setze die Frist auf Freitag" → action, domain: deck
   "Gib ihr das Fälligkeitsdatum morgen" → action, domain: deck
+  "Habe ich offene Aufgaben?" → action, domain: deck
+  "Was ist auf meinem Board?" → action, domain: deck
+  "Welche Boards habe ich?" → action, domain: deck
+  "Zeig mir überfällige Aufgaben" → action, domain: deck
   "Speichere das im Wiki" → action, domain: wiki
   "Lade den Bericht hoch" → action, domain: file`,
     compound: `
@@ -122,7 +129,6 @@ const CLASSIFICATION_EXAMPLES = {
   Beispiele (ALLE Sachfragen sind knowledge — "Was ist X?", "Wer macht X?", "Wie funktioniert X?"):
   "Wer ist Alex?" → knowledge
   "Wie ist der Stand beim Onboarding?" → knowledge
-  "Welche Boards habe ich?" → knowledge
   "Wie ist das Wetter in Berlin?" → knowledge
   "Was ist der HeartbeatManager?" → knowledge
   "Wer arbeitet an Moltagent?" → knowledge
@@ -150,6 +156,10 @@ const CLASSIFICATION_EXAMPLES = {
   "Quando é a minha próxima reunião?" → action, domain: calendar
   "Move o cartão de onboarding para Concluído" → action, domain: deck
   "Define o prazo para sexta-feira" → action, domain: deck
+  "Tenho tarefas em aberto?" → action, domain: deck
+  "O que está no meu board?" → action, domain: deck
+  "Que boards é que tenho?" → action, domain: deck
+  "Mostra tarefas atrasadas" → action, domain: deck
   "Guarda isto no wiki" → action, domain: wiki
   "Carrega o relatório" → action, domain: file`,
     compound: `
@@ -162,7 +172,6 @@ const CLASSIFICATION_EXAMPLES = {
   Exemplos (TODAS as perguntas factuais são knowledge — "O que é X?", "Quem faz X?", "Como funciona X?"):
   "Quem é o Alex?" → knowledge
   "Qual é o estado do onboarding?" → knowledge
-  "Que boards é que tenho?" → knowledge
   "Como está o tempo em Lisboa?" → knowledge
   "O que é o HeartbeatManager?" → knowledge
   "Como funciona a ingestão de documentos?" → knowledge
@@ -291,6 +300,8 @@ THE CRITICAL TEST:
   "What is X?" "Who is X?" "How does X work?" → ALWAYS knowledge, NEVER thinking.
   4. Calendar questions (events today? free at X? next meeting? what's on my schedule?) → action, domain: calendar
      These READ the calendar — that's an action, not knowledge.
+  5. Deck/board questions (open tasks? what's on my board? overdue items? task progress? which boards?) → action, domain: deck
+     These READ the live board state — that's an action, not knowledge.
 
 CONTEXT-AWARE RULES:
 - Read the <conversation> block FIRST. The user's message usually continues the current topic.

--- a/test/unit/agent/three-gate-classifier.test.js
+++ b/test/unit/agent/three-gate-classifier.test.js
@@ -49,7 +49,7 @@ function createRouter(providerResponse) {
 }
 
 // ============================================================
-// KNOWLEDGE GATE (default — 6 tests)
+// KNOWLEDGE GATE (default — 5 tests; TG-06 is now a deck-read action test, #134)
 // ============================================================
 
 asyncTest('TG-01: "What\'s Alex\'s email?" → knowledge (NOT email)', async () => {
@@ -90,11 +90,16 @@ asyncTest('TG-05: "Tell me about Paradiesgarten" → knowledge', async () => {
   assert.strictEqual(result.domain, null);
 });
 
-asyncTest('TG-06: "What boards do I have?" → knowledge (listing = knowing)', async () => {
-  const router = createRouter('{"gate":"knowledge","confidence":0.85}');
+// #134: reading the live board list is an action (domain deck), not knowledge.
+// This reverses the old "listing = knowing" premise — symmetric with the
+// calendar-read rule. "Status of onboarding" (a topic question) stays knowledge
+// (TG-02); the boundary is live board state vs. topic synthesis.
+asyncTest('TG-06: "What boards do I have?" → action, deck (reading live board state)', async () => {
+  const router = createRouter('{"gate":"action","domain":"deck","confidence":0.85}');
   const result = await router.classify("What boards do I have?");
-  assert.strictEqual(result.gate, 'knowledge');
-  assert.strictEqual(result.domain, null);
+  assert.strictEqual(result.gate, 'action');
+  assert.strictEqual(result.domain, 'deck');
+  assert.strictEqual(result.intent, 'deck');
 });
 
 // ============================================================


### PR DESCRIPTION
## #134 — deck reads classify as action/deck, symmetric with calendar reads

Phase C of the Verdict-Custody cluster. Builds on #132 (merged). Independent of D/E.

### The wound
The classification prompt special-cased calendar reads into the action gate (CRITICAL TEST rule 4) but had **no equivalent for deck reads**. Deck *action* examples were all writes; deck *reads* sat under the *knowledge* examples. So `"Do I have any open tasks?"` matched no action example and could land on either gate — the documented gate-flip (#125): identical input classified `action`, then `knowledge`, on consecutive turns. Knowledge-gate keyword probes answer deck reads poorly (they match card titles, not card status).

### The fix (prompt only — Rule 1)
- **Rule 5** added to the CRITICAL TEST, parallel to rule 4: deck/board questions (open tasks? what's on my board? overdue? task progress? which boards?) → action, domain: deck. *Reading live board state is an action.*
- **EN/DE/PT action blocks** gain deck-read examples; the boards-list example moves from knowledge to action.
- `"Status of onboarding"` **stays knowledge** as the negative-contrast example — a topic-status question, not live board state (the two-axis edge #134 documents but defers).

### Scope
Rule text + the **three core-language blocks** (multilingual-by-default) + tests. **FR/ES are intentionally untouched** — they already lacked the calendar-read examples EN/DE/PT carry. That per-language policy duplication is its own generating function, filed as **#157** (canonical example set + generated translations), not patched here. `TG-06` updated: `"What boards do I have?"` now documents `action/deck`, reversing the old "listing = knowing" premise.

### [VERIFIED]
Live on the bot box against **real qwen3:8b** on the remote Ollama (`[OLLAMA_HOST]`). Real `IntentRouter` + the new prompt, local path forced. Five deck-read questions classified `gate=action, domain=deck` **stably across 5 runs each** (25 classifications, zero flips — the #134 non-determinism is gone):

```
[EN] Do I have any open tasks?      → action/deck ×5  ✓
[EN] What's on my board?            → action/deck ×5  ✓
[DE] Habe ich offene Aufgaben?      → action/deck ×5  ✓
[DE] Was ist auf meinem Board?      → action/deck ×5  ✓
[PT] Tenho tarefas em aberto?       → action/deck ×5  ✓

knowledge controls (no regression):
[EN] Who is Alex?                   → knowledge  ✓
[EN] What's the status of onboarding? → knowledge ✓   (contrast holds)
[DE] Wer ist Alex?                  → knowledge  ✓
```

Full unit suite **223/223 files pass**; `three-gate-classifier` 27, `knowledge-mode` 22, `dual-model-classifier` 12 green.

### Rider commit
A second commit extends the privacy pass to **commit messages** (host placeholders in `[VERIFIED]` blocks, never literal IPs — `23a5496` carries one). Docs only; binds every session.

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
