### PR TITLE
fix(nc-request): keep custody of HTTP status on 401/403/429 rejections

### DIFF
--- a/src/lib/integrations/deck-client.js
+++ b/src/lib/integrations/deck-client.js
@@ -408,8 +408,13 @@ class DeckClient {
         try {
           return await this.getBoard(boardId);
         } catch (err) {
-          // Board was deleted — invalidate and fall through to name scan
-          if (err.statusCode === 404) {
+          // A cached id can become unusable two ways: the board was deleted
+          // (404), or it is no longer reachable by this identity (403,
+          // "Permission denied" — a board recreated under a new id, trashed,
+          // or unshared). Both mean the registry entry is stale: invalidate
+          // and re-resolve by name scan. Other errors (instance-wide auth
+          // failure, 5xx) are real and propagate.
+          if (err.statusCode === 404 || err.statusCode === 403) {
             boardRegistry.invalidateBoard(this.role);
           } else {
             throw err;

--- a/src/lib/nc-request-manager.js
+++ b/src/lib/nc-request-manager.js
@@ -536,14 +536,18 @@ class NCRequestManager {
 
         // Max retries exceeded
         this.metrics.failures++;
-        reject(new Error(`Rate limited after ${requestItem.retryCount} retries`));
+        const err = new Error(`Rate limited after ${requestItem.retryCount} retries`);
+        err.statusCode = 429;   // signal keeps custody
+        reject(err);
         return;
       }
 
       // Handle auth errors - NEVER retry 401/403
       if (response.status === 401 || response.status === 403) {
         this.metrics.failures++;
-        reject(new Error(`Authentication error: ${response.status}`));
+        const err = new Error(`Authentication error: ${response.status}`);
+        err.statusCode = response.status;   // signal keeps custody (#49/#123/#133 class)
+        reject(err);
         return;
       }
 

--- a/test/unit/integrations/deck-registry-403-selfheal.test.js
+++ b/test/unit/integrations/deck-registry-403-selfheal.test.js
@@ -99,10 +99,28 @@ function makeMockNC({ listBoards, getBoard } = {}) {
   };
 }
 
-/** Create an error with an HTTP status code, as DeckClient._request produces */
+/**
+ * Create a generic HTTP error (matches DeckApiError / NCRequestManager 4xx/5xx shape).
+ * Used for non-auth errors (404, 500, 503) where the message varies.
+ */
 function makeHttpError(statusCode, message) {
   const err = new Error(message || `HTTP ${statusCode}`);
   err.statusCode = statusCode;
+  return err;
+}
+
+/**
+ * Create an auth error that EXACTLY mirrors NCRequestManager's rejection shape
+ * after the status-custody fix: message is "Authentication error: <status>"
+ * and .statusCode is set.  This is the single source of truth — if the
+ * chokepoint message ever changes, update here only.
+ *
+ * 403: nc.request() rejects → propagates through DeckClient._request (no wrapping)
+ *      → reaches findBoard()'s catch with this exact shape.
+ */
+function makeNcAuthError(status) {
+  const err = new Error(`Authentication error: ${status}`);
+  err.statusCode = status;
   return err;
 }
 
@@ -146,8 +164,8 @@ asyncTest('TC-403-002: 403 from getBoard() invalidates registry and falls throug
   boardRegistry.registerBoard(role, 99);
 
   const nc = makeMockNC({
-    // 403 — simulates a stale id (board recreated, trashed, or unshared)
-    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    // 403 — mirrors exact NCRequestManager rejection shape after custody fix
+    getBoard: () => { throw makeNcAuthError(403); },
     listBoards: () => ({ status: 200, body: [], headers: {} })
   });
 
@@ -203,7 +221,7 @@ asyncTest('TC-403-004: 403 fall-through + matching board in listBoards → retur
   boardRegistry.registerBoard(role, 200); // stale id
 
   const nc = makeMockNC({
-    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    getBoard: () => { throw makeNcAuthError(403); },
     listBoards: () => ({
       status: 200,
       body: [
@@ -236,7 +254,7 @@ asyncTest('TC-403-005: 403 fall-through + no match in listBoards → returns nul
   boardRegistry.registerBoard(role, 300);
 
   const nc = makeMockNC({
-    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    getBoard: () => { throw makeNcAuthError(403); },
     listBoards: () => ({
       status: 200,
       body: [

--- a/test/unit/integrations/deck-registry-403-selfheal.test.js
+++ b/test/unit/integrations/deck-registry-403-selfheal.test.js
@@ -1,0 +1,297 @@
+/**
+ * Moltagent - DeckClient.findBoard() 403 self-heal tests
+ *
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: A board cached in the registry under a given role can become
+ * unreachable for two distinct reasons: the board was deleted (404) or the
+ * identity no longer has access (403 — board recreated with a new id, trashed,
+ * or unshared). In both cases the registry entry is stale and must be
+ * invalidated so findBoard() can re-resolve by name scan.
+ *
+ * These tests verify:
+ * 1. 404 from getBoard() still invalidates and falls through (regression guard)
+ * 2. 403 from getBoard() now also invalidates and falls through (new behavior)
+ * 3. 500 from getBoard() is re-thrown; invalidateBoard is NOT called
+ * 4. After a 403 fall-through, a matching board in listBoards is returned and
+ *    registerBoard is called with the new id (cockpit heal shape)
+ * 5. After a 403 fall-through, an empty listBoards returns null (knowledge
+ *    shape; ensureBoard then creates the board)
+ * 6. ensureBoard() listBoards rejection propagates; createBoard is NOT called
+ *    (proves create-on-confirmed-absence without a new guard)
+ *
+ * Isolation note: boardRegistry is a module singleton. A single _reset()
+ * call at module load puts it in test-mode (no disk writes, empty cache).
+ * Each test uses a globally unique role string; tests do NOT call _reset()
+ * themselves so they cannot wipe each other's seeded entries, even when
+ * asyncTests execute concurrently.
+ *
+ * Run: NC_URL=https://test.example.com node test/unit/integrations/deck-registry-403-selfheal.test.js
+ *
+ * @module test/unit/integrations/deck-registry-403-selfheal
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const DeckClient = require('../../../src/lib/integrations/deck-client');
+const boardRegistry = require('../../../src/lib/integrations/deck-board-registry');
+
+// Single reset at module load — puts registry in test mode (no disk I/O),
+// empty cache. Individual tests do NOT reset; each uses a unique role string.
+boardRegistry._reset();
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Build a minimal NC mock that covers the two paths exercised by findBoard():
+ *   - GET /boards          (listBoards)
+ *   - GET /boards/<id>     (getBoard)
+ *
+ * Each handler can be a function (receives path, options) or a plain object.
+ * A missing handler falls through to a safe 200 default.
+ */
+function makeMockNC({ listBoards, getBoard } = {}) {
+  return {
+    ncUrl: 'https://cloud.example.com',
+    ncUser: 'testuser',
+    request: async (path, options = {}) => {
+      const method = options.method || 'GET';
+
+      // GET /index.php/apps/deck/api/v1.0/boards  (list all boards)
+      if (method === 'GET' && path === '/index.php/apps/deck/api/v1.0/boards') {
+        if (typeof listBoards === 'function') return listBoards(path, options);
+        if (listBoards !== undefined) return listBoards;
+        return { status: 200, body: [], headers: {} };
+      }
+
+      // GET /index.php/apps/deck/api/v1.0/boards/<id>  (single board)
+      if (method === 'GET' && /^\/index\.php\/apps\/deck\/api\/v1\.0\/boards\/\d+$/.test(path)) {
+        if (typeof getBoard === 'function') return getBoard(path, options);
+        if (getBoard !== undefined) return getBoard;
+        return { status: 200, body: {}, headers: {} };
+      }
+
+      return { status: 200, body: {}, headers: {} };
+    },
+    getMetrics: () => ({}),
+    invalidateCache: () => {},
+    shutdown: async () => {}
+  };
+}
+
+/** Create an error with an HTTP status code, as DeckClient._request produces */
+function makeHttpError(statusCode, message) {
+  const err = new Error(message || `HTTP ${statusCode}`);
+  err.statusCode = statusCode;
+  return err;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+console.log('\n=== DeckClient findBoard() 403 self-heal tests ===\n');
+
+// ---------------------------------------------------------------------------
+// TC-403-001: 404 from getBoard() invalidates and falls through (regression)
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-001: 404 from getBoard() invalidates registry and falls through to name scan', async () => {
+  const role = 'tc403001-tasks';
+  boardRegistry.registerBoard(role, 42);
+
+  const nc = makeMockNC({
+    // 404 — simulates a board that was deleted
+    getBoard: () => { throw makeHttpError(404, 'Not Found'); },
+    // name scan returns empty — findBoard returns null after invalidation
+    listBoards: () => ({ status: 200, body: [], headers: {} })
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Tasks' });
+  const result = await client.findBoard();
+
+  // The registry entry must have been removed by invalidateBoard()
+  const all = boardRegistry.getAll();
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(all, role),
+    'registry entry must be removed after 404'
+  );
+  assert.strictEqual(result, null, 'findBoard returns null when name scan yields nothing');
+});
+
+// ---------------------------------------------------------------------------
+// TC-403-002: 403 from getBoard() invalidates and falls through (new behavior)
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-002: 403 from getBoard() invalidates registry and falls through to name scan', async () => {
+  const role = 'tc403002-tasks';
+  boardRegistry.registerBoard(role, 99);
+
+  const nc = makeMockNC({
+    // 403 — simulates a stale id (board recreated, trashed, or unshared)
+    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    listBoards: () => ({ status: 200, body: [], headers: {} })
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Tasks' });
+  const result = await client.findBoard();
+
+  const all = boardRegistry.getAll();
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(all, role),
+    'registry entry must be removed after 403'
+  );
+  assert.strictEqual(result, null, 'findBoard returns null when name scan yields nothing');
+});
+
+// ---------------------------------------------------------------------------
+// TC-403-003: 500 from getBoard() re-throws; registry entry is preserved
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-003: 500 from getBoard() re-throws; invalidateBoard is NOT called', async () => {
+  const role = 'tc403003-tasks';
+  boardRegistry.registerBoard(role, 77);
+
+  const nc = makeMockNC({
+    // 500 must propagate — it is a real server error, not a stale-id signal
+    getBoard: () => { throw makeHttpError(500, 'Internal Server Error'); }
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Tasks' });
+
+  let thrownError = null;
+  try {
+    await client.findBoard();
+  } catch (err) {
+    thrownError = err;
+  }
+
+  assert.ok(thrownError !== null, 'findBoard must re-throw on 500');
+  assert.strictEqual(thrownError.statusCode, 500, 'thrown error must preserve statusCode 500');
+
+  // Registry entry must still be present — invalidateBoard must NOT have fired
+  const all = boardRegistry.getAll();
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(all, role),
+    'registry entry must remain intact after a 500 (no invalidation)'
+  );
+  assert.strictEqual(all[role].boardId, 77, 'cached boardId must still be 77');
+});
+
+// ---------------------------------------------------------------------------
+// TC-403-004: 403 fall-through, name scan finds board → return & re-register
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-004: 403 fall-through + matching board in listBoards → returns board, registerBoard called', async () => {
+  const role = 'tc403004-cockpit';
+  boardRegistry.registerBoard(role, 200); // stale id
+
+  const nc = makeMockNC({
+    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    listBoards: () => ({
+      status: 200,
+      body: [
+        { id: 201, title: 'Moltagent Cockpit', stacks: [], labels: [] }
+      ],
+      headers: {}
+    })
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Cockpit' });
+  const result = await client.findBoard();
+
+  assert.ok(result !== null, 'findBoard must return the discovered board');
+  assert.strictEqual(result.id, 201, 'board id must be 201 from the name scan');
+
+  // registerBoard must have been called with the new id
+  const all = boardRegistry.getAll();
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(all, role),
+    'role must be re-registered after name scan'
+  );
+  assert.strictEqual(all[role].boardId, 201, 'registered boardId must be the new id 201');
+});
+
+// ---------------------------------------------------------------------------
+// TC-403-005: 403 fall-through, name scan finds no match → null
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-005: 403 fall-through + no match in listBoards → returns null', async () => {
+  const role = 'tc403005-knowledge';
+  boardRegistry.registerBoard(role, 300);
+
+  const nc = makeMockNC({
+    getBoard: () => { throw makeHttpError(403, 'Permission denied'); },
+    listBoards: () => ({
+      status: 200,
+      body: [
+        { id: 999, title: 'Unrelated Board', stacks: [], labels: [] }
+      ],
+      headers: {}
+    })
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Knowledge' });
+  const result = await client.findBoard();
+
+  assert.strictEqual(result, null, 'findBoard must return null when no title matches');
+});
+
+// ---------------------------------------------------------------------------
+// TC-403-006: ensureBoard() listBoards rejection propagates; createBoard NOT called
+// ---------------------------------------------------------------------------
+asyncTest('TC-403-006: ensureBoard() listBoards rejection propagates; createBoard is NOT called', async () => {
+  // No registry entry for this role — findBoard goes straight to listBoards
+  const role = 'tc403006-tasks';
+
+  let createBoardCalled = false;
+
+  const nc = makeMockNC({
+    // listBoards throws — simulates an instance-wide failure (e.g. auth down)
+    listBoards: () => { throw makeHttpError(503, 'Service Unavailable'); }
+  });
+
+  const client = new DeckClient(nc, { role, boardName: 'Moltagent Tasks' });
+
+  // Spy on createBoard to confirm it is never called
+  const origCreateBoard = client.createBoard.bind(client);
+  client.createBoard = async (...args) => {
+    createBoardCalled = true;
+    return origCreateBoard(...args);
+  };
+
+  let thrownError = null;
+  try {
+    await client.ensureBoard();
+  } catch (err) {
+    thrownError = err;
+  }
+
+  assert.ok(thrownError !== null, 'ensureBoard must propagate the listBoards error');
+  assert.strictEqual(thrownError.statusCode, 503, 'error statusCode must be 503');
+  assert.strictEqual(createBoardCalled, false, 'createBoard must NOT be called when listBoards rejects');
+});
+
+// ============================================================
+// Summary
+// ============================================================
+
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);

--- a/test/unit/nc-request-status-custody.test.js
+++ b/test/unit/nc-request-status-custody.test.js
@@ -1,0 +1,224 @@
+/**
+ * Moltagent - NCRequestManager HTTP status custody tests
+ *
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Architecture Brief:
+ * -------------------
+ * Verifies the status-custody invariant: every rejection caused by a non-2xx
+ * HTTP status carries .statusCode equal to that status.  Without this, the
+ * findBoard() 403-self-heal branch (err.statusCode === 403) can never fire in
+ * production even though the branch exists in the code (#49/#123/#133 class:
+ * signals keep custody).
+ *
+ * Seam: _httpRequest is overridden on the instance to return a synthetic
+ * {status, statusText, headers, body} response, bypassing the real network
+ * layer entirely.  maxRetries is set to 0 so 429 exhausts immediately.
+ *
+ * Run: NC_URL=https://test.example.com node test/unit/nc-request-status-custody.test.js
+ *
+ * @module test/unit/nc-request-status-custody
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../helpers/test-runner');
+
+// Stub fs.readFileSync so NCRequestManager can load without a real credential
+// file, matching the idiom in the sibling nc-request-manager.test.js file.
+const originalReadFileSync = require('fs').readFileSync;
+require('fs').readFileSync = function(filePath, encoding) {
+  if (typeof filePath === 'string' && filePath.includes('nc-password')) {
+    return 'test-password';
+  }
+  return originalReadFileSync.call(this, filePath, encoding);
+};
+
+const NCRequestManager = require('../../src/lib/nc-request-manager');
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * Build a minimal NCRequestManager instance with:
+ *   - maxRetries = 0 so 429 exhausts on the very first attempt (no re-queue)
+ *   - defaultRetryAfter = 0 so no sleep between attempts
+ *   - _httpRequest stubbed to return the supplied synthetic response
+ *   - _getGroupConfig patched so per-request maxRetries is also 0
+ *     (the per-group config overrides ncResilience.maxRetries in production)
+ *
+ * @param {{ status, statusText?, headers?, body? }} syntheticResponse
+ */
+function makeNcWithStub(syntheticResponse) {
+  const nc = new NCRequestManager({
+    nextcloud: { url: 'https://test.example.com', username: 'testuser' },
+    ncResilience: { maxRetries: 0, defaultRetryAfter: 0 }
+  });
+  nc.ncPassword = 'test-password';
+
+  // Patch per-group config so maxRetries=0 is honoured at the request level too.
+  const origGetGroupConfig = nc._getGroupConfig.bind(nc);
+  nc._getGroupConfig = (group) => {
+    const cfg = origGetGroupConfig(group);
+    return { ...cfg, maxRetries: 0 };
+  };
+
+  // Override _httpRequest at the instance level — the only transport seam.
+  nc._httpRequest = async () => ({
+    status: syntheticResponse.status,
+    statusText: syntheticResponse.statusText || String(syntheticResponse.status),
+    headers: syntheticResponse.headers || {},
+    body: syntheticResponse.body || ''
+  });
+
+  return nc;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+console.log('\n=== NCRequestManager HTTP status-custody tests ===\n');
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-01: 401 rejection carries .statusCode === 401
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-01: request() rejects with .statusCode=401 on 401 response', async () => {
+  const nc = makeNcWithStub({ status: 401 });
+
+  let caughtErr = null;
+  try {
+    await nc.request('/index.php/apps/deck/api/v1.0/boards', { method: 'GET' });
+  } catch (err) {
+    caughtErr = err;
+  }
+
+  assert.ok(caughtErr !== null, 'request() must reject on 401');
+  assert.strictEqual(caughtErr.statusCode, 401,
+    `expected .statusCode=401, got ${caughtErr.statusCode}`);
+  assert.strictEqual(caughtErr.message, 'Authentication error: 401',
+    `message must be "Authentication error: 401", got "${caughtErr.message}"`);
+});
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-02: 403 rejection carries .statusCode === 403
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-02: request() rejects with .statusCode=403 on 403 response', async () => {
+  const nc = makeNcWithStub({ status: 403 });
+
+  let caughtErr = null;
+  try {
+    await nc.request('/index.php/apps/deck/api/v1.0/boards/99', { method: 'GET' });
+  } catch (err) {
+    caughtErr = err;
+  }
+
+  assert.ok(caughtErr !== null, 'request() must reject on 403');
+  assert.strictEqual(caughtErr.statusCode, 403,
+    `expected .statusCode=403, got ${caughtErr.statusCode}`);
+  assert.strictEqual(caughtErr.message, 'Authentication error: 403',
+    `message must be "Authentication error: 403", got "${caughtErr.message}"`);
+});
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-03: 429 rejection carries .statusCode === 429 (maxRetries exhausted)
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-03: request() rejects with .statusCode=429 after maxRetries exhausted', async () => {
+  const nc = makeNcWithStub({ status: 429, headers: {} });
+
+  let caughtErr = null;
+  try {
+    await nc.request('/ocs/v2.php/apps/spreed/api/v1/chat/room', { method: 'GET' });
+  } catch (err) {
+    caughtErr = err;
+  }
+
+  assert.ok(caughtErr !== null, 'request() must reject when 429 maxRetries exhausted');
+  assert.strictEqual(caughtErr.statusCode, 429,
+    `expected .statusCode=429, got ${caughtErr.statusCode}`);
+  // Message must start with "Rate limited after" — the unchanged text that
+  // existing consumers may parse.
+  assert.ok(
+    caughtErr.message.startsWith('Rate limited after'),
+    `message must start with "Rate limited after", got "${caughtErr.message}"`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-04: message strings are UNCHANGED (protects regex consumers)
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-04: 401 message string is exactly "Authentication error: 401"', async () => {
+  const nc = makeNcWithStub({ status: 401 });
+  let msg = null;
+  try {
+    await nc.request('/ocs/v2.php/test', { method: 'GET' });
+  } catch (err) {
+    msg = err.message;
+  }
+  assert.strictEqual(msg, 'Authentication error: 401');
+});
+
+asyncTest('TC-STATUS-05: 403 message string is exactly "Authentication error: 403"', async () => {
+  const nc = makeNcWithStub({ status: 403 });
+  let msg = null;
+  try {
+    await nc.request('/ocs/v2.php/test', { method: 'GET' });
+  } catch (err) {
+    msg = err.message;
+  }
+  assert.strictEqual(msg, 'Authentication error: 403');
+});
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-06: 404 resolves (not rejects) — regression guard
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-06: 404 resolves normally (not rejected) so callers can inspect status', async () => {
+  const nc = makeNcWithStub({ status: 404, body: 'Not Found' });
+
+  const response = await nc.request('/index.php/apps/deck/api/v1.0/boards/999', { method: 'GET' });
+  assert.strictEqual(response.status, 404, 'resolved response.status must be 404');
+  assert.strictEqual(response.fromCache, false);
+});
+
+// ---------------------------------------------------------------------------
+// TC-STATUS-07: pre-existing ~line 584 pattern still works (5xx)
+// ---------------------------------------------------------------------------
+asyncTest('TC-STATUS-07: 500 rejection carries .statusCode=500 (pre-existing pattern regression guard)', async () => {
+  // maxRetries=0 so 500 doesn't retry
+  const nc = makeNcWithStub({ status: 500, statusText: 'Internal Server Error', body: 'boom' });
+
+  let caughtErr = null;
+  try {
+    await nc.request('/index.php/apps/deck/api/v1.0/boards', { method: 'GET' });
+  } catch (err) {
+    caughtErr = err;
+  }
+
+  assert.ok(caughtErr !== null, 'request() must reject on 500');
+  assert.strictEqual(caughtErr.statusCode, 500,
+    `expected .statusCode=500, got ${caughtErr.statusCode}`);
+});
+
+// ============================================================
+// Summary
+// ============================================================
+
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);


### PR DESCRIPTION
## Why

A dangling Deck board-registry pointer (`knowledge → <stale id>`) returned HTTP 403, but the board-registry 403 self-heal added in the prior commit was **inert in production**: `NCRequestManager` rejected 401/403 with a bare `Error("Authentication error: <status>")` carrying no `.statusCode`, so `findBoard`'s `err.statusCode === 403` branch evaluated `undefined === 403` and re-threw. The knowledge verification board stayed dark and re-failed on every heartbeat pulse.

The Verification Gate on the first attempt caught this: green tests (which mocked a `{statusCode:403}` shape production never emits) over a subsystem that was still failing live — the WikiSteward green-but-hollow class, reproduced.

## Root cause (one layer up)

The chokepoint every NC call passes through flattened the HTTP status into a **message string** for 401/403 and 429, destroying the signal. Downstream consumers then coped by re-parsing it with regex (`cockpit-manager`, `bot-enroller`) or went blind (`findBoard`). That re-derivation of a once-known truth is the **signals-keep-custody** class (#49 / #123 / #133).

## The fix

Restore custody at the chokepoint: the 401/403 and 429 rejections in `nc-request-manager.js` now attach `.statusCode`, matching the HTTP-error (`>=400`) path that already did. **Message strings are byte-for-byte unchanged**, so the existing regex consumers keep working untouched — their removal is a deliberate fast-follow once production confirms `.statusCode` lands. With the status now travelling on the error, `findBoard`'s existing 404/403 branch fires as intended and the knowledge board self-heals on the next pulse (invalidate → name scan → `ensureBoard` creates a fresh board). Create-on-confirmed-absence stays structural; no guard added.

Audit of the chokepoint's reject surface: two sites flattened status (auth 401/403, rate-limit 429); one already carried it (HTTP `>=400`); the rest are transport/queue/timeout/shutdown and correctly carry no HTTP status.

## Tests (pinned to the real chokepoint shape)

- **New** `nc-request-status-custody.test.js`: drives a real `NCRequestManager` with the transport layer stubbed; asserts 401/403/429 reject with `.statusCode` **and** an unchanged message (the message assertion protects the regex consumers). Adversarially confirmed bound to the fix — reverting the `.statusCode` attachment makes exactly these cases fail.
- `deck-registry-403-selfheal.test.js` refactored to a shared helper mirroring the chokepoint error contract instead of a hand-built literal.
- Full suite **232/232**, lint 0 errors.

## Verification Gate (live on Prime)

- `npm run lint` → exit 0; `npm test` → 232/232; status-custody test → 7/7 (real reject path).
- Deployed + restarted. Boot showed `[Deck] Creating board: Moltagent Knowledge` → `[KnowledgeBoard] Board ready (ID: <n>)` → `[Heartbeat] Knowledge board initialized`, with **no** `Failed to initialize board` / `Knowledge board initialization failed`.
- Registry `knowledge`: stale id → new id. Old dangling id → still HTTP 403; new id → HTTP 200 (title "Moltagent Knowledge"). Heal persists after restoring the box to `next` (registry now points at a valid board).

## Fast-follow (separate PR, after production confirmation)

Delete the `/Authentication error:\s*(\d{3})/` re-parse in `cockpit-manager.js` (#141) and `bot-enroller.js`, and the documenting note in `nc-files-client.js`, replacing them with a read of `err.statusCode`. That PR is the net deletion that closes the class.

## Out of scope

No retry shim, no active reconciler, no duplicate-title fix, no readiness/observability change, no removal of the still-working regex consumers here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)