### PR TITLE
fix(email): await per-message parses before resolving _fetchEmails

### DIFF
--- a/src/lib/handlers/email-handler.js
+++ b/src/lib/handlers/email-handler.js
@@ -426,6 +426,13 @@ Examples:
               struct: true
             });
 
+            // Collect a parse promise per message. simpleParser is async, so
+            // without awaiting these the fetch 'end' below resolves before any
+            // parse completes — returning an empty/partial list even when the
+            // search found messages. The EmailMonitor read loop guards the same
+            // way; this mirrors it. (resolve-before-async-parse race)
+            const parsePromises = [];
+
             fetch.on('message', (msg, seqno) => {
               let buffer = '';
               let attrs = null;
@@ -440,32 +447,38 @@ Examples:
                 attrs = a;
               });
 
-              msg.once('end', async () => {
-                try {
-                  const parsed = await simpleParser(buffer);
-                  emails.push({
-                    id: attrs.uid,
-                    seqno,
-                    messageId: parsed.messageId,
-                    from: parsed.from?.text || '',
-                    fromAddress: parsed.from?.value?.[0]?.address || '',
-                    to: parsed.to?.text || '',
-                    subject: parsed.subject || '(No subject)',
-                    date: parsed.date,
-                    snippet: this._getSnippet(parsed.text, 200),
-                    body: parsed.text || '',
-                    hasAttachments: (parsed.attachments?.length || 0) > 0,
-                    attachmentCount: parsed.attachments?.length || 0,
-                    isRead: attrs.flags.includes('\\Seen'),
-                    isStarred: attrs.flags.includes('\\Flagged')
-                  });
-                } catch (e) {
-                  console.error('[Email] Parse error:', e.message);
-                }
+              const parsePromise = new Promise((resolveMsg) => {
+                msg.once('end', async () => {
+                  try {
+                    const parsed = await simpleParser(buffer);
+                    emails.push({
+                      id: attrs.uid,
+                      seqno,
+                      messageId: parsed.messageId,
+                      from: parsed.from?.text || '',
+                      fromAddress: parsed.from?.value?.[0]?.address || '',
+                      to: parsed.to?.text || '',
+                      subject: parsed.subject || '(No subject)',
+                      date: parsed.date,
+                      snippet: this._getSnippet(parsed.text, 200),
+                      body: parsed.text || '',
+                      hasAttachments: (parsed.attachments?.length || 0) > 0,
+                      attachmentCount: parsed.attachments?.length || 0,
+                      isRead: attrs.flags.includes('\\Seen'),
+                      isStarred: attrs.flags.includes('\\Flagged')
+                    });
+                  } catch (e) {
+                    console.error('[Email] Parse error:', e.message);
+                  }
+                  resolveMsg();
+                });
               });
+              parsePromises.push(parsePromise);
             });
 
