### PR TITLE
fix(workflow): sync the trigger mailbox before resolving the NC Mail link

### DIFF
--- a/src/lib/integrations/nc-mail-client.js
+++ b/src/lib/integrations/nc-mail-client.js
@@ -171,6 +171,42 @@ class NCMailClient {
   }
 
   /**
+   * Best-effort: ask NC Mail to sync a mailbox from IMAP into its database.
+   *
+   * The bridge ingests on a heartbeat (minutes) while NC Mail's own background
+   * SyncJob runs on a much slower per-account interval, so a just-arrived email
+   * is usually NOT yet in NC Mail's DB when we look it up — the lookup misses
+   * and the link can't be built. A sync here closes that race.
+   *
+   * Safe on \Seen: this syncs a mailbox the bridge already reads every pulse
+   * (warm), which fetches envelopes only and does NOT mark messages read.
+   * (A cold first-ever sync of a never-synced mailbox can mark pre-existing
+   * unread mail read; operators warm the trigger mailbox once by enabling its
+   * background sync — after that every sync here is incremental and safe.)
+   *
+   * Best-effort: returns false on any error and never throws; resolution
+   * continues regardless (the message may already be synced).
+   *
+   * @param {number} mailboxId - The mailbox databaseId to sync
+   * @returns {Promise<boolean>} true on a 2xx sync, false otherwise
+   */
+  async syncMailbox(mailboxId) {
+    try {
+      const response = await this.nc.request(
+        `/index.php/apps/mail/api/mailboxes/${encodeURIComponent(mailboxId)}/sync`,
+        {
+          method: 'POST',
+          headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: [], init: true })
+        }
+      );
+      return !!response && response.status >= 200 && response.status < 300;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /**
    * Best-effort: resolve a deep-link URL to a message thread in NC Mail.
    *
    * Returns null (never throws) on any error, missing account/mailbox, or
@@ -186,6 +222,11 @@ class NCMailClient {
     try {
       const mailbox = await this.resolveMailbox(folder);
       if (!mailbox) return null;
+
+      // Close the sync race: pull the mailbox into NC Mail's DB before lookup,
+      // so a just-ingested email is present. Best-effort — a failed sync does
+      // not block resolution (the message may already be synced).
+      await this.syncMailbox(mailbox.mailboxId);
 
       const databaseId = await this.resolveMessageDatabaseId(mailbox.mailboxId, messageId);
       if (databaseId == null) return null;

--- a/test/unit/integrations/nc-mail-client.test.js
+++ b/test/unit/integrations/nc-mail-client.test.js
@@ -207,5 +207,52 @@ function makeRoutes() {
     assert.strictEqual(result, null, '_getJson should return null on parse error');
   });
 
+  // TC-MAIL-12: resolveThreadUrl issues a sync POST for the resolved mailbox
+  // before looking up the message (closes the heartbeat-vs-background-sync race).
+  await asyncTest('TC-MAIL-12: resolveThreadUrl syncs the mailbox before lookup', async () => {
+    const calls = [];
+    const nc = {
+      ncUrl: 'https://nc.example.com',
+      request: async (path, opts) => {
+        calls.push({ path, method: (opts && opts.method) || 'GET' });
+        if (path.startsWith('/index.php/apps/mail/api/accounts')) return { status: 200, body: JSON.stringify(ACCOUNTS) };
+        if (path.includes('/sync')) return { status: 200, body: JSON.stringify({ newMessages: [] }) };
+        if (path.startsWith('/index.php/apps/mail/api/mailboxes')) return { status: 200, body: JSON.stringify(MAILBOXES_RESP) };
+        if (path.startsWith('/index.php/apps/mail/api/messages')) return { status: 200, body: JSON.stringify(MESSAGES_RESP) };
+        return { status: 404, body: null };
+      }
+    };
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+    assert.strictEqual(url, 'https://nc.example.com/apps/mail/box/99/thread/555');
+
+    const syncCall = calls.find(c => c.path.includes('/index.php/apps/mail/api/mailboxes/99/sync'));
+    assert.ok(syncCall, 'a sync POST should be issued for the resolved mailbox (id 99)');
+    assert.strictEqual(syncCall.method, 'POST', 'sync must be a POST');
+    // The sync must precede the messages lookup.
+    const syncIdx = calls.findIndex(c => c.path.includes('/sync'));
+    const msgIdx = calls.findIndex(c => c.path.startsWith('/index.php/apps/mail/api/messages'));
+    assert.ok(syncIdx >= 0 && msgIdx >= 0 && syncIdx < msgIdx, 'sync must precede the messages lookup');
+  });
+
+  // TC-MAIL-13: a failed sync does NOT block resolution (best-effort).
+  await asyncTest('TC-MAIL-13: resolveThreadUrl still resolves when the sync POST fails', async () => {
+    const nc = {
+      ncUrl: 'https://nc.example.com',
+      request: async (path) => {
+        if (path.includes('/sync')) throw new Error('sync boom');
+        if (path.startsWith('/index.php/apps/mail/api/accounts')) return { status: 200, body: JSON.stringify(ACCOUNTS) };
+        if (path.startsWith('/index.php/apps/mail/api/mailboxes')) return { status: 200, body: JSON.stringify(MAILBOXES_RESP) };
+        if (path.startsWith('/index.php/apps/mail/api/messages')) return { status: 200, body: JSON.stringify(MESSAGES_RESP) };
+        return { status: 404, body: null };
+      }
+    };
+    const client = new NCMailClient(nc);
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+    assert.strictEqual(url, 'https://nc.example.com/apps/mail/box/99/thread/555', 'resolution proceeds despite sync failure');
+  });
+
   setTimeout(() => { summary(); exitWithCode(); }, 500);
 })();


### PR DESCRIPTION
Follow-up to #178. On the first real inquiry after deploy, the card had **no source link** — the resolver returned null and fell back to the Message-ID footer.

## Root cause (confirmed live)
NC Mail's background `SyncJob` runs on a slow per-account interval (up to ~1h), while the bridge ingests on the heartbeat (~5 min). So a just-arrived email is **not yet in NC Mail's DB** when the resolver looks it up → miss → footer fallback. Enabling `syncInBackground` on the folder doesn't help on its own: the cron simply hasn't fired at ingest time. Verified on Prime: the real inquiry's Message-ID was still absent from NC Mail's DB minutes after the heartbeat ingested it.

## Fix
`NCMailClient.resolveThreadUrl` now triggers a **best-effort incremental sync** of the resolved mailbox (`POST /api/mailboxes/{id}/sync`) before the message lookup. The trigger mailbox is one the bridge reads every pulse (warm), so the sync fetches envelopes only and does **not** mark messages `\Seen`. Best-effort throughout: a failed sync doesn't block resolution and never throws; the Message-ID footer stays as the fallback.

This is the "later decision if the unattended sync race proves common" flagged in the Phase 0 findings — it proved common on the very first email.

## Verified live on Prime (branch code)
Appended a fresh unread inquiry → confirmed it was **not** in NC Mail's DB (the bug condition) → new `resolveThreadUrl` returned `…/apps/mail/box/{id}/thread/{id}` (the internal sync closed the race) → the test email **stayed unread** (`\Seen` untouched). The deployed code returns `null` for this exact condition.

## Tests
+2 cases (sync POST issued before the lookup; resolution still succeeds when the sync fails). **228/228 unit files, lint 0 errors.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)