### PR TITLE
fix(intent): carry the classification domain through to AgentLoop tool selection (#133)

### DIFF
--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -122,7 +122,16 @@ class AgentLoop {
 
     // 2. Build initial messages array
     const systemPrompt = this._buildSystemPrompt(memoryContext, briefingContext, options, warmMemoryContext, history);
-    const tools = this.toolRegistry.getToolDefinitions();
+    // #133: scope the advertised tools to the verdict's domain when it is a single,
+    // known, non-compound domain. Null/unknown/compound → full registry. Execution
+    // is uncaged (ToolRegistry.execute reads the full map), so this guides the
+    // model's first choice without stranding the turn.
+    const scopeDomain = (options.domain && !options.compound && this.toolRegistry.hasDomainTools(options.domain))
+      ? options.domain
+      : null;
+    const tools = scopeDomain
+      ? this.toolRegistry.getToolSubset(scopeDomain)
+      : this.toolRegistry.getToolDefinitions();
 
     const messages = [
       ...history.map(m => ({ role: m.role, content: m.content })),
@@ -782,6 +791,15 @@ class AgentLoop {
 
     if (briefingContext) {
       prompt += `\n\n${briefingContext}`;
+    }
+
+    // Turn verdict (declarative register — name the subject, never forbid tools).
+    // The domain comes from the classification verdict carried in options (#133);
+    // scoping the advertised tools is handled at the tools-build site, this only
+    // tells the model what the turn is about. No domain → no line.
+    if (options.domain && this.toolRegistry.hasDomainTools(options.domain)) {
+      prompt += `\n\n## This Turn\n\nThe user's request is about ${options.domain}. `
+        + 'The tools you need for it are available; reach for them first.';
     }
 
     // Voice input context: help LLM interpret transcribed speech

--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -599,7 +599,7 @@ class IntentRouter {
       } else if (gate === 'compound') {
         result = { gate: 'compound', domain: domain || null, needsHistory: false, confidence, compound: true };
       } else if (gate === 'knowledge') {
-        result = { gate: 'knowledge', domain: null, needsHistory: false, confidence, compound };
+        result = { gate: 'knowledge', domain: domain || null, needsHistory: false, confidence, compound };
       } else if (gate === 'confirmation' || gate === 'confirmation_declined' || gate === 'selection') {
         result = { gate, domain: null, needsHistory: gate === 'confirmation' || gate === 'selection', confidence, compound };
       } else if (gate === 'complex') {

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -696,7 +696,7 @@ class MessageProcessor {
         // Smart-mix: three-path routing (local text / local tools / cloud)
         // Build live context ONCE — passed to classifier, probes, synthesis, guard
         const liveContext = earlyLiveContext || (session ? buildLiveContext(session, pipelineMessage) : null);
-        const { useLocal, useDomainTools, intent, compound, gate } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
+        const { useLocal, useDomainTools, intent, compound, gate, domain } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
         console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}${gate ? ` (gate=${gate})` : ''}`);
 
         // Intent-specific feedback: acknowledge the user immediately (fire-and-forget)
@@ -718,6 +718,8 @@ class MessageProcessor {
             inputType: extracted._isVoice ? 'voice' : 'text',
             user: extracted.user,
             gate,
+            domain,
+            compound,
             systemSuffix: focusContext ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext) : flushPrompt,
             onArtifact
           });
@@ -784,6 +786,8 @@ class MessageProcessor {
                 inputType: extracted._isVoice ? 'voice' : 'text',
                 user: extracted.user,
                 gate,
+                domain,
+                compound,
                 systemSuffix: focusContext || undefined,
                 onArtifact
               });
@@ -829,6 +833,7 @@ class MessageProcessor {
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
               gate,
+              domain,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -861,6 +866,7 @@ class MessageProcessor {
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
               gate,
+              domain,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -904,6 +910,7 @@ class MessageProcessor {
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
               gate,
+              domain,
               systemSuffix: focusContext
                 ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext)
                 : flushPrompt,
@@ -948,6 +955,7 @@ class MessageProcessor {
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
               gate,
+              domain,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -977,6 +985,7 @@ class MessageProcessor {
               inputType: extracted._isVoice ? 'voice' : 'text',
               user: extracted.user,
               gate,
+              domain,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -1014,7 +1023,9 @@ class MessageProcessor {
             inputType: extracted._isVoice ? 'voice' : 'text',
             voiceReplyEnabled,
             user: extracted.user,
-            gate
+            gate,
+            domain,
+            compound
           };
 
           // Bug 3 fix: Short confirmations shouldn't loop to max iterations
@@ -1796,24 +1807,24 @@ class MessageProcessor {
 
       // Confirmation/selection → cloud (needs full history)
       if (intent === 'confirmation' || intent === 'selection') {
-        return { useLocal: false, useDomainTools: false, intent, compound: false, gate };
+        return { useLocal: false, useDomainTools: false, intent, compound: false, gate, domain };
       }
       if (intent === 'confirmation_declined') {
-        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate };
+        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate, domain };
       }
       // Knowledge → dedicated handler (probes, deep reads, web fallback, synthesis)
       if (intent === 'knowledge') {
-        return { useLocal: true, useDomainTools: true, intent, compound: !!compound, gate };
+        return { useLocal: true, useDomainTools: true, intent, compound: !!compound, gate, domain };
       }
       // Compound + domain → compound handler (already cloud-powered)
       if (compound && DOMAIN_INTENTS.has(intent)) {
-        return { useLocal: true, useDomainTools: true, intent, compound: true, gate };
+        return { useLocal: true, useDomainTools: true, intent, compound: true, gate, domain };
       }
       // Everything else → cloud via AgentLoop (Haiku, full tools, web search)
-      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate };
+      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate, domain };
     } catch (err) {
       console.warn(`[Message] Smart-mix classification failed: ${err.message}`);
-      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false, gate: null };
+      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false, gate: null, domain: null };
     }
   }
 

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1674,6 +1674,237 @@ asyncTest('terminal strip: 🔐 marker never reaches the user even if staged twi
 });
 
 // ============================================================
+// #133: Domain-scoped tool selection and system-prompt verdict
+// ============================================================
+
+console.log('\n--- #133: Domain-scoped tool selection ---\n');
+
+// Domain-aware mock registry: 'calendar' and 'deck' have a small known subset;
+// all others return empty (hasDomainTools false).
+const CALENDAR_TOOLS = ['calendar_list_events', 'calendar_create_event'];
+const DECK_TOOLS = ['deck_list_cards', 'deck_create_card'];
+const ALL_DOMAIN_TOOLS = [...CALENDAR_TOOLS, ...DECK_TOOLS, 'wiki_read', 'web_search'];
+
+function createDomainMockToolRegistry(extraTools = {}) {
+  // Build tool map: domain tools + any extra
+  const allTools = {};
+  for (const name of ALL_DOMAIN_TOOLS) {
+    allTools[name] = async () => ({ success: true, result: `Result from ${name}` });
+  }
+  for (const [name, fn] of Object.entries(extraTools)) {
+    allTools[name] = fn;
+  }
+
+  const makeDef = (name) => ({ type: 'function', function: { name, description: `Tool: ${name}`, parameters: {} } });
+
+  return {
+    getToolDefinitions: () => Object.keys(allTools).map(makeDef),
+    getToolSubset: (domain) => {
+      if (domain === 'calendar') return CALENDAR_TOOLS.map(makeDef);
+      if (domain === 'deck') return DECK_TOOLS.map(makeDef);
+      return [];
+    },
+    hasDomainTools: (domain) => domain === 'calendar' || domain === 'deck',
+    execute: async (name, args) => {
+      if (allTools[name]) return allTools[name](args);
+      return { success: false, result: '', error: `Unknown tool: ${name}` };
+    },
+    has: (name) => name in allTools
+  };
+}
+
+// Capture what tools the provider receives
+function createCapturingProvider(finalContent = 'Done.') {
+  const calls = [];
+  return {
+    chat: async ({ tools, system, messages }) => {
+      calls.push({ tools: tools ? tools.map(t => t.function.name) : [], system });
+      return { content: finalContent, toolCalls: null };
+    },
+    getCalls: () => calls
+  };
+}
+
+asyncTest('#133: known domain (calendar) scopes tools to calendar subset', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Events listed.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('What meetings do I have?', 'room-abc', { domain: 'calendar', compound: false });
+  const { tools } = provider.getCalls()[0];
+  assert.ok(tools.includes('calendar_list_events'), 'calendar_list_events should be in scoped tools');
+  assert.ok(tools.includes('calendar_create_event'), 'calendar_create_event should be in scoped tools');
+  assert.ok(!tools.includes('deck_list_cards'), 'deck tools should NOT be in calendar-scoped set');
+  assert.ok(!tools.includes('wiki_read'), 'wiki tools should NOT be in calendar-scoped set');
+});
+
+asyncTest('#133: null domain → full registry advertised', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Help me', 'room-abc', { domain: null, compound: false });
+  const { tools } = provider.getCalls()[0];
+  assert.ok(tools.includes('calendar_list_events'), 'full registry: calendar tools present');
+  assert.ok(tools.includes('deck_list_cards'), 'full registry: deck tools present');
+  assert.ok(tools.includes('wiki_read'), 'full registry: wiki tools present');
+  assert.strictEqual(tools.length, ALL_DOMAIN_TOOLS.length, 'full registry count must match');
+});
+
+asyncTest('#133: unknown domain (astrology, hasDomainTools false) → full registry', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Tell me my fortune', 'room-abc', { domain: 'astrology', compound: false });
+  const { tools } = provider.getCalls()[0];
+  // hasDomainTools('astrology') returns false → full registry
+  assert.strictEqual(tools.length, ALL_DOMAIN_TOOLS.length, 'unknown domain must use full registry');
+});
+
+asyncTest('#133: compound:true with a domain → full registry (not scoped)', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Create a card and send an email', 'room-abc', { domain: 'deck', compound: true });
+  const { tools } = provider.getCalls()[0];
+  // compound: true → guard fires, full registry used
+  assert.strictEqual(tools.length, ALL_DOMAIN_TOOLS.length, 'compound turn must use full registry');
+  assert.ok(tools.includes('wiki_read'), 'compound must not exclude non-domain tools');
+});
+
+asyncTest('#133: execution uncaged — scope to calendar but provider can call a deck tool', async () => {
+  // Provider receives calendar subset advertised, but then calls deck_list_cards.
+  // toolRegistry.execute must still be invoked (execution is not gated on the subset).
+  let deckToolExecuted = false;
+  let callIndex = 0;
+
+  const allTools = {
+    calendar_list_events: async () => ({ success: true, result: 'no events' }),
+    deck_list_cards: async () => { deckToolExecuted = true; return { success: true, result: 'cards' }; }
+  };
+
+  const registry = {
+    getToolDefinitions: () => Object.keys(allTools).map(n => ({ type: 'function', function: { name: n, description: '', parameters: {} } })),
+    getToolSubset: (domain) => domain === 'calendar'
+      ? [{ type: 'function', function: { name: 'calendar_list_events', description: '', parameters: {} } }]
+      : [],
+    hasDomainTools: (domain) => domain === 'calendar',
+    execute: async (name, args) => {
+      if (allTools[name]) return allTools[name](args);
+      return { success: false, result: '', error: `Unknown tool: ${name}` };
+    },
+    has: (name) => name in allTools
+  };
+
+  const provider = {
+    chat: async () => {
+      callIndex++;
+      if (callIndex === 1) {
+        // LLM calls deck_list_cards even though it wasn't in advertised subset
+        return { content: null, toolCalls: [{ id: 'call_1', name: 'deck_list_cards', arguments: {} }] };
+      }
+      return { content: 'Cards fetched.', toolCalls: null };
+    }
+  };
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Check cards', 'room-abc', { domain: 'calendar', compound: false });
+  assert.ok(deckToolExecuted, 'deck tool must execute even when not in advertised subset (uncaged execution)');
+});
+
+asyncTest('#133: system prompt — known domain injects ## This Turn block for calendar', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Book a meeting', 'room-abc', { domain: 'calendar', compound: false });
+  const { system } = provider.getCalls()[0];
+  assert.ok(system.includes('The user\'s request is about calendar'), 'system prompt must include the domain verdict line');
+  assert.ok(system.includes('## This Turn'), 'system prompt must include ## This Turn heading');
+  // Declarative register — must never forbid
+  assert.ok(!/never|only use|do not use/i.test(system.split('## This Turn')[1] || ''),
+    '## This Turn block must not contain "never", "only use", or "do not use"');
+});
+
+asyncTest('#133: system prompt — absent domain produces no ## This Turn block', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Hello', 'room-abc', { domain: null });
+  const { system } = provider.getCalls()[0];
+  assert.ok(!system.includes('## This Turn'), 'no domain → no ## This Turn block in system prompt');
+});
+
+asyncTest('#133: system prompt — unknown domain (astrology) produces no ## This Turn block', async () => {
+  const registry = createDomainMockToolRegistry();
+  const provider = createCapturingProvider('Done.');
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  await loop.process('Tell me about stars', 'room-abc', { domain: 'astrology', compound: false });
+  const { system } = provider.getCalls()[0];
+  assert.ok(!system.includes('## This Turn'), 'unknown domain → no ## This Turn block in system prompt');
+});
+
+// ============================================================
 // Cleanup & Summary
 // ============================================================
 

--- a/test/unit/agent/intent-router.test.js
+++ b/test/unit/agent/intent-router.test.js
@@ -515,4 +515,41 @@ asyncTest('classify() uses smart model first', async () => {
   assert.strictEqual(models[0], 'qwen3:8b', 'Smart model should be used first');
 });
 
+// === #133: domain custody through the knowledge gate ===
+console.log('\n--- #133: domain custody through the knowledge gate ---\n');
+
+// Knowledge verdict with a deck domain keeps result.domain === 'deck'
+test('#133: knowledge verdict with deck domain preserves domain', () => {
+  const router = createRouter('');
+  // Simulate LLM returning gate:knowledge with domain:deck
+  const result = router._parseClassification('{"gate":"knowledge","intent":"deck","domain":"deck","confidence":0.8}');
+  assert.strictEqual(result.gate, 'knowledge', 'gate must be knowledge');
+  assert.strictEqual(result.domain, 'deck', 'domain must survive the knowledge gate');
+});
+
+// That same knowledge verdict still has result.intent === 'knowledge' (regression guard for the shim)
+test('#133: knowledge verdict with deck domain still has intent===knowledge (shim regression guard)', () => {
+  const router = createRouter('');
+  const result = router._parseClassification('{"gate":"knowledge","intent":"deck","domain":"deck","confidence":0.8}');
+  assert.strictEqual(result.intent, 'knowledge', 'intent shim must stay knowledge for knowledge gate');
+});
+
+// Knowledge verdict with no domain → result.domain === null, intent 'knowledge'
+test('#133: knowledge verdict with no domain → domain null, intent knowledge', () => {
+  const router = createRouter('');
+  const result = router._parseClassification('{"gate":"knowledge","confidence":0.7}');
+  assert.strictEqual(result.gate, 'knowledge');
+  assert.strictEqual(result.domain, null, 'absent domain must remain null');
+  assert.strictEqual(result.intent, 'knowledge');
+});
+
+// Action verdict unchanged: domain survives, intent === domain
+test('#133: action verdict domain survives unchanged', () => {
+  const router = createRouter('');
+  const result = router._parseClassification('{"intent":"calendar","confidence":0.9}');
+  assert.strictEqual(result.gate, 'action');
+  assert.strictEqual(result.domain, 'calendar');
+  assert.strictEqual(result.intent, 'calendar', 'action intent shim must stay domain name');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 100);

--- a/test/unit/server/message-processor.test.js
+++ b/test/unit/server/message-processor.test.js
@@ -1213,6 +1213,107 @@ test('TC-WEB-136-08: null trust falls through to searchPolicy (resolver-absent, 
   assert.strictEqual(decide({ trust: null, searchPolicy: 'sovereign' }).action, 'suppress');
 });
 
+// --- #133: _smartMixClassify domain custody ---
+console.log('\n--- #133: _smartMixClassify domain custody ---\n');
+
+// Helper: build a smart-mix-capable processor with a stubbed intentRouter
+function createSmartMixProcessor(classifyResult) {
+  return createProcessor({
+    intentRouter: {
+      classify: async () => classifyResult
+    },
+    microPipeline: {
+      _classifyFallback: async () => ({ intent: 'chitchat' }),
+      memoryContextEnricher: null,
+      process: async () => 'local response'
+    },
+    agentLoop: {
+      llmProvider: {
+        resetConversation: function () {},
+        skipLocalForConversation: function () {},
+        chatProviders: new Map([['local', {}], ['cloud', {}]])
+      },
+      process: async () => 'agent response'
+    }
+  });
+}
+
+asyncTest('TC-D133-01: _smartMixClassify returns domain on confirmation path', async () => {
+  const proc = createSmartMixProcessor({ gate: 'confirmation', intent: 'confirmation', domain: null, needsHistory: true, confidence: 0.9, compound: false });
+  const result = await proc._smartMixClassify('yes', null, null, null);
+  assert.ok('domain' in result, '_smartMixClassify result must have domain key');
+});
+
+asyncTest('TC-D133-02: _smartMixClassify returns domain on confirmation_declined path', async () => {
+  const proc = createSmartMixProcessor({ gate: 'confirmation_declined', intent: 'confirmation_declined', domain: null, needsHistory: false, confidence: 0.9, compound: false });
+  const result = await proc._smartMixClassify('no', null, null, null);
+  assert.ok('domain' in result, '_smartMixClassify result must have domain key');
+});
+
+asyncTest('TC-D133-03: _smartMixClassify preserves domain on knowledge path (deck domain survives)', async () => {
+  const proc = createSmartMixProcessor({ gate: 'knowledge', intent: 'knowledge', domain: 'deck', needsHistory: false, confidence: 0.8, compound: false });
+  const result = await proc._smartMixClassify('what cards do I have', null, null, null);
+  assert.ok('domain' in result, 'domain key must be present');
+  assert.strictEqual(result.domain, 'deck', 'deck domain must survive the knowledge path');
+});
+
+asyncTest('TC-D133-04: _smartMixClassify returns domain on compound+domain path', async () => {
+  const proc = createSmartMixProcessor({ gate: 'compound', intent: 'deck', domain: 'deck', needsHistory: false, confidence: 0.8, compound: true });
+  const result = await proc._smartMixClassify('create a card and send an email', null, null, null);
+  assert.ok('domain' in result, 'domain key must be present');
+});
+
+asyncTest('TC-D133-05: _smartMixClassify catch-all cloud path — calendar action carries domain', async () => {
+  // Specimen: {gate:'action',intent:'calendar',domain:'calendar',compound:false}
+  // → domain==='calendar', useLocal===false
+  const proc = createSmartMixProcessor({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false });
+  const result = await proc._smartMixClassify('book a meeting', null, null, null);
+  assert.ok('domain' in result, 'domain key must be present on catch-all cloud path');
+  assert.strictEqual(result.domain, 'calendar', 'domain must be calendar');
+  assert.strictEqual(result.useLocal, false, 'calendar action must route to cloud in smart-mix mode');
+});
+
+asyncTest('TC-D133-06: _smartMixClassify classify-throws → {gate:null, domain:null, intent:\'error\'} no crash', async () => {
+  const proc = createProcessor({
+    intentRouter: {
+      classify: async () => { throw new Error('classification failed'); }
+    },
+    microPipeline: {
+      _classifyFallback: async () => ({ intent: 'chitchat' }),
+      memoryContextEnricher: null,
+      process: async () => 'local response'
+    },
+    agentLoop: {
+      llmProvider: {
+        resetConversation: function () {},
+        chatProviders: new Map([['local', {}], ['cloud', {}]])
+      },
+      process: async () => 'fallback'
+    }
+  });
+  const result = await proc._smartMixClassify('anything', null, null, null);
+  assert.ok('domain' in result, 'domain key must be present even on error path');
+  assert.strictEqual(result.domain, null, 'error path domain must be null');
+  assert.strictEqual(result.gate, null, 'error path gate must be null');
+  assert.strictEqual(result.intent, 'error');
+});
+
+asyncTest('TC-D133-07: _smartMixClassify universal invariant — every path has domain key', async () => {
+  // Run all shaped inputs and assert 'domain' in result for each
+  const shapes = [
+    { gate: 'confirmation', intent: 'confirmation', domain: null, needsHistory: true, confidence: 0.9, compound: false },
+    { gate: 'confirmation_declined', intent: 'confirmation_declined', domain: null, needsHistory: false, confidence: 0.9, compound: false },
+    { gate: 'knowledge', intent: 'knowledge', domain: 'deck', needsHistory: false, confidence: 0.8, compound: false },
+    { gate: 'compound', intent: 'deck', domain: 'deck', needsHistory: false, confidence: 0.8, compound: true },
+    { gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false }
+  ];
+  for (const shape of shapes) {
+    const proc = createSmartMixProcessor(shape);
+    const result = await proc._smartMixClassify('test', null, null, null);
+    assert.ok('domain' in result, `domain key missing for shape: ${JSON.stringify(shape)}`);
+  }
+});
+
 // Summary
 setTimeout(() => {
   summary();


### PR DESCRIPTION
## What

**Phase D — the last phase of the verdict-custody cluster (#132/#134/#136 merged).** The classification verdict `{gate, domain, confidence}` was computed at `IntentRouter.classify`, logged, then discarded before the tool-selecting actor. `AgentLoop` saw the full 68-tool catalog with no domain signal and re-derived intent for itself.

Production specimen (@architectonio, Discussion #72): *"setup a task tomorrow at 19:00, subject 'Check Moltagent Ollama Backend', duration 120 minutes"* → `gate=action, domain=calendar, confidence=1` → AgentLoop called `web_search({query:"best practices for remote team collaboration"})` on iteration 1. The signal died between the log and the actor — the same generator as #49 and #123 (a truth computed once, re-derived downstream; TAO: *signals keep custody*).

The verdict now travels canonically to the actor and shapes — never cages — tool selection:

- **`intent-router.js`** — the knowledge gate keeps its domain (`domain || null`) instead of nulling it (Death 1). The `result.intent` shim is unchanged (keys on `gate`), so knowledge turns still route to `_handleKnowledgeQuery`.
- **`message-processor.js`** — `_smartMixClassify` returns `domain` on every path (Death 2); the dispatch destructures it and forwards it (with `compound`) into `agentLoop.process` options — Path 5 **and every escalation site**, so custody is complete on every edge.
- **`agent-loop.js:125`** — the advertised tools scope to `getToolSubset(domain)` when the verdict is a single, known, non-compound domain; null / unknown / compound → the full `getToolDefinitions()`.
- **`agent-loop.js` `_buildSystemPrompt`** — a declarative `## This Turn` line names what the turn is about, gated on `hasDomainTools`, silent when the domain is absent.

## Guardrails

**Guardrail 1 — the subset is guidance, never a cage.** Tool *execution* stays uncaged: `ToolRegistry.execute` and `_resolveToolName` read the full tool map, so a tool outside the advertised subset still runs. A null / unknown / **compound** verdict falls back to the full registry. No turn is stranded in a wrong subset — scoping shapes the model's first choice, never a later one. `compound` is forwarded on the two escalation paths that can carry a compound turn (flush, compound-decomposition double-failure) so the `!options.compound` guard is real, not inert.

**Guardrail 2 — declarative register, not imperative negation.** The prompt line *names the subject* ("The user's request is about `<domain>`."); it never says "NEVER use other tools". Rule 1: the domain comes from the structured verdict, never re-derived from message text (the existing keyword-scan in `getCloudWorkflowToolDefinitions` is untouched and **not** copied). Rule 3: trust unchanged — `web_search` is already in every subset, so scoping opens no new egress pore.

## Scope boundary

This is the **last phase** of the cluster. Out of scope, left as a follow-up: the `MemoryContextEnricher`'s domain-blind deck priming (it front-loads deck cards on every turn regardless of domain) — a separate generator, flagged not patched.

## Tests

19 new (`#133` / `TC-D133-*`): domain survives the knowledge gate + the shim stays `'knowledge'`; `_smartMixClassify` returns `domain` on all six paths incl. the error path; agent-loop scopes to the subset for a known domain and falls back to full registry for null/unknown/compound; **execution is uncaged** (a deck tool runs though only calendar was advertised); the system-prompt line is declarative-not-imperative and absent when there's no domain. `223/223` unit files pass; `npm run lint` → 0 errors.

## Live verification

**[VERIFIED**: live on the bot box (`moltagent-bot-01`) against real qwen3:8b on the remote Ollama (`OLLAMA_URL`). Two real components, no NC/Talk: real `IntentRouter.classify` → real `AgentLoop.process` with that verdict's domain; real 68-tool `ToolRegistry`; AgentLoop's `llmProvider` is a spy that runs the real qwen3:8b call and captures the iteration-1 tool choice + advertised tool set + system prompt. **18/18 assertions pass.**

**Part 1 (classification):** EN → `action/calendar` conf=1 · DE → `action/deck` conf=0.95 · PT → `action/calendar` conf=1 · control greeting → `greeting` · control knowledge → `knowledge` (gate unchanged).

**Part 2 (actor, iteration-1 tool):**
- **EN** `domain=calendar` → `calendar_quick_schedule({summary:"Check Moltagent Ollama Backend", duration_minutes:120})`; advertised **9** tools (calendar subset), not 68; `## This Turn` present. **Not** `web_search`.
- **DE** `domain=deck` → `deck_create_card({...})`; advertised **25** (deck subset). One empty iteration-1 (qwen3:8b no-op turn — the #125 flake) retried; the production loop continues to iter-2, so an empty turn is not a failure; never `web_search`.
- **PT** `domain=calendar` → `calendar_quick_schedule(...)`; **9** tools; declarative line present.
- **compound** (calendar AND deck) → **full 68** tools advertised, both calendar and deck present — no stranding.
- **control no-domain** → full 68, no `## This Turn`.
- **control greeting** → full 68, no `## This Turn`.

The specimen that previously emitted `web_search` now creates the calendar/deck item in-domain across EN/DE/PT. The #133 wound is closed at the actor.**]**

Pipeline: architect (opus) confirmed the design + guardrails → implementer (sonnet) built → live gate (real qwen3:8b) → reviewer (opus, APPROVE-WITH-NITS; the two compound-forwarding nits are fixed in this branch).

Refs #133. Not auto-closing — squash to `next` does not auto-close; close manually with the verification evidence after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
