### PR TITLE
feat(workflow): add NC Mail source link to ingested inquiry cards

### DIFF
--- a/src/lib/integrations/nc-mail-client.js
+++ b/src/lib/integrations/nc-mail-client.js
@@ -1,0 +1,200 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ */
+
+/**
+ * Moltagent NC Mail Client
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: Email-trigger-ingested Deck cards need a best-effort deep link back
+ * to the original message in the Nextcloud Mail app so operators can open the
+ * source email in one click from the card description.
+ *
+ * Pattern: Thin API client over NCRequestManager — same structure as
+ * NewsClient and DeckClient. All methods are best-effort: every error path
+ * returns null rather than throwing, so the caller (WorkflowEngine) can always
+ * continue card ingestion even when the Mail API is unavailable or the message
+ * has not yet synced.
+ *
+ * Key Dependencies:
+ *   - NCRequestManager (injected): .request(path, opts) for all API calls;
+ *     .ncUrl exposed as the Nextcloud base URL for link construction.
+ *
+ * Data Flow:
+ *   resolveMailbox(folder)
+ *     → GET /index.php/apps/mail/api/accounts          (list accounts)
+ *     → GET /index.php/apps/mail/api/mailboxes?accountId={id}
+ *       (find mailbox whose name === folder, return {accountId, mailboxId})
+ *
+ *   resolveMessageDatabaseId(mailboxId, messageId)
+ *     → GET /index.php/apps/mail/api/messages?mailboxId={id}&limit=50
+ *       (find message by normalized Message-ID header, return databaseId)
+ *
+ *   resolveThreadUrl(folder, messageId)
+ *     → resolveMailbox + resolveMessageDatabaseId
+ *     → {ncUrl}/apps/mail/box/{mailboxId}/thread/{databaseId}
+ *
+ * Dependency Map:
+ *   NCMailClient
+ *     ← WorkflowEngine (_ingestTriggerEmails: append link to card description)
+ *     → NCRequestManager (all HTTP calls)
+ *
+ * @module integrations/nc-mail-client
+ * @version 1.0.0
+ */
+
+'use strict';
+
+class NCMailClient {
+  /**
+   * Create a new NC Mail client.
+   * @param {Object} ncRequestManager - NCRequestManager instance with .request() method and .ncUrl string
+   */
+  constructor(ncRequestManager) {
+    this.nc = ncRequestManager;
+  }
+
+  /**
+   * Issue a GET request to a NC Mail API path and return the parsed JSON body,
+   * or null on any non-2xx status or parse/network error. Never throws.
+   * @param {string} path - Full API path, e.g. '/index.php/apps/mail/api/accounts'
+   * @returns {Promise<*|null>} Parsed JSON value or null
+   * @private
+   */
+  async _getJson(path) {
+    try {
+      const response = await this.nc.request(path, {
+        method: 'GET',
+        headers: {
+          'OCS-APIRequest': 'true',
+          'Accept': 'application/json'
+        }
+      });
+      if (!response || response.status < 200 || response.status >= 300) {
+        return null;
+      }
+      const raw = response.body;
+      if (raw === null || raw === undefined) return null;
+      if (typeof raw === 'string') {
+        return JSON.parse(raw);
+      }
+      // Already parsed (some NCRequestManager implementations return an object)
+      return raw;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the numeric mailbox id for a given IMAP folder name.
+   *
+   * Iterates all accounts, then for each account fetches the mailbox list and
+   * looks for a mailbox whose `name` exactly matches `folder`. Returns on the
+   * first match across all accounts.
+   *
+   * @param {string} folder - Full IMAP folder path, e.g. 'INBOX.INQUIRIES'
+   * @returns {Promise<{accountId: number, mailboxId: number}|null>}
+   */
+  async resolveMailbox(folder) {
+    const accounts = await this._getJson('/index.php/apps/mail/api/accounts');
+    if (!Array.isArray(accounts)) return null;
+
+    for (const account of accounts) {
+      const accountId = account && account.id;
+      if (accountId == null) continue;
+
+      const mbData = await this._getJson(
+        `/index.php/apps/mail/api/mailboxes?accountId=${encodeURIComponent(accountId)}`
+      );
+      // The mailboxes endpoint returns an object with a `mailboxes` array.
+      const mailboxes = mbData && Array.isArray(mbData.mailboxes) ? mbData.mailboxes : null;
+      if (!mailboxes) continue;
+
+      for (const mb of mailboxes) {
+        if (mb && mb.name === folder) {
+          return { accountId, mailboxId: mb.databaseId };
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find the numeric database id of a message in a given mailbox by its
+   * RFC 822 Message-ID header value.
+   *
+   * Normalization: trim whitespace and strip ONE layer of surrounding angle
+   * brackets from both the stored `messageId` field and the caller-supplied
+   * `messageId` before comparing, so `<abc@host>` and `abc@host` both match.
+   *
+   * @param {number} mailboxId - The mailbox databaseId returned by resolveMailbox
+   * @param {string} messageId - RFC 822 Message-ID value (with or without angle brackets)
+   * @returns {Promise<number|null>} The message's databaseId, or null if not found
+   */
+  async resolveMessageDatabaseId(mailboxId, messageId) {
+    // Best-effort: scan the most recent 50 messages (newest-first). A just-
+    // ingested email is near the top; a Message-ID older than this window
+    // won't resolve and the caller keeps the Message-ID footer as fallback.
+    const messages = await this._getJson(
+      `/index.php/apps/mail/api/messages?mailboxId=${encodeURIComponent(mailboxId)}&limit=50`
+    );
+    if (!Array.isArray(messages)) return null;
+
+    const normalize = (id) => {
+      if (!id) return '';
+      const trimmed = String(id).trim();
+      // Strip one layer of surrounding angle brackets
+      return trimmed.startsWith('<') && trimmed.endsWith('>')
+        ? trimmed.slice(1, -1)
+        : trimmed;
+    };
+
+    const needle = normalize(messageId);
+    for (const msg of messages) {
+      if (msg && normalize(msg.messageId) === needle) {
+        return msg.databaseId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Best-effort: resolve a deep-link URL to a message thread in NC Mail.
+   *
+   * Returns null (never throws) on any error, missing account/mailbox, or
+   * message not yet synced. The caller keeps the existing footer as-is when
+   * null is returned.
+   *
+   * @param {string} folder   - IMAP folder name from the TRIGGER: line locator
+   * @param {string} messageId - RFC 822 Message-ID header value of the email
+   * @returns {Promise<string|null>} Deep-link URL or null
+   */
+  async resolveThreadUrl(folder, messageId) {
+    if (!folder || !messageId) return null;
+    try {
+      const mailbox = await this.resolveMailbox(folder);
+      if (!mailbox) return null;
+
+      const databaseId = await this.resolveMessageDatabaseId(mailbox.mailboxId, messageId);
+      if (databaseId == null) return null;
+
+      return `${this.nc.ncUrl}/apps/mail/box/${mailbox.mailboxId}/thread/${databaseId}`;
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+module.exports = NCMailClient;

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -37,9 +37,11 @@ class WorkflowEngine {
    * @param {string} options.talkToken - Primary Talk room token for notifications
    * @param {Object} [options.emailHandler] - EmailHandler instance; when provided, boards with a
    *   TRIGGER: email:<folder> line will have unread emails ingested as cards each pulse.
+   * @param {Object} [options.ncMailClient] - NCMailClient instance; when provided, ingested cards
+   *   receive a best-effort deep-link back to the original message in NC Mail.
    * @param {Object} [options.config]
    */
-  constructor({ workflowDetector, deckClient, agentLoop, talkSendQueue, talkToken, emailHandler, config, budgetEnforcer }) {
+  constructor({ workflowDetector, deckClient, agentLoop, talkSendQueue, talkToken, emailHandler, ncMailClient, config, budgetEnforcer }) {
     this.detector = workflowDetector;
     this.deck = deckClient;
     this.agent = agentLoop;
@@ -49,6 +51,7 @@ class WorkflowEngine {
     this.budgetEnforcer = budgetEnforcer || null;
     this.botUsername    = this.config.botUsername || 'moltagent';
     this.emailHandler   = emailHandler || null;
+    this.ncMailClient   = ncMailClient || null;
 
     // Resolve data directory. Disk persistence is only enabled when config.dataDir
     // is explicitly provided (or config.dataDir === true to use the default).
@@ -970,9 +973,25 @@ class WorkflowEngine {
       // Build the card title and description.
       const title = email.subject || '(No subject)';
       const bodyText = (email.body || '').slice(0, 2000);
-      const description = bodyText + '\n\n---\nFrom: ' + (email.from || '') +
+      let description = bodyText + '\n\n---\nFrom: ' + (email.from || '') +
         '\nDate: ' + (email.date || '') +
         '\nMessage-ID: ' + key;
+
+      // Best-effort: append a deep-link back to the original message in NC Mail.
+      // Only attempt resolution when the real Message-ID header is available
+      // (key may be a sha1 fallback when messageId is absent — not resolvable).
+      if (this.ncMailClient && email.messageId) {
+        try {
+          const mailUrl = await this.ncMailClient.resolveThreadUrl(trigger.locator, email.messageId);
+          if (mailUrl) {
+            description += '\n[Open the original email in Mail](' + mailUrl + ')';
+          } else {
+            console.log('[Workflow] NC Mail back-link: no match for Message-ID ' + email.messageId + ' (message may not yet be synced) — keeping Message-ID footer');
+          }
+        } catch (err) {
+          console.log('[Workflow] NC Mail back-link: resolution errored for Message-ID ' + email.messageId + ': ' + err.message + ' — keeping Message-ID footer');
+        }
+      }
 
       const card = await this.deck.createCardOnBoard(wb.boardId, stack.id, title, { description });
 

--- a/test/unit/integrations/nc-mail-client.test.js
+++ b/test/unit/integrations/nc-mail-client.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+/**
+ * NCMailClient Unit Tests
+ *
+ * Run: node test/unit/integrations/nc-mail-client.test.js
+ *
+ * @module test/unit/integrations/nc-mail-client
+ */
+
+const assert = require('assert');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const NCMailClient = require('../../../src/lib/integrations/nc-mail-client');
+
+// ---------------------------------------------------------------------------
+// Mock factory helpers
+// ---------------------------------------------------------------------------
+
+/** Build a canned NCRequestManager mock. `routes` maps path prefixes to return values. */
+function createMockNC(routes = {}, ncUrl = 'https://nc.example.com') {
+  return {
+    ncUrl,
+    request: async (path, _opts) => {
+      for (const [prefix, value] of Object.entries(routes)) {
+        if (path.startsWith(prefix)) {
+          if (value instanceof Error) throw value;
+          return value;
+        }
+      }
+      // No match → 404
+      return { status: 404, body: null };
+    }
+  };
+}
+
+/** Minimal canned API fixtures */
+const ACCOUNTS = [{ id: 7, email: 'bot@example.com' }];
+const MAILBOXES_RESP = {
+  id: 7,
+  email: 'bot@example.com',
+  mailboxes: [
+    { databaseId: 42, name: 'INBOX', delimiter: '.' },
+    { databaseId: 99, name: 'INBOX.INQUIRIES', delimiter: '.' }
+  ],
+  delimiter: '.'
+};
+const MESSAGES_RESP = [
+  { databaseId: 555, uid: 10, messageId: '<msg1@host>', threadRootId: 555, mailboxId: 99, subject: 'Hello' },
+  { databaseId: 556, uid: 11, messageId: '<msg2@host>', threadRootId: 556, mailboxId: 99, subject: 'World' }
+];
+
+function makeRoutes() {
+  return {
+    '/index.php/apps/mail/api/accounts': { status: 200, body: JSON.stringify(ACCOUNTS) },
+    '/index.php/apps/mail/api/mailboxes': { status: 200, body: JSON.stringify(MAILBOXES_RESP) },
+    '/index.php/apps/mail/api/messages': { status: 200, body: JSON.stringify(MESSAGES_RESP) }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+(async () => {
+  console.log('\n=== NCMailClient Unit Tests ===\n');
+
+  // TC-MAIL-01: resolveThreadUrl — full happy path resolves correct deep-link URL.
+  await asyncTest('TC-MAIL-01: resolveThreadUrl resolves correct deep-link URL', async () => {
+    const nc = createMockNC(makeRoutes(), 'https://nc.example.com');
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+
+    assert.strictEqual(
+      url,
+      'https://nc.example.com/apps/mail/box/99/thread/555',
+      'should return the deep-link URL with correct mailboxId and databaseId'
+    );
+  });
+
+  // TC-MAIL-02: resolveThreadUrl — message found when caller omits angle brackets.
+  await asyncTest('TC-MAIL-02: resolveThreadUrl matches Message-ID without angle brackets', async () => {
+    const nc = createMockNC(makeRoutes(), 'https://nc.example.com');
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', 'msg2@host');
+
+    assert.strictEqual(
+      url,
+      'https://nc.example.com/apps/mail/box/99/thread/556',
+      'should strip angle brackets from stored messageId for comparison'
+    );
+  });
+
+  // TC-MAIL-03: resolveThreadUrl — returns null when folder not found in any account.
+  await asyncTest('TC-MAIL-03: resolveThreadUrl returns null when folder not found', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.NONEXISTENT', '<msg1@host>');
+
+    assert.strictEqual(url, null, 'should return null when folder has no matching mailbox');
+  });
+
+  // TC-MAIL-04: resolveThreadUrl — returns null when message not in mailbox.
+  await asyncTest('TC-MAIL-04: resolveThreadUrl returns null when message not found', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<unknown@host>');
+
+    assert.strictEqual(url, null, 'should return null when messageId has no match in messages list');
+  });
+
+  // TC-MAIL-05: resolveThreadUrl — returns null when accounts request errors (throws).
+  await asyncTest('TC-MAIL-05: resolveThreadUrl returns null when accounts request throws', async () => {
+    const routes = {
+      '/index.php/apps/mail/api/accounts': new Error('network failure')
+    };
+    const nc = createMockNC(routes);
+    const client = new NCMailClient(nc);
+
+    let url;
+    let threw = false;
+    try {
+      url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+    } catch (_) {
+      threw = true;
+    }
+
+    assert.strictEqual(threw, false, 'should never throw');
+    assert.strictEqual(url, null, 'should return null on network error');
+  });
+
+  // TC-MAIL-06: resolveThreadUrl — returns null when folder/messageId are falsy.
+  await asyncTest('TC-MAIL-06: resolveThreadUrl returns null for falsy inputs', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    assert.strictEqual(await client.resolveThreadUrl(null, '<msg1@host>'), null);
+    assert.strictEqual(await client.resolveThreadUrl('INBOX.INQUIRIES', null), null);
+    assert.strictEqual(await client.resolveThreadUrl('', ''), null);
+  });
+
+  // TC-MAIL-07: resolveThreadUrl — returns null when accounts returns non-2xx.
+  await asyncTest('TC-MAIL-07: resolveThreadUrl returns null on non-2xx accounts response', async () => {
+    const nc = createMockNC({
+      '/index.php/apps/mail/api/accounts': { status: 503, body: null }
+    });
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+    assert.strictEqual(url, null, 'should return null on 503 from accounts');
+  });
+
+  // TC-MAIL-08: resolveMailbox — returns {accountId, mailboxId} on match.
+  await asyncTest('TC-MAIL-08: resolveMailbox returns correct accountId and mailboxId', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    const result = await client.resolveMailbox('INBOX.INQUIRIES');
+
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.accountId, 7);
+    assert.strictEqual(result.mailboxId, 99);
+  });
+
+  // TC-MAIL-09: resolveMailbox — returns null when no account has the folder.
+  await asyncTest('TC-MAIL-09: resolveMailbox returns null when folder absent from all accounts', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    const result = await client.resolveMailbox('INBOX.MISSING');
+    assert.strictEqual(result, null);
+  });
+
+  // TC-MAIL-10: resolveMessageDatabaseId — matches with angle-bracket normalization.
+  await asyncTest('TC-MAIL-10: resolveMessageDatabaseId matches angle-bracket variants', async () => {
+    const nc = createMockNC(makeRoutes());
+    const client = new NCMailClient(nc);
+
+    // Both with and without brackets should resolve to databaseId 555
+    const withBrackets = await client.resolveMessageDatabaseId(99, '<msg1@host>');
+    const withoutBrackets = await client.resolveMessageDatabaseId(99, 'msg1@host');
+
+    assert.strictEqual(withBrackets, 555, 'with angle brackets');
+    assert.strictEqual(withoutBrackets, 555, 'without angle brackets');
+  });
+
+  // TC-MAIL-11: _getJson — returns null (not throw) when body is malformed JSON.
+  await asyncTest('TC-MAIL-11: _getJson returns null on malformed JSON body', async () => {
+    const nc = {
+      ncUrl: 'https://nc.example.com',
+      request: async () => ({ status: 200, body: 'NOT JSON {{{' })
+    };
+    const client = new NCMailClient(nc);
+
+    let result;
+    let threw = false;
+    try {
+      result = await client._getJson('/index.php/apps/mail/api/accounts');
+    } catch (_) {
+      threw = true;
+    }
+
+    assert.strictEqual(threw, false, '_getJson must not throw');
+    assert.strictEqual(result, null, '_getJson should return null on parse error');
+  });
+
+  setTimeout(() => { summary(); exitWithCode(); }, 500);
+})();

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -92,14 +92,15 @@ function makeWorkflowBoard({
 }
 
 /** Build a minimal WorkflowEngine without disk persistence. */
-function makeEngine({ emailHandler, deck } = {}) {
+function makeEngine({ emailHandler, deck, ncMailClient } = {}) {
   return new WorkflowEngine({
     workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
     deckClient: deck || createMockDeck(),
     agentLoop: createMockAgentLoop(),
     talkSendQueue: createMockTalkQueue(),
     talkToken: 'tok',
-    emailHandler: emailHandler || null
+    emailHandler: emailHandler || null,
+    ncMailClient: ncMailClient || null
     // no config.dataDir → in-memory only
   });
 }
@@ -427,6 +428,103 @@ function makeEmail(overrides = {}) {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  // TC-TRIGGER-17: ncMailClient resolves a URL → description contains Markdown link AND
+  //               still contains the Message-ID: footer.
+  await asyncTest('TC-TRIGGER-17: ncMailClient resolves URL → description has link AND Message-ID footer', async () => {
+    const MAIL_URL = 'https://nc.example.com/apps/mail/box/99/thread/555';
+    const ncMailClient = {
+      resolveThreadUrl: async (_folder, _msgId) => MAIL_URL
+    };
+    const email = makeEmail({
+      messageId: '<link-test@example.com>',
+      from: 'Charlie <charlie@example.com>',
+      body: 'Mail body.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'one card should be created');
+    const desc = deck._calls[0].description;
+    assert.ok(
+      desc.includes('[Open the original email in Mail](' + MAIL_URL + ')'),
+      'description should contain Markdown link to NC Mail'
+    );
+    assert.ok(
+      desc.includes('Message-ID: <link-test@example.com>'),
+      'description should still contain the Message-ID footer'
+    );
+  });
+
+  // TC-TRIGGER-18: ncMailClient.resolveThreadUrl returns null → description falls back to
+  //               Message-ID footer with NO Mail link; ingestion returns 1 card (no throw).
+  await asyncTest('TC-TRIGGER-18: ncMailClient returns null → Message-ID footer intact, no link, ingestion completes', async () => {
+    const ncMailClient = {
+      resolveThreadUrl: async (_folder, _msgId) => null
+    };
+    const email = makeEmail({ messageId: '<null-link-test@example.com>' });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
+
+    let threw = false;
+    let result;
+    try {
+      result = await engine._ingestTriggerEmails(wb);
+    } catch (_) {
+      threw = true;
+    }
+
+    assert.strictEqual(threw, false, 'ingestion must not throw when resolveThreadUrl returns null');
+    assert.strictEqual(result, 1, 'should return 1 ingested card');
+    const desc = deck._calls[0].description;
+    assert.ok(
+      desc.includes('Message-ID: <null-link-test@example.com>'),
+      'Message-ID footer must be present'
+    );
+    assert.ok(
+      !desc.includes('[Open the original email in Mail]'),
+      'no Mail link should be present when resolveThreadUrl returned null'
+    );
+  });
+
+  // TC-TRIGGER-19: ncMailClient.resolveThreadUrl throws → ingestion still completes
+  //               (try/catch swallows it), footer is intact, returns 1 card.
+  await asyncTest('TC-TRIGGER-19: ncMailClient throws → ingestion completes, footer intact', async () => {
+    const ncMailClient = {
+      resolveThreadUrl: async () => { throw new Error('simulated NC Mail error'); }
+    };
+    const email = makeEmail({ messageId: '<throw-test@example.com>' });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
+
+    let threw = false;
+    let result;
+    try {
+      result = await engine._ingestTriggerEmails(wb);
+    } catch (_) {
+      threw = true;
+    }
+
+    assert.strictEqual(threw, false, 'ingestion must not throw when resolveThreadUrl throws');
+    assert.strictEqual(result, 1, 'should return 1 ingested card');
+    const desc = deck._calls[0].description;
+    assert.ok(
+      desc.includes('Message-ID: <throw-test@example.com>'),
+      'Message-ID footer must be present after resolveThreadUrl threw'
+    );
+    assert.ok(
+      !desc.includes('[Open the original email in Mail]'),
+      'no Mail link should appear when resolveThreadUrl threw'
+    );
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -95,6 +95,8 @@ try {
   NewsClient = null;
 }
 
+const NCMailClient = require('./src/lib/integrations/nc-mail-client');
+
 let NCFilesClient, NCSearchClient, TextExtractor;
 try {
   ({ NCFilesClient } = require('./src/lib/integrations/nc-files-client'));
@@ -1988,6 +1990,7 @@ async function initialize() {
         talkSendQueue: talkQueue,
         talkToken: defaultTalkToken,
         emailHandler,
+        ncMailClient: ncRequestManager ? new NCMailClient(ncRequestManager) : null,
         budgetEnforcer: llmRouter?.router?.budget || null,
         config: { botUsername: CONFIG.nc.username, adminUser: appConfig.cockpit?.adminUser || appConfig.knowledge?.adminUser || '', dataDir: true }
       });


### PR DESCRIPTION
Implements the CardSourceLink briefing: ingested inquiry cards get a best-effort, clickable deep-link back to the canonical message in NC Mail. Phase 0 discovery was approved; this is Phase 1.

## Design (per the maintainer's constraints — nothing deployment-specific in source)
New `NCMailClient` (thin client over the existing app-password `NCRequestManager`) resolves the link entirely at runtime:
- **folder** comes from the card's `TRIGGER:` locator — never a constant
- **account id** via `GET /api/accounts`
- **mailbox id** by matching that folder name against `GET /api/mailboxes` — box numbers are unstable DB surrogates, never hardcoded
- **message databaseId** by matching the RFC822 Message-ID against `GET /api/messages`
- **host** from the `NCRequestManager` base URL — never a literal

The bridge (`_ingestTriggerEmails`) appends `[Open the original email in Mail](<url>)` to the card footer when resolution succeeds.

## Best-effort & additive
Any miss or error returns `null`; the existing `Message-ID` footer stays as the fallback and ingestion never fails over a missing link. Body + footer are untouched. NC Mail calls reuse the existing app-password `NCRequestManager` — no new egress or trust surface.

## Phase 0 findings that shaped this
- The HTTP path works with app-password Basic auth (Nextcloud exempts app-password auth from CSRF) — no DB access needed.
- The trigger folder must be **background-synced** in NC Mail for the message to be in its DB at resolve time. INQUIRIES was `syncInBackground:false`; set it true via `PATCH /api/mailboxes/{id}` `{syncInBackground:true}` (done on Prime). Otherwise the link best-effort falls back to the footer until the next sync.
- A cold full-sync of a never-synced mailbox marks existing unread mail `\Seen`; the bridge therefore never triggers a sync — it only reads, and background sync (envelope-only, `\Seen`-safe) keeps the DB current.

## Tests
New `nc-mail-client` unit suite (11) + 3 bridge cases (link present when resolvable, footer fallback on null, no-throw on resolver error). **228/228 unit files, lint 0 errors.**

## Verified live on Prime (branch code, real NC Mail + Deck)
- Resolver: a real synced inquiry → correct `…/apps/mail/box/{id}/thread/{id}` (ids resolved at runtime, host from config); message-miss and folder-miss both → `null`.
- Full bridge: ingested a card whose description carried the clickable link **and** the intact Message-ID footer + body; link matched the resolver output and points at the right message (databaseId confirmed = that inquiry by Message-ID). Throwaway card cleaned up; source mail stayed **unread** (bridge read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)