### PR TITLE
feat(workflows): ingest folder emails as cards via a TRIGGER: board line

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const fs   = require('fs');
-const path = require('path');
+const fs     = require('fs');
+const path   = require('path');
+const crypto = require('crypto');
 const GateDetector = require('./gate-detector');
 const { ScheduleHandler, parseScheduleBlock, findConfigCard, stripHtml } = require('./schedule-handler');
 const { isStructuralCard, hasLabel } = require('../integrations/deck-card-classifier');
@@ -34,9 +35,11 @@ class WorkflowEngine {
    * @param {import('../agent/agent-loop').AgentLoop} options.agentLoop
    * @param {import('../talk/talk-send-queue').TalkSendQueue} options.talkSendQueue
    * @param {string} options.talkToken - Primary Talk room token for notifications
+   * @param {Object} [options.emailHandler] - EmailHandler instance; when provided, boards with a
+   *   TRIGGER: email:<folder> line will have unread emails ingested as cards each pulse.
    * @param {Object} [options.config]
    */
-  constructor({ workflowDetector, deckClient, agentLoop, talkSendQueue, talkToken, config, budgetEnforcer }) {
+  constructor({ workflowDetector, deckClient, agentLoop, talkSendQueue, talkToken, emailHandler, config, budgetEnforcer }) {
     this.detector = workflowDetector;
     this.deck = deckClient;
     this.agent = agentLoop;
@@ -44,7 +47,8 @@ class WorkflowEngine {
     this.talkToken = talkToken || null;
     this.config = config || {};
     this.budgetEnforcer = budgetEnforcer || null;
-    this.botUsername = this.config.botUsername || 'moltagent';
+    this.botUsername    = this.config.botUsername || 'moltagent';
+    this.emailHandler   = emailHandler || null;
 
     // Resolve data directory. Disk persistence is only enabled when config.dataDir
     // is explicitly provided (or config.dataDir === true to use the default).
@@ -79,6 +83,16 @@ class WorkflowEngine {
       ? path.join(this._dataDir, 'workflow-notified-gates.json')
       : null;
     this._notifiedGates = this._loadNotifiedGates();
+
+    // Track emails already ingested as cards to guarantee idempotency.
+    // On-disk shape: { "<boardId>": ["<msgId>", ...] }
+    // In memory: Map<string, Set<string>>
+    // Keyed by Message-ID (or a sha1 fallback for emails that lack one).
+    // Persisted to disk so service restarts don't re-ingest.
+    this._ingestedEmailsFile = this._dataDir
+      ? path.join(this._dataDir, 'workflow-ingested-emails.json')
+      : null;
+    this._ingestedEmails = this._loadIngestedEmails(); // Map<boardId(string), Set<messageId>>
 
     // Reentrancy guard — prevents concurrent processAll() when a pulse
     // outlasts the heartbeat interval.
@@ -168,6 +182,15 @@ class WorkflowEngine {
     if (hasLabel(rulesCard, 'PAUSED')) {
       console.log(`[Workflow] Board "${board.title}" is PAUSED — skipping`);
       return result;
+    }
+
+    // External-event ingestion: a TRIGGER: line pulls emails from a folder into
+    // this board as cards, once per email (idempotent on Message-ID), before the
+    // per-card processing loop. Inherits the board PAUSED gate above.
+    try {
+      await this._ingestTriggerEmails(wb);
+    } catch (err) {
+      console.error('[Workflow] Email trigger ingestion error on "' + board.title + '": ' + err.message);
     }
 
     for (const stack of stacks) {
@@ -756,6 +779,217 @@ class WorkflowEngine {
     } catch (err) {
       console.error('[Workflow] Failed to persist notified gates:', err.message);
     }
+  }
+
+  // ===========================================================================
+  // Ingested Emails Persistence  (email-trigger-bridge)
+  // ===========================================================================
+
+  /**
+   * Load the per-board ingested-email sets from disk.
+   * On-disk shape: { "<boardId>": ["<msgId>", ...] }
+   * Returns Map<string, Set<string>>; starts fresh on missing/corrupt file.
+   * @private
+   */
+  _loadIngestedEmails() {
+    if (!this._ingestedEmailsFile) return new Map();
+    try {
+      const raw = fs.readFileSync(this._ingestedEmailsFile, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const map = new Map();
+        for (const [boardId, ids] of Object.entries(parsed)) {
+          map.set(boardId, new Set(Array.isArray(ids) ? ids : []));
+        }
+        return map;
+      }
+    } catch (_err) {
+      // Missing file or corrupt JSON — start fresh
+    }
+    return new Map();
+  }
+
+  /**
+   * Persist the ingested-emails Map to disk (atomic tmp + rename).
+   * @private
+   */
+  _saveIngestedEmails() {
+    if (!this._ingestedEmailsFile) return;
+    try {
+      if (!fs.existsSync(this._dataDir)) {
+        fs.mkdirSync(this._dataDir, { recursive: true });
+      }
+      const obj = {};
+      for (const [boardId, set] of this._ingestedEmails.entries()) {
+        obj[boardId] = [...set];
+      }
+      const tmp = this._ingestedEmailsFile + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), 'utf8');
+      fs.renameSync(tmp, this._ingestedEmailsFile);
+    } catch (err) {
+      console.error('[Workflow] Failed to persist ingested emails:', err.message);
+    }
+  }
+
+  /**
+   * Check whether an email has already been ingested for a given board.
+   * @param {string|number} boardId
+   * @param {string} msgId
+   * @returns {boolean}
+   * @private
+   */
+  _isEmailIngested(boardId, msgId) {
+    const set = this._ingestedEmails.get(String(boardId));
+    return set ? set.has(msgId) : false;
+  }
+
+  /**
+   * Mark an email as ingested for a given board and persist to disk.
+   * Caps each board's set at 1000 most-recent entries (insertion-order).
+   * @param {string|number} boardId
+   * @param {string} msgId
+   * @private
+   */
+  _markEmailIngested(boardId, msgId) {
+    const key = String(boardId);
+    let set = this._ingestedEmails.get(key);
+    if (!set) {
+      set = new Set();
+      this._ingestedEmails.set(key, set);
+    }
+    set.add(msgId);
+    // Cap at 1000 most-recent entries to prevent unbounded growth
+    if (set.size > 1000) {
+      this._ingestedEmails.set(key, new Set([...set].slice(-1000)));
+    }
+    this._saveIngestedEmails();
+  }
+
+  // ===========================================================================
+  // Email Trigger Bridge  (email-trigger-bridge)
+  // ===========================================================================
+
+  /**
+   * Parse a TRIGGER: line from the board rules. Structured metadata, not NL.
+   * Form: TRIGGER: <kind>:<locator>  (optionally  -> <stack name>)
+   * The locator is a folder path (e.g. INBOX.INQUIRIES) for email triggers.
+   * The locator must be whitespace-free (dotted IMAP paths like INBOX.INQUIRIES);
+   * folder names containing spaces are not supported by this unquoted form, and
+   * the optional stack-target separator is ASCII "->" (not the Unicode arrow).
+   * Returns { kind, locator, stackName } or null.
+   * @private
+   */
+  _parseTrigger(wb) {
+    const desc = wb._plainDescription || stripHtml(wb.description || '');
+    const m = desc.match(/^TRIGGER:\s*(\w+):(\S+?)(?:\s*->\s*(.+?))?\s*$/im);
+    if (!m) return null;
+    return { kind: m[1].toLowerCase(), locator: m[2], stackName: m[3] ? m[3].trim() : null };
+  }
+
+  /**
+   * Compute a stable fallback dedup key for emails that lack a Message-ID.
+   * Uses a sha1 of folder|uid|date|from|subject so the same physical email
+   * always maps to the same key across pulses.
+   * @private
+   */
+  _fallbackEmailKey(folder, email) {
+    const parts = [
+      folder,
+      String(email.id ?? ''),
+      String(email.date ?? ''),
+      String(email.from ?? ''),
+      String(email.subject ?? '')
+    ].join('|');
+    return 'nomsgid:' + crypto.createHash('sha1').update(parts).digest('hex');
+  }
+
+  /**
+   * Ingest unread emails from a TRIGGER: email:<folder> declaration into this
+   * board as Deck cards. Idempotent on Message-ID; never mutates \Seen.
+   * @param {Object} wb - WorkflowBoard descriptor
+   * @returns {Promise<number>} Number of cards created this pulse
+   * @private
+   */
+  async _ingestTriggerEmails(wb) {
+    const trigger = this._parseTrigger(wb);
+    if (!trigger) return 0;
+
+    // Dispatch on kind — only 'email' is implemented; future kinds add here.
+    if (trigger.kind !== 'email') {
+      console.warn('[Workflow] Unsupported TRIGGER kind: ' + trigger.kind + ' — skipping');
+      return 0;
+    }
+
+    // Graceful no-op when emailHandler was not injected (e.g. unit tests).
+    if (!this.emailHandler) return 0;
+
+    // Resolve the entry stack: named target takes precedence; else first by order.
+    let stack;
+    if (trigger.stackName) {
+      stack = (wb.stacks || []).find(
+        s => s.title.toLowerCase() === trigger.stackName.toLowerCase()
+      );
+    } else {
+      const sorted = [...(wb.stacks || [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      stack = sorted[0];
+    }
+
+    if (!stack) {
+      console.warn('[Workflow] Email trigger: no entry stack resolved for board "' + wb.board.title + '" (stackName=' + (trigger.stackName || 'null') + ')');
+      return 0;
+    }
+
+    // Fetch unread emails — opens the mailbox READ-ONLY (never mutates \Seen).
+    let emails;
+    try {
+      emails = await this.emailHandler._fetchEmails({
+        folder: trigger.locator,
+        unreadOnly: true,
+        limit: 50
+      });
+    } catch (err) {
+      console.error('[Workflow] Email trigger fetch failed for board "' + wb.board.title + '": ' + err.message);
+      return 0;
+    }
+
+    if (emails.length === 50) {
+      // Soft warning: a full fetch window may silently cap a backlog.
+      console.warn('[Workflow] Email trigger fetch hit the limit (50) for folder ' + trigger.locator + ' — older unread may wait for the next pulse');
+    }
+
+    // Process oldest-first so card order on the board reflects email arrival order.
+    // _fetchEmails returns newest-first (sorted descending); reverse to get oldest-first.
+    const orderedEmails = [...emails].reverse();
+
+    let ingested = 0;
+    for (const email of orderedEmails) {
+      const key = email.messageId || this._fallbackEmailKey(trigger.locator, email);
+
+      if (this._isEmailIngested(wb.boardId, key)) continue;
+
+      // Build the card title and description.
+      const title = email.subject || '(No subject)';
+      const bodyText = (email.body || '').slice(0, 2000);
+      const description = bodyText + '\n\n---\nFrom: ' + (email.from || '') +
+        '\nDate: ' + (email.date || '') +
+        '\nMessage-ID: ' + key;
+
+      const card = await this.deck.createCardOnBoard(wb.boardId, stack.id, title, { description });
+
+      if (card) {
+        // Only mark ingested after successful card creation.
+        // If createCardOnBoard returned null (entry stack is PAUSED) we do NOT
+        // mark, so the email is retried on the next pulse when unpaused.
+        this._markEmailIngested(wb.boardId, key);
+        ingested++;
+      }
+    }
+
+    if (ingested > 0) {
+      console.log('[Workflow] Email trigger ingested ' + ingested + ' card(s) into "' + wb.board.title + '" from ' + trigger.locator);
+    }
+
+    return ingested;
   }
 
   /**

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -1,0 +1,433 @@
+'use strict';
+
+/**
+ * AGPL-3.0 License
+ * Copyright (C) 2024 Moltagent Contributors
+ *
+ * email-trigger-bridge.test.js
+ *
+ * Tests for the Email-to-Card Trigger Bridge in WorkflowEngine.
+ * Covers: TRIGGER: line parsing, email dedup (idempotency on Message-ID),
+ * entry stack resolution, folder forwarding, fallback key, PAUSED gate,
+ * card description footer, and dispatch-readiness for non-email kinds.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const WorkflowEngine = require('../../../src/lib/workflows/workflow-engine');
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+/** Minimal mock DeckClient — records createCardOnBoard calls. */
+function createMockDeck(opts = {}) {
+  const calls = [];
+  return {
+    createCardOnBoard: async (boardId, stackId, title, cardOpts) => {
+      calls.push({ boardId, stackId, title, description: cardOpts && cardOpts.description });
+      if (opts.returnNull) return null;
+      return { id: 100 + calls.length };
+    },
+    _calls: calls
+  };
+}
+
+/** Minimal mock EmailHandler — returns a fixture array. */
+function createMockEmailHandler(emails = []) {
+  const fetchCalls = [];
+  return {
+    _fetchEmails: async (options) => {
+      fetchCalls.push(options);
+      return emails;
+    },
+    _fetchCalls: fetchCalls
+  };
+}
+
+/** Minimal mock AgentLoop (needed for WorkflowEngine constructor). */
+function createMockAgentLoop() {
+  return { processWorkflowTask: async () => 'done' };
+}
+
+/** Minimal mock TalkQueue. */
+function createMockTalkQueue() {
+  return { enqueue: async () => {} };
+}
+
+/**
+ * Build a WorkflowBoard descriptor (wb) with a rules card that does NOT have
+ * the PAUSED label, so _processBoard won't bail early.
+ */
+function makeWorkflowBoard({
+  boardId = 1,
+  description = 'WORKFLOW: pipeline',
+  stacks = null,
+  rulesCardId = 900,
+  pauseRulesCard = false
+} = {}) {
+  const rulesCard = {
+    id: rulesCardId,
+    title: 'WORKFLOW: pipeline',
+    description: 'Rules',
+    labels: pauseRulesCard ? [{ title: 'PAUSED' }] : []
+  };
+  const defaultStacks = [
+    { id: 10, title: 'Inbox', order: 0, cards: [rulesCard] },
+    { id: 20, title: 'In Progress', order: 1, cards: [] },
+    { id: 30, title: 'Done', order: 2, cards: [] }
+  ];
+  return {
+    board: { id: boardId, title: 'Test Board' },
+    boardId,
+    stacks: stacks || defaultStacks,
+    description,
+    workflowType: 'pipeline',
+    rulesCardId,
+    _plainDescription: description
+  };
+}
+
+/** Build a minimal WorkflowEngine without disk persistence. */
+function makeEngine({ emailHandler, deck } = {}) {
+  return new WorkflowEngine({
+    workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
+    deckClient: deck || createMockDeck(),
+    agentLoop: createMockAgentLoop(),
+    talkSendQueue: createMockTalkQueue(),
+    talkToken: 'tok',
+    emailHandler: emailHandler || null
+    // no config.dataDir → in-memory only
+  });
+}
+
+/** Fixture: a single email with a Message-ID. */
+function makeEmail(overrides = {}) {
+  return {
+    id: 42,
+    messageId: '<test-001@example.com>',
+    from: 'Alice <alice@example.com>',
+    fromAddress: 'alice@example.com',
+    subject: 'Test Email',
+    date: new Date('2026-06-17T10:00:00Z'),
+    body: 'Hello from test.',
+    snippet: 'Hello from test.',
+    isRead: false,
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+(async () => {
+  console.log('\n=== Email Trigger Bridge Tests ===\n');
+
+  // TC-TRIGGER-01: No TRIGGER line → returns 0, _fetchEmails NOT called, no card created.
+  await asyncTest('TC-TRIGGER-01: No TRIGGER line → 0 ingested, no fetch, no card', async () => {
+    const emailHandler = createMockEmailHandler([makeEmail()]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nRULES: do stuff' });
+
+    const result = await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(result, 0, 'should return 0');
+    assert.strictEqual(emailHandler._fetchCalls.length, 0, '_fetchEmails should NOT be called');
+    assert.strictEqual(deck._calls.length, 0, 'no card should be created');
+  });
+
+  // TC-TRIGGER-02: _parseTrigger parses TRIGGER: email:INBOX.INQUIRIES correctly.
+  test('TC-TRIGGER-02: _parseTrigger parses email:INBOX.INQUIRIES → {kind,locator,stackName:null}', () => {
+    const engine = makeEngine();
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES\n→ Inbox:' });
+    const result = engine._parseTrigger(wb);
+
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.kind, 'email');
+    assert.strictEqual(result.locator, 'INBOX.INQUIRIES');
+    assert.strictEqual(result.stackName, null);
+  });
+
+  // TC-TRIGGER-03: _parseTrigger parses optional -> stack name.
+  test('TC-TRIGGER-03: _parseTrigger parses TRIGGER: email:INBOX.X -> Inbox → stackName:Inbox', () => {
+    const engine = makeEngine();
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.X -> Inbox' });
+    const result = engine._parseTrigger(wb);
+
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.kind, 'email');
+    assert.strictEqual(result.locator, 'INBOX.X');
+    assert.strictEqual(result.stackName, 'Inbox');
+  });
+
+  // TC-TRIGGER-04: _parseTrigger on a description with no TRIGGER → null.
+  test('TC-TRIGGER-04: _parseTrigger on description without TRIGGER → null', () => {
+    const engine = makeEngine();
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nRULES: do stuff' });
+    assert.strictEqual(engine._parseTrigger(wb), null);
+  });
+
+  // TC-TRIGGER-05: Idempotency — two consecutive calls with same messageId → card created exactly once.
+  await asyncTest('TC-TRIGGER-05: Same messageId on two calls → card created exactly once', async () => {
+    const emails = [makeEmail({ messageId: '<dedup-test@example.com>' })];
+    const emailHandler = createMockEmailHandler(emails);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'card should be created exactly once');
+  });
+
+  // TC-TRIGGER-06: New messageId on the second call → a new card created.
+  await asyncTest('TC-TRIGGER-06: New messageId on second call → second card created', async () => {
+    let callCount = 0;
+    const emailSets = [
+      [makeEmail({ messageId: '<first@example.com>' })],
+      [makeEmail({ messageId: '<first@example.com>' }), makeEmail({ messageId: '<second@example.com>', id: 43 })]
+    ];
+    const fetchCalls = [];
+    const emailHandler = {
+      _fetchEmails: async (opts) => {
+        fetchCalls.push(opts);
+        return emailSets[callCount++] || emailSets[1];
+      },
+      _fetchCalls: fetchCalls
+    };
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 2, 'two distinct emails → two cards');
+  });
+
+  // TC-TRIGGER-07: _fetchEmails is called with the correct options.
+  await asyncTest('TC-TRIGGER-07: _fetchEmails called with {folder, unreadOnly:true, limit:50}', async () => {
+    const emailHandler = createMockEmailHandler([]);
+    const engine = makeEngine({ emailHandler });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(emailHandler._fetchCalls.length, 1);
+    const opts = emailHandler._fetchCalls[0];
+    assert.strictEqual(opts.folder, 'INBOX.INQUIRIES');
+    assert.strictEqual(opts.unreadOnly, true);
+    assert.strictEqual(opts.limit, 50);
+  });
+
+  // TC-TRIGGER-08: Entry stack selection — first by order when no stackName.
+  await asyncTest('TC-TRIGGER-08: No stackName → first stack by order is chosen', async () => {
+    const emailHandler = createMockEmailHandler([makeEmail()]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+
+    // Stacks intentionally out of order; lowest order=0 is id=30.
+    const stacks = [
+      { id: 30, title: 'Inbox', order: 0, cards: [] },
+      { id: 10, title: 'In Progress', order: 1, cards: [] },
+      { id: 20, title: 'Done', order: 2, cards: [] }
+    ];
+    const wb = makeWorkflowBoard({
+      description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST',
+      stacks
+    });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'card should be created');
+    assert.strictEqual(deck._calls[0].stackId, 30, 'should use lowest-order stack (id=30)');
+  });
+
+  // TC-TRIGGER-09: Entry stack by name — case-insensitive match.
+  await asyncTest('TC-TRIGGER-09: stackName resolves case-insensitively to matching stack id', async () => {
+    const emailHandler = createMockEmailHandler([makeEmail()]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+
+    const stacks = [
+      { id: 10, title: 'Inbox', order: 0, cards: [] },
+      { id: 20, title: 'Support', order: 1, cards: [] }
+    ];
+    // "SUPPORT" in the trigger → should match stack id=20 (title='Support')
+    const wb = makeWorkflowBoard({
+      description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.SUPPORT -> SUPPORT',
+      stacks
+    });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1);
+    assert.strictEqual(deck._calls[0].stackId, 20, 'should match Support stack (id=20) case-insensitively');
+  });
+
+  // TC-TRIGGER-10: Missing messageId → fallback key; still idempotent across two calls.
+  await asyncTest('TC-TRIGGER-10: No messageId → fallback key used, still idempotent', async () => {
+    const emailNoId = makeEmail({ messageId: undefined });
+    delete emailNoId.messageId;
+    const emailHandler = createMockEmailHandler([emailNoId]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'fallback key should still be idempotent');
+  });
+
+  // TC-TRIGGER-11: emailHandler absent → returns 0, no throw.
+  await asyncTest('TC-TRIGGER-11: No emailHandler → returns 0, no throw', async () => {
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler: null, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    let result;
+    let threw = false;
+    try {
+      result = await engine._ingestTriggerEmails(wb);
+    } catch (_) {
+      threw = true;
+    }
+
+    assert.strictEqual(threw, false, 'should not throw');
+    assert.strictEqual(result, 0, 'should return 0');
+    assert.strictEqual(deck._calls.length, 0);
+  });
+
+  // TC-TRIGGER-12: createCardOnBoard returns null (paused entry stack) → email NOT marked;
+  //               subsequent call retries (createCardOnBoard called again).
+  await asyncTest('TC-TRIGGER-12: createCardOnBoard null → email not marked, retried next call', async () => {
+    const emails = [makeEmail({ messageId: '<retry-test@example.com>' })];
+    const emailHandler = createMockEmailHandler(emails);
+    const deck = createMockDeck({ returnNull: true });
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+    await engine._ingestTriggerEmails(wb);
+
+    // Both attempts should have tried (since marking never happened)
+    assert.strictEqual(deck._calls.length, 2, 'createCardOnBoard should be called on both pulses');
+    assert.strictEqual(engine._isEmailIngested(1, '<retry-test@example.com>'), false,
+      'email should NOT be marked as ingested when card creation returned null');
+  });
+
+  // TC-TRIGGER-13: Card description contains sender, date, and Message-ID footer.
+  await asyncTest('TC-TRIGGER-13: Card description has From/Date/Message-ID footer', async () => {
+    const email = makeEmail({
+      messageId: '<footer-test@example.com>',
+      from: 'Bob <bob@example.com>',
+      date: new Date('2026-06-17T12:00:00Z'),
+      body: 'Body content here.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1);
+    const desc = deck._calls[0].description;
+    assert.ok(desc.includes('Bob <bob@example.com>'), 'description should contain sender');
+    assert.ok(desc.includes('<footer-test@example.com>'), 'description should contain Message-ID');
+    // date is included (any format — it's the raw Date object converted to string)
+    assert.ok(desc.includes('Date:'), 'description should contain Date: label');
+  });
+
+  // TC-TRIGGER-14: Unsupported kind (files:) → returns 0, _fetchEmails NOT called.
+  await asyncTest('TC-TRIGGER-14: Unsupported kind "files:" → 0 returned, no email fetch', async () => {
+    const emailHandler = createMockEmailHandler([makeEmail()]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: files:/some/path' });
+
+    const result = await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(emailHandler._fetchCalls.length, 0, '_fetchEmails should NOT be called for unsupported kind');
+    assert.strictEqual(deck._calls.length, 0);
+  });
+
+  // TC-TRIGGER-15: Board with PAUSED rules card → _processBoard returns without calling _ingestTriggerEmails.
+  await asyncTest('TC-TRIGGER-15: PAUSED rules card → _ingestTriggerEmails never called', async () => {
+    const emailHandler = createMockEmailHandler([makeEmail()]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+
+    // Replace with a spy to verify it's not called
+    let ingestCalled = 0;
+    engine._ingestTriggerEmails = async () => { ingestCalled++; return 0; };
+
+    const wb = makeWorkflowBoard({
+      description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST',
+      pauseRulesCard: true
+    });
+
+    // Call _processBoard directly; it should bail at the PAUSED check
+    await engine._processBoard(wb);
+
+    assert.strictEqual(ingestCalled, 0, '_ingestTriggerEmails should NOT be called when board is PAUSED');
+  });
+
+  // TC-TRIGGER-16: Disk round-trip — the processed-Message-ID store survives a
+  //                service restart (a second engine on the same dataDir must not
+  //                re-ingest). This locks the briefing's "restarts don't re-ingest"
+  //                idempotency guarantee, which the in-memory tests above cannot reach.
+  await asyncTest('TC-TRIGGER-16: ingested Message-ID survives restart (disk round-trip)', async () => {
+    const tmpDir = path.join(os.tmpdir(), 'moltagent-trigger-test-' + process.pid);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    try {
+      const email = makeEmail({ messageId: '<restart-test@example.com>' });
+      const desc = 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST';
+
+      // First engine ("before restart") — ingests and persists to disk.
+      const deckA = createMockDeck();
+      const engineA = new WorkflowEngine({
+        workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
+        deckClient: deckA,
+        agentLoop: createMockAgentLoop(),
+        talkSendQueue: createMockTalkQueue(),
+        talkToken: 'tok',
+        emailHandler: createMockEmailHandler([email]),
+        config: { dataDir: tmpDir }
+      });
+      await engineA._ingestTriggerEmails(makeWorkflowBoard({ description: desc }));
+      assert.strictEqual(deckA._calls.length, 1, 'first engine creates the card');
+      assert.ok(fs.existsSync(path.join(tmpDir, 'workflow-ingested-emails.json')),
+        'store file should be written to disk');
+
+      // Second engine ("after restart") — fresh instance, same dataDir, must load
+      // the prior record and NOT re-ingest the same email.
+      const deckB = createMockDeck();
+      const engineB = new WorkflowEngine({
+        workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
+        deckClient: deckB,
+        agentLoop: createMockAgentLoop(),
+        talkSendQueue: createMockTalkQueue(),
+        talkToken: 'tok',
+        emailHandler: createMockEmailHandler([email]),
+        config: { dataDir: tmpDir }
+      });
+      assert.strictEqual(engineB._isEmailIngested(1, '<restart-test@example.com>'), true,
+        'reloaded engine should recognize the prior Message-ID');
+      await engineB._ingestTriggerEmails(makeWorkflowBoard({ description: desc }));
+      assert.strictEqual(deckB._calls.length, 0, 'reloaded engine must NOT re-create the card');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  setTimeout(() => { summary(); exitWithCode(); }, 500);
+})();

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1987,6 +1987,7 @@ async function initialize() {
         agentLoop,
         talkSendQueue: talkQueue,
         talkToken: defaultTalkToken,
+        emailHandler,
         budgetEnforcer: llmRouter?.router?.budget || null,
         config: { botUsername: CONFIG.nc.username, adminUser: appConfig.cockpit?.adminUser || appConfig.knowledge?.adminUser || '', dataDir: true }
       });


### PR DESCRIPTION
## Email-to-Card Trigger Bridge for WORKFLOW: boards

The WorkflowEngine reacts to internal Deck state but has had no path for an
**external event** to enter a board as a card. This adds the first external
trigger source: a `WORKFLOW:` board whose rules-card description carries a
`TRIGGER:` line gets emails from a mail folder turned into cards each heartbeat
pulse — once per email, gated by the existing PAUSED governor, without ever
touching the human's mailbox.

```
WORKFLOW: pipeline
TRIGGER: email:INBOX.INQUIRIES        # optionally:  -> Inbox
```

### The load-bearing property: idempotency that never reads `\Seen`

A polling ingestion that re-does work it already did produces duplicate cards
(the governor covers creation volume; idempotency is the other half). The wrong
design infers "already processed" from the IMAP `\Seen` flag — which is shared
and externally mutable, so it silently double-fires or never fires.

Here the processed record is the **agent's own durable fact, keyed on the email
Message-ID**, stored in the engine's existing data dir
(`workflow-ingested-emails.json`, atomic write, per-board, bounded). `\Seen` and
the folder stay owned by the human (read-only IMAP open). Correct idempotency
and "don't mutate the human's mailbox" land on the same design.

### What changed (4 edits, additive)

- **`workflow-engine.js`** — `emailHandler` constructor injection; an
  ingested-emails store (clone of the existing notified-gates persistence
  pattern); `_parseTrigger` (a generic `kind:locator`, parsed as a sibling of
  the existing `MODEL:`/`SLA:` markers — structured metadata, not NL);
  `_ingestTriggerEmails`; and the call wired into `_processBoard` at the single
  per-board chokepoint, **after** the PAUSED return and **before** the per-card
  loop (so it inherits the governor for free).
- **`webhook-server.js`** — one line: inject the existing `emailHandler` into
  the engine.
- **tests** — `test/unit/workflows/email-trigger-bridge.test.js`, 16 cases.

Marks a Message-ID ingested **only after** the card is created, so a paused
entry stack retries rather than dropping the email; the Message-ID is also
embedded in the card description as a recovery key. Reuses
`EmailHandler._fetchEmails` (no second IMAP connection). Only the `email` kind
is implemented — a future `files:` source is a new dispatch entry, not a fork.

### Scope fences (left alone)

No email **send** from a workflow (discovery finding below); no change to the
conversational HITL (`requiresConfirmation`), PAUSED, or GATE; no NL parsing of
the trigger line; no second IMAP connection; no mailbox mutation.

### Discovery findings carried forward

- **Send-from-workflow (report only):** the workflow loop's `mail_send` reaches
  SMTP via `confirmSendEmail` and **bypasses** the conversational
  `requiresConfirmation` path entirely — so it does not collide with it, but
  also has no heartbeat-side approval. Untouched here; flagged for a later
  gated-outbound design (a GATE ceremony, not `requiresConfirmation`).
- **Known edge + follow-up:** `unreadOnly:true` is used only as a cheap fetch
  filter (the store is the sole dedup authority); a `\Seen`-flip before the
  first ingest pulse can drop an email from the unread window. The
  `\Seen`-independent robustness path is a per-folder UID high-water-mark fetch,
  noted as a future enhancement.

### Tests

16 new `TC-TRIGGER-01..16` (parsing, Message-ID idempotency, **cross-restart
disk round-trip**, entry-stack resolution by order and by name, fallback key,
mark-only-on-success/retry, PAUSED-skips-ingestion, dispatch-readiness).
Unit test files **223 → 224 pass**; `npm run lint` **0 errors**.

---

### [VERIFIED] — live on the Bot VM, real feature-branch code vs. real infrastructure

Targeted in-process harness (the team's creds/path-limited verification
technique). The production service runs on `next`, and the live intake mailbox
had **0 unread** at verification time, so a restarted-branch heartbeat pulse
with a seeded unread email was **not** run; instead the real IMAP fetch path and
the real engine code path were exercised in-process, and cards were **captured**
(not written to the production Deck board) to avoid mutation. Stated honestly.

**Live IMAP (real EmailHandler + real credential broker → live `[NC_HOST]`):**
- `_fetchEmails({folder:INBOX, unreadOnly:true, limit:50})` → returned the live
  unread state (**0**, matching EmailMonitor's "0 new").
- A real read-only INBOX read returned a message carrying a **real RFC-2822
  Message-ID** → the idempotency key source is real, not the hash fallback.
  Read-only open — `\Seen` is never written by this path.

**Real WorkflowEngine (branch code):**
- Accepts the injected `emailHandler` (wiring effective); ran the bridge
  end-to-end against the live IMAP fetch.
- **PAUSED board** → real `_processBoard` bails **before** ingestion → no card
  (`[Workflow] Board "…" is PAUSED — skipping`).
- **Non-paused board** → exactly **1 card** created in the entry stack
  (`[Workflow] Email trigger ingested 1 card(s) … from INBOX.INQUIRIES`), with
  the Message-ID footer present.
- **Second pulse** → **no duplicate** (idempotent on Message-ID, independent of
  `\Seen`).
- **Fresh engine on the same data dir** → processed-record **survives restart**,
  no re-ingest.

**14/14 live harness checks passed.** Lint 0 errors; 224/224 unit test files.

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
