### PR TITLE
fix(soul): reply in the user's language (#172)

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -168,6 +168,7 @@ You operate in different modes that affect your behavior. Your current mode is i
 
 ## Response Style
 
+- **Reply in the user's language.** Always respond in the same language the user wrote in — if they write to you in German, answer in German; in Portuguese, answer in Portuguese; in English, answer in English; and the same for any other language they use. This applies to transcribed voice messages too: the `[Voice transcription]` label and any surrounding system or context text are English metadata, not a cue to answer in English — the user's own words decide the language. If the user switches language mid-conversation, switch with them.
 - Direct and practical
 - Use checkmarks for confirmed actions, X marks for failures, warning symbols for warnings
 - Lists only when showing multiple items


### PR DESCRIPTION
Fixes #172. Prerequisite for #173 (confidence-gated STT reland).

## Problem

Live testing showed the agent answering a **German** voice query in **English**:
*"Was habe ich morgen auf dem Kalender?"* → *"Your calendar is empty tomorrow as well. Nothing scheduled."* A Portuguese query was likewise answered in English. This violates multilingual-by-default (DE/EN/PT).

## Root cause (investigation)

The reply is **LLM-synthesized** (AgentLoop final `chat`), not a template — the German text **is** in the model's input, so it could match it. But:
- **No language-matching directive exists in the loaded prompt.** `config/SOUL.md` mentions "in the user's language" only for error reporting; `config/system-prompt.md` is English-only. `_buildSystemPrompt` never instructs the model to reply in the user's language.
- **English scaffolding primes English:** transcripts are wrapped as `[Voice transcription]: "…"`, alongside an English date header and voice-context block.
- On `trust: cloud-ok`, synthesis runs on **Haiku**, which follows the implicit convention weakly.

## Fix — the LLM is the language layer, so fix the prompt

One directive added to `config/SOUL.md` (the prompt AgentLoop actually loads), leading the `## Response Style` section. It:
- tells the agent to answer in the same language the user wrote in (DE/PT/EN given as examples, generalises to any language — not a closed word-list);
- explicitly marks the `[Voice transcription]` label and surrounding context as English **metadata**, not a cue to answer in English;
- tells it to switch when the user switches language mid-conversation.

No code change — per the dev-rule "prompt updates, not code guards." If DE/PT replies ever drift on Haiku despite the directive, the documented fallback is routing synthesis to Sonnet/Opus; the directive alone proved sufficient in live testing.

## Verification (real Haiku path, on Prime)

Deployed to Prime and sent a German voice calendar query — the exact scenario that previously returned English:

```
Transcribed: "Was habe ich übermorgen auf dem Kalender?"
IntentRouter: Trust=cloud-ok → Haiku;  gate=action domain=calendar conf=0.95
chat_outgoing (smart_mix_cloud:calendar, agent):
  "Deine Kalender ist leer für die nächsten 72 Stunden."   ← German reply ✅
```

Before the fix this same query returned an English reply. PT not yet re-confirmed live but is covered by the same language-agnostic directive.

## Not in scope (separate)

Hardcoded English calendar/deck reply templates (`calendar-executor.js` and siblings) — a real multilingual violation, but on the local-only/MicroPipeline path, not the cause of this incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)