### PR TITLE
fix(knowledge): gate web fallback on trust and workspace truth, not count alone (#136)

### DIFF
--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -50,6 +50,22 @@ const { parseFrontmatter } = require('../knowledge/frontmatter');
 /** Domain intents that can be handled locally with focused tool subsets. */
 const DOMAIN_INTENTS = new Set(['deck', 'calendar', 'email', 'wiki', 'file', 'search', 'knowledge', 'confirmation', 'confirmation_declined']);
 
+/**
+ * Knowledge-probe SOURCE tags that read the user's own workspace STATE (not the
+ * open web, and not stored knowledge). These are internal probe identifiers, not
+ * natural-language tokens. When a probe with one of these sources returns data,
+ * that data IS the answer to a workspace question — web results cannot contain
+ * the user's board, so the auto web fallback is suppressed (#136).
+ *
+ * Membership is the workspace-state sources that `_executeKnowledgeProbes`
+ * actually emits today — currently only `deck`. `wiki_unified` is intentionally
+ * absent: the wiki is stored *knowledge*, which the open web can legitimately
+ * augment, so a wiki hit must not suppress the fallback. As calendar / files /
+ * contacts / activity probes land (each with its own source tag), add them here
+ * — the gate is generic, but it only claims coverage it can verify.
+ */
+const WORKSPACE_KNOWLEDGE_SOURCES = new Set(['deck']);
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -1806,6 +1822,34 @@ class MessageProcessor {
   // ---------------------------------------------------------------------------
 
   /**
+   * Decide whether the knowledge path may fall back to a web search. Pure — no
+   * I/O — so the egress policy is unit-testable on its own (#136).
+   *
+   * Two gates sit ahead of the searchPolicy preference. The count heuristic
+   * (wantsMore) alone used to escape to the web whenever the local result count
+   * was low; these gates stop it from overriding facts it has no business over-
+   * riding:
+   *   - trust:local-only → the web never auto-fires (the single control; web
+   *     egresses). searchPolicy can only narrow within cloud-ok, never widen
+   *     past trust.
+   *   - a workspace probe returned data → the workspace IS the answer; web
+   *     results cannot contain the user's board.
+   * Otherwise the Cockpit searchPolicy decides: research → fire, internal-first
+   * → offer, sovereign → suppress.
+   *
+   * @param {{wantsMore:boolean, trust:?string, workspaceAnswered:boolean, searchPolicy:string}} input
+   * @returns {{action:'fire'|'offer'|'suppress'|'none', reason:string}}
+   */
+  static decideWebFallback({ wantsMore, trust, workspaceAnswered, searchPolicy }) {
+    if (!wantsMore) return { action: 'none', reason: 'sufficient local knowledge' };
+    if (trust === 'local-only') return { action: 'suppress', reason: 'trust:local-only (no egress)' };
+    if (workspaceAnswered) return { action: 'suppress', reason: 'workspace probe returned data' };
+    if (searchPolicy === 'research') return { action: 'fire', reason: 'cloud-ok + research policy' };
+    if (searchPolicy === 'internal-first') return { action: 'offer', reason: 'internal-first policy' };
+    return { action: 'suppress', reason: 'sovereign policy' };
+  }
+
+  /**
    * Handle a knowledge query through multi-source probes + LLM synthesis.
    *
    * Instead of routing to a single domain executor:
@@ -1885,28 +1929,44 @@ class MessageProcessor {
     const contextSuggestsWeb = liveContext?.lastAssistantAction?.admittedIgnorance === true;
     let webSearchOffered = false;
 
-    if (substantiveResults < 2 || (contextSuggestsWeb && substantiveResults < 4)) {
-      if (searchPolicy === 'research') {
-        // Auto web fallback — current behavior
-        if (roomToken) {
-          this.sendTalkReply(roomToken, '\u{1F310} Also checking the web...').catch(() => {});
-        }
-        const webResults = await this._probeWeb(query);
-        if (webResults.length > 0) {
-          probeResults.push({
-            source: 'web',
-            results: webResults,
-            provenance: 'web_search'
-          });
-          console.log(`[Message] Knowledge insufficient (${substantiveResults} results) — web fallback added ${webResults.length} result(s)`);
-        }
-      } else if (searchPolicy === 'internal-first') {
-        webSearchOffered = true;
-        console.log(`[Message] Knowledge insufficient (${substantiveResults} results) — search policy: internal-first, web search available but not auto-fired`);
-      } else {
-        // sovereign — no web search
-        console.log(`[Message] Knowledge insufficient (${substantiveResults} results) — search policy: sovereign, no web search`);
+    // Web egress decision — two gates ahead of the searchPolicy preference (#136).
+    // The count heuristic alone escapes to the web whenever substantiveResults is
+    // low, ignoring two facts it has no business overriding:
+    //   Gate 1 — trust (the single control): under trust:local-only the auto web
+    //     fallback never fires. _probeWeb egresses (SearXNG proxies external
+    //     engines; WebReader fetches external URLs), so it is cloud, not local.
+    //     searchPolicy can only narrow within cloud-ok; it cannot widen past trust.
+    //   Gate 2 — workspace truth: when a workspace-source probe already returned
+    //     data, that IS the answer. Web results cannot contain the user's board.
+    //     This honors the probe signal the keyword-count heuristic dropped (the
+    //     "found 5 deck cards, escaped to web anyway" case).
+    const trust = this.intentRouter?.getTrust?.() || null;
+    const workspaceAnswered = probeResults.some(
+      p => WORKSPACE_KNOWLEDGE_SOURCES.has(p.source) && (p.results || []).length > 0
+    );
+    const wantsMore = substantiveResults < 2 || (contextSuggestsWeb && substantiveResults < 4);
+    const decision = MessageProcessor.decideWebFallback({ wantsMore, trust, workspaceAnswered, searchPolicy });
+    let webSuppressed = false;
+
+    if (decision.action === 'fire') {
+      if (roomToken) {
+        this.sendTalkReply(roomToken, '\u{1F310} Also checking the web...').catch(() => {});
       }
+      const webResults = await this._probeWeb(query);
+      if (webResults.length > 0) {
+        probeResults.push({
+          source: 'web',
+          results: webResults,
+          provenance: 'web_search'
+        });
+        console.log(`[Message] Knowledge insufficient (${substantiveResults} results) — web fallback added ${webResults.length} result(s)`);
+      }
+    } else if (decision.action === 'offer') {
+      webSearchOffered = true;
+      console.log(`[Message] Knowledge insufficient (${substantiveResults} results) — search policy: internal-first, web search available but not auto-fired`);
+    } else if (decision.action === 'suppress') {
+      webSuppressed = true;
+      console.log(`[Message] Knowledge thin (${substantiveResults} results) — web fallback suppressed: ${decision.reason}`);
     }
 
     // Tag provenance on all results
@@ -1924,12 +1984,15 @@ class MessageProcessor {
 
     console.log(`[Message] Knowledge probes: ${sourcesConsulted.length} sources consulted, ${sourcesWithResults.length} returned results (${sourcesWithResults.join(', ')})`);
 
-    // Step 4: Synthesis — one LLM call with policy-aware context
+    // Step 4: Synthesis — one LLM call with policy-aware context (#117 honest
+    // disclosure when the web was not consulted).
     let policyContext = '';
     if (webSearchOffered) {
       policyContext = '\n\nNote: Internal knowledge was limited. Offer to search the web for more information if the user would find that helpful.';
-    } else if (searchPolicy === 'sovereign' && substantiveResults < 2) {
-      policyContext = '\n\nNote: Search policy is sovereign — no web search. If internal knowledge is insufficient, state what you know and what gaps exist honestly. Do not offer to search the web.';
+    } else if (workspaceAnswered) {
+      policyContext = '\n\nNote: This is about the user\'s own workspace. Answer from the workspace data returned above. Do not search or offer to search the web.';
+    } else if (webSuppressed && substantiveResults < 2) {
+      policyContext = '\n\nNote: No web search was performed. State what you know from internal knowledge and the workspace, and name the gaps honestly. Do not offer to search the web.';
     }
     const response = await this._synthesizeKnowledge(query, aggregated, session, router, liveContext, policyContext + extraPolicy, knowledgeIndex);
 

--- a/test/unit/server/message-processor.test.js
+++ b/test/unit/server/message-processor.test.js
@@ -1159,6 +1159,60 @@ asyncTest('TC-OOO-004: setMode() stores the active mode', async () => {
   assert.strictEqual(processor.activeMode, 'out-of-office', 'Should store out-of-office');
 });
 
+// --- Web-fallback egress decision (#136) ---
+// decideWebFallback is pure: it encodes the two gates that sit AHEAD of the
+// searchPolicy preference. The precedence is the point — trust and workspace
+// truth must beat searchPolicy, never the other way round. These cases pin that
+// ordering so a future searchPolicy tweak can't silently widen egress.
+console.log('\n--- Web-fallback egress decision (#136) ---\n');
+
+const decide = (over) => MessageProcessor.decideWebFallback({
+  wantsMore: true, trust: 'cloud-ok', workspaceAnswered: false, searchPolicy: 'research', ...over
+});
+
+test('TC-WEB-136-01: sufficient local knowledge → none (no egress considered)', () => {
+  const d = decide({ wantsMore: false });
+  assert.strictEqual(d.action, 'none');
+});
+
+test('TC-WEB-136-02: cloud-ok + research → fire', () => {
+  assert.strictEqual(decide({}).action, 'fire');
+});
+
+test('TC-WEB-136-03: internal-first → offer (never auto-fires)', () => {
+  assert.strictEqual(decide({ searchPolicy: 'internal-first' }).action, 'offer');
+});
+
+test('TC-WEB-136-04: sovereign → suppress', () => {
+  assert.strictEqual(decide({ searchPolicy: 'sovereign' }).action, 'suppress');
+});
+
+test('TC-WEB-136-05: trust:local-only suppresses even under research policy (trust is the single control)', () => {
+  // The gate that matters most: searchPolicy can only narrow within cloud-ok,
+  // it cannot widen past trust. local-only + research must NOT fire.
+  const d = decide({ trust: 'local-only', searchPolicy: 'research' });
+  assert.strictEqual(d.action, 'suppress');
+  assert.ok(d.reason.includes('local-only'), 'reason should name the trust gate');
+});
+
+test('TC-WEB-136-06: trust:local-only beats workspace gate too (ordering is deterministic)', () => {
+  assert.strictEqual(decide({ trust: 'local-only', workspaceAnswered: true }).action, 'suppress');
+});
+
+test('TC-WEB-136-07: workspace probe answered suppresses web even under research policy', () => {
+  // "found 5 deck cards, escaped to web anyway" — the case #136 closes.
+  const d = decide({ workspaceAnswered: true, searchPolicy: 'research' });
+  assert.strictEqual(d.action, 'suppress');
+  assert.ok(d.reason.includes('workspace'), 'reason should name the workspace gate');
+});
+
+test('TC-WEB-136-08: null trust falls through to searchPolicy (resolver-absent, no widening)', () => {
+  // trust unknown (resolver absent) must not be treated as cloud permission;
+  // it simply defers to searchPolicy. research → fire, sovereign → suppress.
+  assert.strictEqual(decide({ trust: null, searchPolicy: 'research' }).action, 'fire');
+  assert.strictEqual(decide({ trust: null, searchPolicy: 'sovereign' }).action, 'suppress');
+});
+
 // Summary
 setTimeout(() => {
   summary();


### PR DESCRIPTION
## What

Phase E of the verdict-custody cluster. The knowledge-path web fallback escaped to the open web whenever the local result count was low, reading the Cockpit `searchPolicy` as if it were the trust boundary. Under `trust:local-only` with `searchPolicy:research` it auto-fired web search anyway.

Two gates now sit ahead of the `searchPolicy` preference, in a pure, unit-testable `MessageProcessor.decideWebFallback({wantsMore, trust, workspaceAnswered, searchPolicy}) → {action, reason}`:

- **Gate 1 — trust (the single control):** under `trust:local-only` the auto web fallback never fires. `_probeWeb` egresses — SearXNG proxies external engines and WebReader fetches external URLs — so it is cloud, not local. `searchPolicy` can only narrow *within* `cloud-ok`; it cannot widen past trust.
- **Gate 2 — workspace truth:** when a workspace-source probe (`WORKSPACE_KNOWLEDGE_SOURCES`, currently `{deck}`) already returned data, that **is** the answer — web results cannot contain the user's board. This honors the probe signal the keyword-count heuristic dropped (the "found 5 cards, escaped to web anyway" case). `wiki_unified` is intentionally excluded: the wiki is stored knowledge the open web can legitimately augment.

Both gates only narrow toward local (Rule 3). No keyword or regex on user text — the gates read the verdict and the trust value, not the message (Rule 1). Synthesis disclosure follows #117: when the web was not consulted the model is told to name gaps honestly and not offer to search.

## The egress membrane

Per the [framing comment on #136](https://github.com/moltagent/moltagent/issues/136#issuecomment-4650093564), this is the **third unsealed pore** in the trust membrane:

1. `hasCloudPlayers()` hard-wiring cloud-LLM routing — sealed by #123.
2. Conversational path ignoring the Cockpit trust setting — sealed by #123.
3. **Web-search egress via `searchPolicy`** — sealed here.

This PR seals pore 3 **at the web-search path**. The structurally honest end-state the comment describes — one egress chokepoint every outbound op consults (RSS, external CalDAV, …) — remains the larger arc tracked on the membrane framing; Phase E was scoped to these two gates by the briefing, and the gate logic is isolated in one pure method so a future chokepoint can absorb it.

## Scope boundary

- **Phase D (#133)** — carrying `domain` into the agent loop and tool scoping — is **untouched** here. This PR is the web-fallback gate only.
- `hasCloudPlayers()`, the classifier path (#132), and the deck-read classification (#134) are unchanged.

## Tests

`TC-WEB-136-01..08` in `test/unit/server/message-processor.test.js`:

| # | Case | Expected |
|---|------|----------|
| 01 | sufficient local knowledge | `none` (no egress considered) |
| 02 | cloud-ok + research | `fire` |
| 03 | internal-first | `offer` (never auto-fires) |
| 04 | sovereign | `suppress` |
| 05 | local-only + research | `suppress` (trust beats policy) |
| 06 | local-only + workspace-answered | `suppress` (ordering deterministic) |
| 07 | workspace probe answered + research | `suppress` |
| 08 | null trust | falls through to `searchPolicy` (no widening) |

`223/223` unit files pass; `npm run lint` → 0 errors.

## Live verification

**[VERIFIED**: live on the bot box (`moltagent-bot-01`) against real qwen3:8b on the remote Ollama (`OLLAMA_URL`). Targeted in-process harness: real `OllamaToolsProvider`, real `MessageProcessor._handleKnowledgeQuery`, real `decideWebFallback`; probes stubbed per scenario, `_probeWeb` replaced by a counting spy so web egress is **asserted, not assumed** (no NC, no Talk; the spy never egresses). 5 real qwen3:8b calls across the run.

- **S1 [DE]** `trust=local-only` + `searchPolicy=research`, 0 probe results, *"Was ist in letzter Zeit passiert?"* → journal `web fallback suppressed: trust:local-only (no egress)`; `_probeWeb` calls = **0**. Trust beat policy — the regression/leak case.
- **S2 [DE]** `trust=cloud-ok` + `searchPolicy=research`, deck probe returned 5 cards, *"Was ist auf meinem Personal Board?"* → journal `suppressed: workspace probe returned data`; `_probeWeb` calls = **0**; answer synthesized from the board in German. The "found 5 cards, escaped to web anyway" case, closed.
- **S3 [EN]** `trust=cloud-ok` + `searchPolicy=research`, non-workspace thin probes → journal `web fallback added 1 result(s)`; `_probeWeb` calls = **1**. No over-suppression regression.

All three assertions pass.**]**

Refs #136. Not auto-closing — squash to `next` does not auto-close; close manually with the verification evidence after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
