### PR TITLE
fix(agent-loop): parse text-form tool calls ("arguments" shape) so the envelope no longer leaks to Talk (#164)

### DIFF
--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -850,7 +850,7 @@ class AgentLoop {
   /**
    * Parse a tool call from LLM text output (resilience for smaller models).
    * Detects two formats:
-   *   JSON: {"name": "tool_name", "parameters": {...}}
+   *   JSON: {"name": "tool_name", "arguments": {...}} (also accepts "parameters")
    *   Function-style: tool_name({"key": "value"})
    *
    * Only returns a match if the tool name exists in the registry.
@@ -862,9 +862,13 @@ class AgentLoop {
   _parseToolCallFromText(text) {
     if (!text) return null;
 
-    // Pattern 1: JSON object with name + parameters
-    // e.g. {"name": "deck_move_card", "parameters": {"card": "#44", "target_stack": "Done"}}
-    const jsonMatch = text.match(/\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"parameters"\s*:\s*(\{[^}]*\})\s*\}/);
+    // Pattern 1: JSON object with name + an args key.
+    // Accept BOTH "arguments" (the canonical OpenAI/Ollama shape qwen3:8b emits,
+    // optionally wrapped in <tool_call> tags — matched here via search) and the
+    // older "parameters" shape. Without "arguments", a text-form call sailed past
+    // the parser and the loop shipped the raw envelope to Talk as the reply (#164).
+    // e.g. {"name": "deck_move_card", "arguments": {"card": "#44", "target_stack": "Done"}}
+    const jsonMatch = text.match(/\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"(?:arguments|parameters)"\s*:\s*(\{[^}]*\})\s*\}/);
     if (jsonMatch) {
       const resolved = this._resolveToolName(jsonMatch[1]);
       if (resolved) {

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1905,6 +1905,80 @@ asyncTest('#133: system prompt — unknown domain (astrology) produces no ## Thi
 });
 
 // ============================================================
+// #164 — text-form tool call must be parsed (canonical "arguments" shape),
+// not shipped to Talk as the raw envelope.
+// ============================================================
+
+function makeParserLoop() {
+  const registry = createMockToolRegistry({
+    calendar_quick_schedule: async () => ({ success: true, result: 'Scheduled.' }),
+    deck_move_card: async () => ({ success: true, result: 'Moved.' })
+  });
+  return new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: createMockProvider({ content: '', toolCalls: null }),
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+}
+
+test('#164: parser recognizes canonical {"name","arguments"} JSON shape', () => {
+  const loop = makeParserLoop();
+  const parsed = loop._parseToolCallFromText(
+    '{"name": "deck_move_card", "arguments": {"card": "#44", "target_stack": "Done"}}'
+  );
+  assert.ok(parsed, 'arguments-shape call must parse (not null)');
+  assert.strictEqual(parsed.name, 'deck_move_card');
+  assert.strictEqual(parsed.arguments.card, '#44');
+});
+
+test('#164: parser recognizes a <tool_call>-wrapped arguments-shape call', () => {
+  const loop = makeParserLoop();
+  const parsed = loop._parseToolCallFromText(
+    '<tool_call>\n{"name": "calendar_quick_schedule", "arguments": {"title": "Check backend"}}\n</tool_call>'
+  );
+  assert.ok(parsed, '<tool_call>-wrapped call must parse');
+  assert.strictEqual(parsed.name, 'calendar_quick_schedule');
+  assert.strictEqual(parsed.arguments.title, 'Check backend');
+});
+
+test('#164: parser still recognizes the legacy {"name","parameters"} shape (regression)', () => {
+  const loop = makeParserLoop();
+  const parsed = loop._parseToolCallFromText(
+    '{"name": "deck_move_card", "parameters": {"card": "#7"}}'
+  );
+  assert.ok(parsed, 'parameters-shape call must still parse');
+  assert.strictEqual(parsed.name, 'deck_move_card');
+});
+
+asyncTest('#164: text-form call on a gate=action turn is invoked, reply is synthesized text (not the envelope)', async () => {
+  // Iteration 1 emits the call as TEXT (qwen3:8b shape); iteration 2 synthesizes.
+  // Pre-fix: parser missed it → action guard re-prompts once → envelope shipped.
+  const provider = createMockProvider([
+    { content: '<tool_call>\n{"name": "calendar_quick_schedule", "arguments": {"title": "Check backend", "start": "2026-06-17T19:00"}}\n</tool_call>', toolCalls: null },
+    { content: 'Scheduled "Check backend" for tomorrow at 19:00.', toolCalls: null }
+  ]);
+  let executed = false;
+  const registry = createDomainMockToolRegistry({
+    calendar_quick_schedule: async () => { executed = true; return { success: true, result: 'Scheduled.' }; }
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('Set up a task tomorrow 19:00', 'room-abc', { gate: 'action', domain: 'calendar', compound: false });
+  assert.ok(executed, 'the text-form call must be routed to execution');
+  assert.ok(!/<tool_call>|"arguments"\s*:|"name"\s*:\s*"/.test(response), 'reply must not contain the raw tool-call envelope');
+  assert.strictEqual(response, 'Scheduled "Check backend" for tomorrow at 19:00.');
+});
+
+// ============================================================
 // Cleanup & Summary
 // ============================================================
 


### PR DESCRIPTION
Refs #164

## Summary

On a conversational turn that classifies and routes correctly, the agent calls the right
tool but the Talk reply was sometimes the **raw tool-call envelope** instead of a
natural-language answer. Root cause (confirmed in discovery): when `qwen3:8b` expresses a
tool call as **text** rather than a native `tool_calls` response, `_parseToolCallFromText`
didn't recognize the canonical OpenAI/Ollama `{"name", "arguments"}` shape (optionally
wrapped in `<tool_call>` tags) — Pattern 1 required the literal key `"parameters"`. The
unrecognized call sailed past the parser; on a `gate=action` turn the action-hallucination
guard re-prompts once, and if the model text-formed again the spent guard let the
final-answer branch (`lastResponse = response.content`) ship the raw JSON to Talk.
`_postProcessResponse` doesn't strip it, so it reached the user verbatim.

This is the success-side mirror of the #117/#160 failure-disclosure family: those make the
agent honest in Talk when a tool **fails**; this makes it articulate in Talk when a tool
**succeeds**.

## The fix (Altitude A — model output parsing)

One regex alternation in `_parseToolCallFromText`: accept both `"arguments"` and
`"parameters"` as the args key. The text-shaped call is then **routed as an invocation**
(executed against the uncaged registry) rather than shipped as the final answer, and the
already-healthy synthesis pass composes the natural-language reply. Parsing a tool-call
envelope is structured plumbing, not natural language; a regex stripping JSON from the
reply would be the wrong altitude (Rule 1/3). Behavior, not phrasing — works in DE/EN/PT.

Tests: 4 new (`#164`) — canonical `arguments` shape, `<tool_call>`-wrapped, legacy
`parameters` regression, and an end-to-end `gate=action` turn that now invokes the tool and
returns synthesized text instead of the envelope. `npm run test:unit` 223/223 files pass,
lint 0 errors.

## [VERIFIED]

**Discovery ruled out Altitude B** (missing synthesis): seeding iteration 1 with a *native*
tool call, the real `qwen3:8b` synthesis iteration composes clean natural language EN/DE +
a deck-read, 3/3. The synthesis pass is healthy; the leak is purely the text-form parse.

**Before → after on the text-form trigger (through the real `AgentLoop`, model output in
the shape `qwen3:8b` emits as text):**

```
BEFORE (next@6afa831):
  [AgentLoop] Action-hallucination guard fired at iteration 1 — re-prompting (zero tool calls (gate=action))
  [AgentLoop] Iteration 2/6 → Complete
  chat_outgoing source: "<tool_call>\n{\"name\": \"calendar_quick_schedule\", \"arguments\": {\"title\": \"Check Moltagent Ollama Backend\", ...}}\n</tool_call>"   ← RAW ENVELOPE LEAKED

AFTER (this branch):
  [AgentLoop] Parsed tool call from text: calendar_quick_schedule({...})
  [AgentLoop] Tool call: calendar_quick_schedule({...})  → executed
  [AgentLoop] Iteration 2/6 → Complete
  chat_outgoing source: "Done — I scheduled \"Check Moltagent Ollama Backend\" for tomorrow at 19:00 (120 minutes)."   ← natural language
```

Parser A/B: current regex MISSES `{"name","arguments"}` and `<tool_call>`-wrapped calls;
fixed regex MATCHES both and still matches the legacy `{"name","parameters"}` shape.

**Live on the Bot VM (NC 32, trust=cloud-ok)** — deployed the branch (`systemctl restart`),
clean boot + healthy `heartbeat_pulse`, then drove real Talk turns (signed webhook). Both
classified `deck → cloud (gate=action)` — the bug's exact path — and returned clean
natural language in the user's language, no envelope:

```
EN  chat_outgoing: "Good morning. No events today and all clear on overdue tasks.\n\nHere's what you've got on your boards…"
DE  chat_outgoing: "Hier ist dein aktueller Board-Status:\n\n**Deine persönlichen Boards:**\n- **Moltagent Personal**: 12 I…"
```

Honest caveat: the live turns went the *native-call* path (qwen3:8b native-called; the
text-form leak is intermittent and can't be forced via Talk on demand), so they confirm
deployability + multilingual synthesis + no regression. The before/after on the text-form
trigger is the deterministic real-loop reproduction above. Prod was restored to
`next@6afa831` after verification (PR left for squash-merge).

`[VERIFIED: #164 — text-form tool-call envelope no longer ships to Talk. Real-AgentLoop A/B
(before=raw <tool_call> JSON, after=executed→NL); parser A/B (arguments/<tool_call> now
matched, parameters preserved); Bot VM live EN+DE deck→cloud turns synthesize clean NL, no
envelope; 223/223 unit files, lint 0.]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
