### PR TITLE
feat(voice): give STT a room-language hint from conversation history

### DIFF
--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -476,13 +476,22 @@ class MessageProcessor {
 
     // Session V2: Voice message — transcribe via VoiceManager (preferred) or WhisperClient (fallback)
     if (extracted._isVoice && extracted._voiceFile) {
+      // STT language custody: derive the room's working language ONCE here (the
+      // chokepoint right before transcription) and pass it forward to STT. Signals
+      // keep custody (#49/#123/#133); null → STT auto-detect (today's behavior).
+      const roomLanguage = await this._detectRoomLanguage(
+        extracted.token, extracted.messageId
+      );
       if (this.voiceManager) {
         if (this.voiceManager.mode === 'off') {
           // Voice processing intentionally disabled via Cockpit — skip silently
           return { skipped: true, reason: 'voice_disabled' };
         }
         try {
-          const result = await this.voiceManager.processVoiceMessage(extracted._rawMessage);
+          const result = await this.voiceManager.processVoiceMessage(
+            extracted._rawMessage,
+            { language: roomLanguage }
+          );
           if (result && result.transcript) {
             extracted._transcript = result.transcript;
             extracted.content = this._tagVoiceTranscription(
@@ -1392,6 +1401,112 @@ class MessageProcessor {
       return `${typedContent}\n${tagged}`;
     }
     return tagged;
+  }
+
+  /**
+   * Detect the working language of a Talk room from its conversation history.
+   *
+   * Architecture Brief:
+   * -------------------
+   * Problem: Whisper STT auto-detects the spoken language and gets it wrong for
+   *   short utterances ("Delete this email" → mis-read as French). The room's
+   *   working language is already known — the bot's last reply is a reliable proxy,
+   *   because the agent matches the user's language naturally — but that signal
+   *   never reaches STT.
+   *
+   * Pattern: SIGNALS KEEP CUSTODY (#49/#123/#133, 4th instance). Compute the
+   *   language ONCE here, at the chokepoint right before voice transcription, and
+   *   pass it forward (mp → VoiceManager → SpeachesClient). VoiceManager must NOT
+   *   re-derive it. Detection is an LLM job (THE LLM IS THE LANGUAGE LAYER) on the
+   *   fast classifier model (`job: 'classification'` → qwen2.5:3b local), never a
+   *   regex / char-set / word list.
+   *
+   * Graceful fallback = preserve today's behavior (STT auto-detect). Return null
+   *   when: conversationContext is absent; no assistant message exists in history
+   *   (new room); the LLM call throws; or the returned token is not a plausible
+   *   2-letter ISO 639-1 code. The plausibility check is the ONE acceptable
+   *   post-LLM guard — it is structural (is it a 2-letter alpha code?), not
+   *   semantic.
+   *
+   * Data flow:
+   *   getHistory(token, {limit:5, excludeMessageId})  // oldest-first
+   *     → last element with role === 'assistant' → its .content
+   *     → LLM classification (ISO 639-1 of that content)
+   *     → structural validation → lowercase 2-letter code | null
+   *
+   * Multilingual by default: the detection prompt carries DE + EN + PT positive
+   *   examples; fr/es are accepted as plausible outputs (bonus), never special-cased.
+   *
+   * @param {string} token - Talk room token
+   * @param {number|string} [excludeMessageId] - Trigger message id to exclude from history
+   * @returns {Promise<string|null>} Lowercase ISO 639-1 code (e.g. 'en','de','pt','fr','es')
+   *   or null when no reliable signal exists (caller falls back to STT auto-detect).
+   * @private
+   */
+  async _detectRoomLanguage(token, excludeMessageId) {
+    // Guard: both deps required; absent → fall through to STT auto-detect.
+    if (!this.conversationContext || !token) return null;
+
+    // 1. Fetch a lightweight history sample (oldest-first array).
+    let history;
+    try {
+      history = await this.conversationContext.getHistory(token, {
+        limit: 5,
+        excludeMessageId
+      });
+    } catch (err) {
+      console.warn(`[Voice] _detectRoomLanguage: getHistory failed: ${err.message}`);
+      return null;
+    }
+
+    if (!Array.isArray(history) || history.length === 0) return null;
+
+    // 2. Language proxy = content of the MOST RECENT assistant message
+    //    (history is oldest-first, so scan from the end).
+    const lastAssistant = [...history].reverse()
+      .find(m => m.role === 'assistant' && m.content && m.content.trim());
+    if (!lastAssistant) return null; // new room → STT auto-detect (current behavior)
+
+    // 3. Resolve the router (same idiom as _extractSearchTermsLLM).
+    const router = this.microPipeline?.router;
+    if (!router) return null;
+
+    // 4. Ask the LLM — language detection is the model's job (Dev Rule 1).
+    //    job:'classification' routes to qwen2.5:3b local; maxTokens 8 → single token answer.
+    try {
+      const snippet = lastAssistant.content.substring(0, 300);
+      const result = await router.route({
+        job: 'classification',
+        task: 'detect_language',
+        content: `The following text was written by an AI assistant. Return ONLY the ISO 639-1 language code of the text (en, de, pt, fr, es). Nothing else.
+
+Examples:
+  "Hier ist eine Zusammenfassung der E-Mail." → de
+  "Here is a summary of the email." → en
+  "Aqui está um resumo do e-mail." → pt
+
+Text: "${snippet}"`,
+        requirements: { maxTokens: 8, temperature: 0.0 }
+      });
+
+      const raw = (result?.result || result?.content || '').trim().toLowerCase();
+
+      // 5. Structural post-LLM guard: accept a bare 2-letter code at the START of
+      //    the answer, optionally trailed by punctuation/whitespace ("en", "en.", "en\n").
+      //    Anchored + non-letter lookahead so prose ("the code is en" → "th") and full
+      //    words ("english") do NOT yield a confidently-wrong hint — they fall through to
+      //    null → STT auto-detect (the safe default). Structural only, NOT a semantic check:
+      //    any 2-letter alpha code passes; STT ignores unrecognised hints gracefully.
+      const m = raw.match(/^[a-z]{2}(?![a-z])/);
+      const code = m ? m[0] : null;
+      if (code) {
+        console.log(`[Voice] Room language custody → ${code} (from last assistant message)`);
+      }
+      return code;
+    } catch (err) {
+      console.warn(`[Voice] _detectRoomLanguage: LLM detection failed: ${err.message}`);
+      return null;
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/voice/voice-manager.js
+++ b/src/lib/voice/voice-manager.js
@@ -77,10 +77,14 @@ class VoiceManager {
    * Process a voice message: download, convert, transcribe.
    *
    * @param {Object} message - NC Talk message object (raw)
+   * @param {Object} [options] - Optional processing hints
+   * @param {string} [options.language] - ISO 639-1 STT language hint (custody signal
+   *   derived once upstream in MessageProcessor; do NOT re-derive language here).
+   *   When absent, falls back to config.language, then to STT auto-detect.
    * @returns {Promise<{transcript: string, confidence: number|null, duration: number}|null>}
    *   Returns null if mode is off, transcription fails, or transcript is empty.
    */
-  async processVoiceMessage(message) {
+  async processVoiceMessage(message, options = {}) {
     if (this.mode === 'off') {
       return null;
     }
@@ -124,7 +128,10 @@ class VoiceManager {
       let transcriptText;
       let confidence = null;
       try {
-        const language = this.config.language || undefined;
+        // options.language is the room-language custody signal derived once upstream in
+        // MessageProcessor (_detectRoomLanguage). Absent → config.language → undefined
+        // (STT auto-detect). Signals keep custody (#49/#123/#133).
+        const language = options.language || this.config.language || undefined;
         const sttResult = await this.speachesClient.transcribe(wavBuffer, { language });
         // SpeachesClient returns { text, confidence }
         if (typeof sttResult === 'string') {

--- a/test/unit/server/message-processor-voice.test.js
+++ b/test/unit/server/message-processor-voice.test.js
@@ -1,0 +1,319 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ */
+
+/**
+ * MessageProcessor — _detectRoomLanguage Unit Tests
+ *
+ * Architecture Brief:
+ * -------------------
+ * Phase 1 of the STT language custody fix: the room's working language is
+ * detected once at the chokepoint right before voice transcription
+ * (MessageProcessor._detectRoomLanguage) and passed forward to VoiceManager
+ * → SpeachesClient. This file tests that method in isolation.
+ *
+ * Pattern: SIGNALS KEEP CUSTODY (#49/#123/#133 — 4th instance).
+ * The language is derived ONCE from conversationContext.getHistory, then
+ * classified by the LLM (job:'classification'). A structural post-LLM guard
+ * extracts a 2-letter alpha token; no semantic language list is maintained
+ * in code (Dev Rule 1: LLM is the language layer).
+ *
+ * Run: node test/unit/server/message-processor-voice.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const MessageProcessor = require('../../../src/lib/server/message-processor');
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Build a minimal MessageProcessor with controlled deps for _detectRoomLanguage.
+ *
+ * @param {Object} opts
+ * @param {Object|null} opts.conversationContext - Mock conversationContext
+ * @param {Object|null} opts.microPipeline - Mock microPipeline with .router
+ */
+function createProcessor({ conversationContext = null, microPipeline = null } = {}) {
+  return new MessageProcessor({
+    conversationContext,
+    microPipeline,
+    // Minimal required deps so construction succeeds
+    commandHandler: { handle: async () => ({ response: 'ok' }) },
+    sendTalkReply: async () => {},
+    botUsername: 'moltagent',
+    auditLog: async () => {},
+    botNames: ['moltagent']
+  });
+}
+
+/**
+ * Build a mock conversationContext whose getHistory resolves to the given array.
+ */
+function mockConversationContext(history) {
+  return {
+    getHistory: async () => history
+  };
+}
+
+/**
+ * Build a mock conversationContext whose getHistory throws.
+ */
+function mockConversationContextThrows(errMessage = 'Network error') {
+  return {
+    getHistory: async () => { throw new Error(errMessage); }
+  };
+}
+
+/**
+ * Build a mock microPipeline whose router.route resolves to the given raw string.
+ */
+function mockMicroPipeline(rawResult, { throws = false } = {}) {
+  const route = throws
+    ? async () => { throw new Error('LLM unavailable'); }
+    : async () => ({ result: rawResult });
+  return { router: { route } };
+}
+
+// ============================================================
+// Test Cases for _detectRoomLanguage
+// ============================================================
+
+console.log('\n=== MessageProcessor._detectRoomLanguage Tests (Phase 1 STT Language Custody) ===\n');
+
+asyncTest('TC-MP-VL-05: Last assistant message EN → returns "en"', async () => {
+  const history = [
+    { id: 1, role: 'user', content: 'Show me emails', timestamp: 1000 },
+    { id: 2, role: 'assistant', content: 'Here is a summary of the email.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('en')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, 'en', 'should return "en" for English assistant content');
+});
+
+asyncTest('TC-MP-VL-06: Last assistant message DE → returns "de"', async () => {
+  const history = [
+    { id: 1, role: 'user', content: 'Zeig mir E-Mails', timestamp: 1000 },
+    { id: 2, role: 'assistant', content: 'Hier ist eine Zusammenfassung der E-Mail.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('de')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, 'de', 'should return "de" for German assistant content');
+});
+
+asyncTest('TC-MP-VL-07: Last assistant message PT → returns "pt"', async () => {
+  const history = [
+    { id: 1, role: 'user', content: 'Mostra e-mails', timestamp: 1000 },
+    { id: 2, role: 'assistant', content: 'Aqui está um resumo do e-mail.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('pt')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, 'pt', 'should return "pt" for Portuguese assistant content');
+});
+
+asyncTest('TC-MP-VL-08: Empty history → returns null (new room, preserves auto-detect)', async () => {
+  const mp = createProcessor({
+    conversationContext: mockConversationContext([]),
+    microPipeline: mockMicroPipeline('en')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'empty history means no language signal; should fall back to STT auto-detect');
+});
+
+asyncTest('TC-MP-VL-09: conversationContext null → returns null (router NOT called)', async () => {
+  let routeCalled = false;
+  const mp = createProcessor({
+    conversationContext: null,
+    microPipeline: {
+      router: {
+        route: async () => { routeCalled = true; return { result: 'en' }; }
+      }
+    }
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null, 'null conversationContext should return null immediately');
+  assert.strictEqual(routeCalled, false, 'router.route should NOT be called when context is absent');
+});
+
+asyncTest('TC-MP-VL-10: microPipeline null → returns null (cannot call router)', async () => {
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: null
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'absent microPipeline means no router; should return null');
+});
+
+asyncTest('TC-MP-VL-11: router.route throws → returns null (graceful degradation)', async () => {
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline(null, { throws: true })
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'LLM throw should be caught and return null (preserve auto-detect)');
+});
+
+asyncTest('TC-MP-VL-12a: LLM returns bare "en." (trailing punctuation) → "en"', async () => {
+  // Realistic non-bare answer: the model added a period. The anchored guard
+  // accepts a 2-letter code at the start followed by a non-letter.
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('en.\n')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, 'en',
+    'anchored guard should accept a leading 2-letter code trailed by punctuation/whitespace');
+});
+
+asyncTest('TC-MP-VL-12a2: LLM returns a full word "english" → null (fail safe)', async () => {
+  // A full word is NOT a code. The non-letter lookahead rejects it so we fall
+  // through to STT auto-detect rather than emitting a guessed "en".
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('english\n')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'a full word (not a bare 2-letter code) must fall through to auto-detect, not a guessed code');
+});
+
+asyncTest('TC-MP-VL-12b: LLM returns prose "the code is en" → null (fail safe)', async () => {
+  // The dangerous case the anchored guard is designed for: unanchored matching
+  // would extract "th" (Thai) and pass a confidently-wrong hint to Whisper.
+  // The anchored guard rejects prose entirely → null → STT auto-detect.
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('the code is en')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'prose output must fall through to auto-detect, never yield a wrong first-2-letter hint');
+});
+
+asyncTest('TC-MP-VL-12c: LLM returns empty string → returns null', async () => {
+  const history = [
+    { id: 2, role: 'assistant', content: 'Here is a summary.', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'empty LLM response should return null (no 2-letter alpha token found)');
+});
+
+asyncTest('TC-MP-VL-13: Multiple assistant messages → uses the MOST RECENT one', async () => {
+  let capturedContent = null;
+  // First assistant msg is DE, second (most recent) is EN.
+  // The router should receive a prompt containing the EN content.
+  const history = [
+    { id: 1, role: 'user', content: 'Hello', timestamp: 1000 },
+    { id: 2, role: 'assistant', content: 'Guten Tag! Wie kann ich helfen?', timestamp: 2000 },
+    { id: 3, role: 'user', content: 'Switch to English please', timestamp: 3000 },
+    { id: 4, role: 'assistant', content: 'Of course! How can I help you today?', timestamp: 4000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: {
+      router: {
+        route: async (opts) => {
+          capturedContent = opts.content || '';
+          return { result: 'en' };
+        }
+      }
+    }
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, 'en', 'should return language of most recent assistant message');
+  assert.ok(
+    capturedContent.includes('Of course! How can I help you today?'),
+    'prompt should contain the MOST RECENT assistant message content, not an older one'
+  );
+});
+
+asyncTest('TC-MP-VL-14: History has no assistant messages → returns null (no role:assistant)', async () => {
+  const history = [
+    { id: 1, role: 'user', content: 'Hello', timestamp: 1000 },
+    { id: 2, role: 'user', content: 'Are you there?', timestamp: 2000 }
+  ];
+  const mp = createProcessor({
+    conversationContext: mockConversationContext(history),
+    microPipeline: mockMicroPipeline('en')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'history with no assistant messages should return null (new room pattern)');
+});
+
+asyncTest('TC-MP-VL-15: token absent → returns null immediately', async () => {
+  let getHistoryCalled = false;
+  const mp = createProcessor({
+    conversationContext: {
+      getHistory: async () => { getHistoryCalled = true; return []; }
+    },
+    microPipeline: mockMicroPipeline('en')
+  });
+  const result = await mp._detectRoomLanguage(null, 99);
+  assert.strictEqual(result, null, 'null token should return null immediately');
+  assert.strictEqual(getHistoryCalled, false, 'getHistory should NOT be called without a token');
+});
+
+asyncTest('TC-MP-VL-16: getHistory throws → returns null (network resilience)', async () => {
+  const mp = createProcessor({
+    conversationContext: mockConversationContextThrows('Talk API 503'),
+    microPipeline: mockMicroPipeline('en')
+  });
+  const result = await mp._detectRoomLanguage('room-token-abc', 99);
+  assert.strictEqual(result, null,
+    'getHistory throw should be caught and return null (degrade to auto-detect)');
+});
+
+// Summary
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);

--- a/test/unit/voice/voice-manager.test.js
+++ b/test/unit/voice/voice-manager.test.js
@@ -382,6 +382,108 @@ asyncTest('TC-VM-020: Returns false when speachesClient is null', async () => {
   assert.strictEqual(result, false);
 });
 
+// --- Language Custody Tests (Phase 1 — STT hint) ---
+console.log('\n--- Language Custody Tests (Phase 1 STT hint) ---\n');
+
+asyncTest('TC-VM-LC-01: options.language overrides config.language (custody wins)', async () => {
+  let capturedOptions = null;
+  const vm = createVoiceManager({
+    speachesClient: {
+      transcribe: async (buf, opts) => {
+        capturedOptions = opts;
+        return { text: 'Delete this email', confidence: null };
+      },
+      isHealthy: async () => true
+    },
+    config: { language: 'de' }
+  });
+  vm.setMode('listen');
+  const msg = {
+    messageType: 'voice-message',
+    messageParameters: { file: { path: '/audio.ogg', name: 'audio.ogg' } }
+  };
+  await vm.processVoiceMessage(msg, { language: 'en' });
+  assert.ok(capturedOptions !== null, 'transcribe should receive options');
+  assert.strictEqual(capturedOptions.language, 'en',
+    'options.language custody hint should override config.language');
+});
+
+asyncTest('TC-VM-LC-02: config.language used when options.language is absent', async () => {
+  let capturedOptions = null;
+  const vm = createVoiceManager({
+    speachesClient: {
+      transcribe: async (buf, opts) => {
+        capturedOptions = opts;
+        return { text: 'Löschen Sie diese E-Mail', confidence: null };
+      },
+      isHealthy: async () => true
+    },
+    config: { language: 'de' }
+  });
+  vm.setMode('listen');
+  const msg = {
+    messageType: 'voice-message',
+    messageParameters: { file: { path: '/audio.ogg', name: 'audio.ogg' } }
+  };
+  await vm.processVoiceMessage(msg, {});
+  assert.ok(capturedOptions !== null, 'transcribe should receive options');
+  assert.strictEqual(capturedOptions.language, 'de',
+    'config.language should be used when options.language is absent');
+});
+
+asyncTest('TC-VM-LC-03: language is undefined when both options.language and config.language are absent', async () => {
+  let capturedOptions = null;
+  const vm = createVoiceManager({
+    speachesClient: {
+      transcribe: async (buf, opts) => {
+        capturedOptions = opts;
+        return { text: 'Hello', confidence: null };
+      },
+      isHealthy: async () => true
+    },
+    config: {}
+  });
+  vm.setMode('listen');
+  const msg = {
+    messageType: 'voice-message',
+    messageParameters: { file: { path: '/audio.ogg', name: 'audio.ogg' } }
+  };
+  await vm.processVoiceMessage(msg, {});
+  assert.ok(capturedOptions !== null, 'transcribe should receive options');
+  assert.strictEqual(capturedOptions.language, undefined,
+    'language should be undefined (STT auto-detect) when neither hint is available');
+});
+
+asyncTest('TC-VM-LC-04: processVoiceMessage(msg) with no second arg does not throw, language is undefined', async () => {
+  let capturedOptions = null;
+  const vm = createVoiceManager({
+    speachesClient: {
+      transcribe: async (buf, opts) => {
+        capturedOptions = opts;
+        return { text: 'Hello', confidence: null };
+      },
+      isHealthy: async () => true
+    },
+    config: {}
+  });
+  vm.setMode('listen');
+  const msg = {
+    messageType: 'voice-message',
+    messageParameters: { file: { path: '/audio.ogg', name: 'audio.ogg' } }
+  };
+  // Call with NO second argument
+  let threw = false;
+  try {
+    await vm.processVoiceMessage(msg);
+  } catch (_err) {
+    threw = true;
+  }
+  assert.strictEqual(threw, false, 'should not throw when options arg is omitted');
+  assert.ok(capturedOptions !== null, 'transcribe should still receive options');
+  assert.strictEqual(capturedOptions.language, undefined,
+    'language should be undefined when options arg is omitted entirely');
+});
+
 // Summary
 setTimeout(() => {
   summary();


### PR DESCRIPTION
## Why

A voice command in English ("Delete this email") was auto-detected by Whisper as **French** and transcribed as garbled phonetic French, so the agent couldn't act on it. The room's working language is already known — the bot's last reply is a reliable proxy — but that signal was never handed to STT, which re-derived it from scratch and got it wrong on a short utterance.

Fourth instance of **"signals keep custody"** (#49 label, #123 trust, #133 domain verdict): a truth the system already holds is re-derived downstream instead of travelling canonically.

## What

Compute the language **once**, at the chokepoint, and let it travel:

- **`MessageProcessor._detectRoomLanguage(token, excludeMessageId)`** — fetch a lightweight history sample, take the most recent assistant message, ask the fast classifier (`job: 'classification'`) for its ISO 639-1 code. Language detection is the model's job — a declarative prompt with DE/EN/PT examples, no regex or word list. The one post-LLM guard is **structural and anchored** (`/^[a-z]{2}(?![a-z])/`), never semantic: prose and full words fall through to `null` → STT auto-detect (today's behavior preserved on every failure branch).
- **`VoiceManager.processVoiceMessage(message, options)`** — prefer `options.language` over static config, then auto-detect. `SpeachesClient` already accepted the hint; the pipe just carried no water.
- The voice block derives the language once and passes it forward; the history object is **not** threaded into AgentLoop (it re-fetches already).

**Out of scope:** the WhisperClient fallback path (no language param) and a bigger Whisper model — the small model is correct when told the language.

## Phase 2 — referent resolution (verified, not built)

The briefing's verify-first call held. Static data-path trace: a proactive email announcement posts to **Talk** under the bot's own account → mapped to `role:'assistant'` → injected into the LLM prompt within the 2h window. So the "this email" referent **is structurally present** for the immediate-reply scenario the incident describes — Phase 1's transcript fix dissolves the original miss. The 2h `maxMessageAge` filter is a known boundary (delayed replies), not a defect; no issue filed.

## Verification

- **Unit:** 225/225 test files pass (`npm run test:unit`); +15 detection cases (EN/DE/PT + fail-safe on prose/full-word/empty/null-context/router-throw), +4 VoiceManager custody cases. Lint 0 errors.
- **Live (real fast classifier on `[OLLAMA_HOST]`):** the production model returns a bare code `en`/`de`/`pt` deterministically across 15 runs (5 samples × 3, full + short messages); the anchored guard accepts all.
- **Not yet exercised live:** full audio → Speaches → Whisper with a real voice message (needs real audio + the deployed service); the language hint into `transcribe()` is unit-verified plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)