-            fetch.once('end', () => {
+            fetch.once('end', async () => {
+              // Wait for all in-flight parses before resolving (see parsePromises).
+              await Promise.all(parsePromises);
               imap.end();
               // Sort by date descending
               emails.sort((a, b) => new Date(b.date) - new Date(a.date));

--- a/test/unit/handlers/email-fetch-race.test.js
+++ b/test/unit/handlers/email-fetch-race.test.js
@@ -1,0 +1,109 @@
+/**
+ * EmailHandler._fetchEmails async-ordering regression test
+ *
+ * Reproduces the resolve-before-async-parse race: imap.search finds a message,
+ * but simpleParser is async, so the fetch stream's 'end' event can fire and
+ * resolve the promise before any per-message parse completes. The pre-fix code
+ * resolved with an empty list even though the message existed.
+ *
+ * This test does NOT mock _fetchEmails — it mocks the `imap` and `mailparser`
+ * modules underneath it and drives the real event sequence, with the parse
+ * resolving on a later tick (setImmediate). It MUST fail against the pre-fix
+ * code (result length 0) and pass only with the Promise.all(parsePromises)
+ * guard in place.
+ *
+ * Run: node test/unit/handlers/email-fetch-race.test.js
+ */
+
+'use strict';
+
+// config.js requires NC_URL; supply a harmless test default (mirrors run-all-tests).
+process.env.NC_URL = process.env.NC_URL || 'https://test.example.com';
+process.env.NC_USER = process.env.NC_USER || 'tester';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const util = require('util');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+// --- Fake `imap` module: drives the racey event order -----------------------
+// connect -> ready -> openBox -> search([1]) -> fetch:
+//   emit 'message' (handlers attach), then body/data/attributes/end on the msg,
+//   then fetch 'end' SYNCHRONOUSLY after msg 'end'. The msg 'end' handler awaits
+//   the async parser, so on pre-fix code fetch 'end' wins and resolves empty.
+const RAW = [
+  'Message-ID: <race-test@moltagent.test>',
+  'From: Sender <sender@example.com>',
+  'To: <tester@example.com>',
+  'Subject: Race Test',
+  '',
+  'body text'
+].join('\r\n');
+
+function FakeImap() { EventEmitter.call(this); }
+util.inherits(FakeImap, EventEmitter);
+FakeImap.prototype.connect = function () { process.nextTick(() => this.emit('ready')); };
+FakeImap.prototype.end = function () { /* no-op */ };
+FakeImap.prototype.openBox = function (folder, readonly, cb) { cb(null, { messages: { total: 1 } }); };
+FakeImap.prototype.search = function (criteria, cb) { cb(null, [1]); };
+FakeImap.prototype.fetch = function () {
+  const fetchEmitter = new EventEmitter();
+  process.nextTick(() => {
+    const msg = new EventEmitter();
+    fetchEmitter.emit('message', msg, 1); // attaches body/attributes/end listeners
+    const stream = new EventEmitter();
+    msg.emit('body', stream);             // attaches stream 'data' listener
+    stream.emit('data', Buffer.from(RAW));
+    msg.emit('attributes', { uid: 1, flags: [] });
+    msg.emit('end');                      // starts the async simpleParser await
+    fetchEmitter.emit('end');             // races ahead of the parse
+  });
+  return fetchEmitter;
+};
+
+// --- Fake `mailparser`: parse resolves ASYNCHRONOUSLY (later macrotask) ------
+async function fakeSimpleParser() {
+  await new Promise((r) => setImmediate(r)); // defer — this is what hid the bug
+  return {
+    messageId: '<race-test@moltagent.test>',
+    from: { text: 'Sender <sender@example.com>', value: [{ address: 'sender@example.com' }] },
+    to: { text: '<tester@example.com>' },
+    subject: 'Race Test',
+    date: new Date('2026-06-17T10:00:00Z'),
+    text: 'body text',
+    attachments: []
+  };
+}
+
+// Inject the fakes into require.cache BEFORE requiring EmailHandler.
+const imapPath = require.resolve('imap');
+require.cache[imapPath] = { id: imapPath, filename: imapPath, loaded: true, exports: FakeImap };
+const mpPath = require.resolve('mailparser');
+require.cache[mpPath] = { id: mpPath, filename: mpPath, loaded: true, exports: { simpleParser: fakeSimpleParser } };
+
+const EmailHandler = require('../../../src/lib/handlers/email-handler');
+
+console.log('\n=== EmailHandler _fetchEmails async-ordering race ===\n');
+
+function makeHandler() {
+  const broker = { get: async () => ({ host: 'imap.test', port: 993, username: 'tester', password: 'pw', tls: true }) };
+  return new EmailHandler(broker, null, () => {});
+}
+
+asyncTest('TC-RACE-01: _fetchEmails awaits async parse before resolving (unreadOnly)', async () => {
+  const handler = makeHandler();
+  const emails = await handler._fetchEmails({ folder: 'INBOX.INQUIRIES', unreadOnly: true, limit: 50 });
+  assert.strictEqual(emails.length, 1, 'expected the searched message to survive the async parse (pre-fix returns 0)');
+  assert.strictEqual(emails[0].messageId, '<race-test@moltagent.test>');
+  assert.strictEqual(emails[0].subject, 'Race Test');
+  assert.strictEqual(emails[0].isRead, false);
+});
+
+asyncTest('TC-RACE-02: _fetchEmails returns the parsed message for ALL search too', async () => {
+  const handler = makeHandler();
+  const emails = await handler._fetchEmails({ folder: 'INBOX', unreadOnly: false, limit: 50 });
+  assert.strictEqual(emails.length, 1);
+  assert.strictEqual(emails[0].messageId, '<race-test@moltagent.test>');
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Problem

`EmailHandler._fetchEmails` resolved on the fetch stream's `'end'` event while each message was parsed in an **async** `simpleParser` handler. The `fetch 'end'` fires before those parses complete, so the promise resolved with an **empty (or partial) list even when the IMAP search found unread mail**.

Impact: the email-trigger workflow bridge (#170) could not ingest. A folder with unread mail produced **zero cards**. #170's own tests ran against a mailbox with zero unread, so this read path was never exercised — the bug was latent until a real unread email was put through it.

## Analysis (generator, not instance)

The shape is *resolve-before-async-parse*. A sibling scan found it in two IMAP read loops:

- `EmailMonitor` (`email-monitor.js`) — **already correct**: collects `parsePromises` and `await Promise.all(parsePromises)` before resolving.
- `EmailHandler._fetchEmails` — the **lagging copy** without the guard.

`_fetchEmails` is the single read path for every `EmailHandler` reader (inbox/search/summary/etc. and the workflow trigger bridge), so one fix covers all readers. The fix mirrors the proven `EmailMonitor` shape rather than inventing a new one.

## Fix

Collect a parse promise per message; `await Promise.all(parsePromises)` in `fetch 'end'` before sorting/resolving.

## Test

`test/unit/handlers/email-fetch-race.test.js` mocks `imap` + `mailparser` and drives the real event order with the parse resolving on a **later tick** (`setImmediate`). It asserts the searched message survives:

- pre-fix → resolves `0` emails → **test fails**
- post-fix → resolves `1` email → **test passes**

A synchronous mock would have hidden the bug, so the test reproduces the async ordering rather than mocking it away.

## Verification

- `npm run lint` → 0 errors
- `npm run test:unit` → **225/225 test files pass** (incl. the new race test; email-handler, email-trigger-bridge, email-monitor suites green)
- **Live on Prime** (real Deck + real mailbox + real WorkflowEngine, board PAUSED throughout, ingestion stage run directly so no downstream processing):
  - one unread test inquiry in `INBOX.INQUIRIES` → `_ingestTriggerEmails` created exactly **1 card** carrying the `Message-ID` footer (pre-fix: 0)
  - `Message-ID` recorded in `workflow-ingested-emails.json` under the board key
  - test email `\Seen` flag **unchanged** (read-only ingestion)
  - board-level PAUSED gate confirmed (`_processBoard` while PAUSED ingests 0)

Co-authored-by: moltagent <github@moltagent.cloud>

🤖 Generated with [Claude Code](https://claude.com/claude-code)