### PR TITLE
refactor(nc): drop status-code regex re-derivation now that .statusCode lands

### DIFF
--- a/src/lib/integrations/bot-enroller.js
+++ b/src/lib/integrations/bot-enroller.js
@@ -91,7 +91,7 @@ class BotEnroller {
       }
       return { enrolled };
     } catch (err) {
-      const statusCode = this._extractStatusCode(err);
+      const statusCode = err?.statusCode;
       this._enrolledRooms.add(roomToken); // Don't retry
       if (statusCode === 403 || statusCode === 400) {
         // Expected: not moderator or bot already active
@@ -157,8 +157,7 @@ class BotEnroller {
           results.skipped++;
         }
       } catch (err) {
-        // Parse HTTP status from NCRequestManager error messages
-        const statusCode = this._extractStatusCode(err);
+        const statusCode = err?.statusCode;
 
         if (statusCode === 400 || statusCode === 403) {
           // 400 = bot already enabled or not available
@@ -287,27 +286,6 @@ class BotEnroller {
       // Can't list bots in this room -- likely not moderator
     }
     return false;
-  }
-
-  /**
-   * Extract HTTP status code from NCRequestManager error messages.
-   * NCRequestManager rejects with Error messages like:
-   * - "Authentication error: 403"
-   * - "HTTP 400: Bad Request"
-   *
-   * @param {Error} err
-   * @returns {number|null} HTTP status code or null
-   * @private
-   */
-  _extractStatusCode(err) {
-    if (!err || !err.message) return null;
-    // Match "Authentication error: 403" or "Authentication error: 401"
-    const authMatch = err.message.match(/Authentication error:\s*(\d{3})/);
-    if (authMatch) return parseInt(authMatch[1], 10);
-    // Match "HTTP 400: ..."
-    const httpMatch = err.message.match(/HTTP\s+(\d{3})/);
-    if (httpMatch) return parseInt(httpMatch[1], 10);
-    return null;
   }
 
   /**

--- a/src/lib/integrations/cockpit-manager.js
+++ b/src/lib/integrations/cockpit-manager.js
@@ -328,10 +328,11 @@ class CockpitManager {
         try {
           board = await this.deck.getBoard(boardId);
         } catch (err) {
-          if (err.statusCode === 404 || err.statusCode === 403 ||
-              /Authentication error:\s*(401|403)/.test(err.message)) {
+          if (err.statusCode === 404 || err.statusCode === 403) {
             // Stale or forbidden registry entry — clear it and fall through to
-            // the self-heal below (treat exactly like a missing entry).
+            // the self-heal below (treat exactly like a missing entry). The
+            // status now travels on the error (#176), so this matches the
+            // canonical findBoard contract; instance-wide 401 propagates.
             this.boardRegistry.invalidateBoard(ROLES.cockpit);
             boardId = null;
           } else {

--- a/src/lib/integrations/nc-files-client.js
+++ b/src/lib/integrations/nc-files-client.js
@@ -81,16 +81,13 @@ class NCFilesClient {
       // Already an NCFilesError
       if (err instanceof NCFilesError) throw err;
 
-      // NCRequestManager rejects on 403 with "Authentication error: 403"
-      const statusMatch = err.message && err.message.match(/(\d{3})/);
-      if (statusMatch) {
-        const code = parseInt(statusMatch[1], 10);
-        if (code === 403) {
-          throw new NCFilesError('Permission denied', 403);
-        }
-        if (code === 401) {
-          throw new NCFilesError('Authentication failed', 401);
-        }
+      // The chokepoint carries the HTTP status on the error (#176), so read it
+      // directly rather than re-deriving it from the message.
+      if (err?.statusCode === 403) {
+        throw new NCFilesError('Permission denied', 403);
+      }
+      if (err?.statusCode === 401) {
+        throw new NCFilesError('Authentication failed', 401);
       }
 
       throw err;

--- a/test/unit/integrations/bot-enroller.test.js
+++ b/test/unit/integrations/bot-enroller.test.js
@@ -214,7 +214,8 @@ asyncTest('enrollAll() handles 403 not-moderator gracefully', async () => {
     'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
     'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': (path) => {
       if (path.includes('room1')) {
-        throw new Error('Authentication error: 403');
+        // Mirror the chokepoint contract: NCRequestManager attaches .statusCode (#176).
+        throw Object.assign(new Error('Authentication error: 403'), { statusCode: 403 });
       }
       return { status: 201, body: {}, headers: {} };
     }
@@ -240,7 +241,7 @@ asyncTest('enrollAll() handles 400 already-enabled gracefully', async () => {
       { token: 'room1', type: 2, name: 'Room 1' }
     ]),
     'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
-    'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': new Error('HTTP 400: Bad Request')
+    'POST:/ocs/v2.php/apps/spreed/api/v1/bot/': Object.assign(new Error('HTTP 400: Bad Request'), { statusCode: 400 })
   });
 
   const enroller = new BotEnroller({ ncRequestManager: nc });
@@ -414,31 +415,25 @@ asyncTest('enrollAll() treats POST 200 as already-enabled (skip not enroll)', as
   assert.strictEqual(enroller.enrolledCount, 1);
 });
 
-// --- _extractStatusCode ---
+// --- enrollAll() propagates a non-403/400 status as an error (not a skip) ---
 
-test('_extractStatusCode parses Authentication error format', () => {
-  const nc = createMockNC();
+asyncTest('enrollAll() records a non-403/400 status rejection as an error', async () => {
+  // The catch path keys off err.statusCode (#176 chokepoint custody): only
+  // 400/403 are "expected" and skipped; any other status is a real error.
+  const nc = createMockNC({
+    'GET:/ocs/v2.php/apps/spreed/api/v4/room': ocsResponse([
+      { token: 'room1', type: 2, name: 'Room 1' }
+    ]),
+    'GET:/ocs/v2.php/apps/spreed/api/v1/bot/room1': ocsResponse(SAMPLE_ROOM_BOTS),
+    'POST:/ocs/v2.php/apps/spreed/api/v1/bot/':
+      Object.assign(new Error('HTTP 500: Internal Server Error'), { statusCode: 500 })
+  });
+
   const enroller = new BotEnroller({ ncRequestManager: nc });
+  const result = await enroller.enrollAll();
 
-  assert.strictEqual(enroller._extractStatusCode(new Error('Authentication error: 403')), 403);
-  assert.strictEqual(enroller._extractStatusCode(new Error('Authentication error: 401')), 401);
-});
-
-test('_extractStatusCode parses HTTP status format', () => {
-  const nc = createMockNC();
-  const enroller = new BotEnroller({ ncRequestManager: nc });
-
-  assert.strictEqual(enroller._extractStatusCode(new Error('HTTP 400: Bad Request')), 400);
-  assert.strictEqual(enroller._extractStatusCode(new Error('HTTP 500: Internal Server Error')), 500);
-});
-
-test('_extractStatusCode returns null for non-HTTP errors', () => {
-  const nc = createMockNC();
-  const enroller = new BotEnroller({ ncRequestManager: nc });
-
-  assert.strictEqual(enroller._extractStatusCode(new Error('Network error: timeout')), null);
-  assert.strictEqual(enroller._extractStatusCode(null), null);
-  assert.strictEqual(enroller._extractStatusCode(new Error('')), null);
+  assert.strictEqual(result.skipped, 0);
+  assert.strictEqual(result.errors.length, 1);
 });
 
 // --- Module export ---

--- a/test/unit/integrations/nc-files-client.test.js
+++ b/test/unit/integrations/nc-files-client.test.js
@@ -173,7 +173,8 @@ asyncTest('writeFile sends PUT request', async () => {
 
 asyncTest('writeFile throws on 403', async () => {
   const nc = createMockNCRM();
-  nc.request = async () => { throw new Error('Authentication error: 403'); };
+  // Mirror the chokepoint contract: NCRequestManager attaches .statusCode (#176).
+  nc.request = async () => { throw Object.assign(new Error('Authentication error: 403'), { statusCode: 403 }); };
   const client = new NCFilesClient(nc);
   try {
     await client.writeFile('readonly/file.md', 'data');


### PR DESCRIPTION
Fast-follow to #176. That PR restored HTTP-status custody at the `NCRequestManager` chokepoint — 401/403/429 rejections now attach `.statusCode`, matching the `HTTP >=400` path that always carried it. This removes the three downstream consumers that coped with the previously-flattened status by re-parsing it out of the message string.

## Changes (net deletion: -61/+33)
- **cockpit-manager**: drop the `/Authentication error:/` regex from the `getBoard` catch. The `.statusCode === 404 || 403` branch now stands alone — identical to the canonical `deck-client.findBoard` contract. **Intended side effect:** an instance-wide `401` now propagates instead of being swallowed as a stale-board self-heal, converging cockpit onto the same behaviour `findBoard` already has.
- **bot-enroller**: delete `_extractStatusCode` entirely; both catch sites read `err?.statusCode`.
- **nc-files-client**: map 403/401 from `err.statusCode`, not a `\d{3}` message match.

Closes the signals-keep-custody re-derivation class for HTTP status (#49/#123/#133 lineage).

## Tests
The mock rejections in the touched tests were the message-only, no-`.statusCode` shape — the green-but-hollow shape #176 stopped emitting. Updated them to carry `.statusCode` like the real chokepoint, and added an `enrollAll()` test asserting a non-403/400 status propagates as an error rather than a skip. **227 test files pass, lint 0 errors.**

## Verification Gate
Live on the Bot VM: a real `NCRequestManager` (live credentials) issuing `GET /boards/11` (still 403 for the bot identity) rejects with `statusCode = 403`, message unchanged (`"Authentication error: 403"`), and the consumer pattern `err?.statusCode === 403` resolves `true` — confirming the exact field all three consumers now read is populated by the live NC on a real 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)