### PR TITLE
refactor(search): decouple web egress from inference-trust (#136)

### DIFF
--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -1833,29 +1833,30 @@ class MessageProcessor {
   // ---------------------------------------------------------------------------
 
   /**
-   * Decide whether the knowledge path may fall back to a web search. Pure — no
-   * I/O — so the egress policy is unit-testable on its own (#136).
+   * Decide whether the knowledge path may fall back to a web search. Pure, no
+   * I/O, so the egress policy is unit-testable on its own (#136).
    *
-   * Two gates sit ahead of the searchPolicy preference. The count heuristic
-   * (wantsMore) alone used to escape to the web whenever the local result count
-   * was low; these gates stop it from overriding facts it has no business over-
-   * riding:
-   *   - trust:local-only → the web never auto-fires (the single control; web
-   *     egresses). searchPolicy can only narrow within cloud-ok, never widen
-   *     past trust.
-   *   - a workspace probe returned data → the workspace IS the answer; web
-   *     results cannot contain the user's board.
-   * Otherwise the Cockpit searchPolicy decides: research → fire, internal-first
-   * → offer, sovereign → suppress.
+   * Web access is governed by the Cockpit `searchPolicy`, not by the
+   * inference-trust axis. The two axes are independent: `trust` (local-only /
+   * cloud-ok) decides which model reasons over the content; `searchPolicy`
+   * decides whether the web is read at all. A local-only roster reads the
+   * public web through the self-hosted SearXNG and synthesizes locally, so the
+   * content never reaches a third-party model and the configuration stays
+   * sovereign. (`_probeWeb` is SearXNG-only; commercial providers are a
+   * separate, opt-in concern handled elsewhere.)
    *
-   * @param {{wantsMore:boolean, trust:?string, workspaceAnswered:boolean, searchPolicy:string}} input
+   * One gate sits ahead of the `searchPolicy` preference: a workspace probe
+   * that returned data IS the answer, since web results cannot contain the
+   * user's board. Otherwise `searchPolicy` decides: research fires,
+   * internal-first offers, sovereign suppresses.
+   *
+   * @param {{wantsMore:boolean, workspaceAnswered:boolean, searchPolicy:string}} input
    * @returns {{action:'fire'|'offer'|'suppress'|'none', reason:string}}
    */
-  static decideWebFallback({ wantsMore, trust, workspaceAnswered, searchPolicy }) {
+  static decideWebFallback({ wantsMore, workspaceAnswered, searchPolicy }) {
     if (!wantsMore) return { action: 'none', reason: 'sufficient local knowledge' };
-    if (trust === 'local-only') return { action: 'suppress', reason: 'trust:local-only (no egress)' };
     if (workspaceAnswered) return { action: 'suppress', reason: 'workspace probe returned data' };
-    if (searchPolicy === 'research') return { action: 'fire', reason: 'cloud-ok + research policy' };
+    if (searchPolicy === 'research') return { action: 'fire', reason: 'research policy' };
     if (searchPolicy === 'internal-first') return { action: 'offer', reason: 'internal-first policy' };
     return { action: 'suppress', reason: 'sovereign policy' };
   }
@@ -1940,23 +1941,18 @@ class MessageProcessor {
     const contextSuggestsWeb = liveContext?.lastAssistantAction?.admittedIgnorance === true;
     let webSearchOffered = false;
 
-    // Web egress decision — two gates ahead of the searchPolicy preference (#136).
-    // The count heuristic alone escapes to the web whenever substantiveResults is
-    // low, ignoring two facts it has no business overriding:
-    //   Gate 1 — trust (the single control): under trust:local-only the auto web
-    //     fallback never fires. _probeWeb egresses (SearXNG proxies external
-    //     engines; WebReader fetches external URLs), so it is cloud, not local.
-    //     searchPolicy can only narrow within cloud-ok; it cannot widen past trust.
-    //   Gate 2 — workspace truth: when a workspace-source probe already returned
-    //     data, that IS the answer. Web results cannot contain the user's board.
-    //     This honors the probe signal the keyword-count heuristic dropped (the
-    //     "found 5 deck cards, escaped to web anyway" case).
-    const trust = this.intentRouter?.getTrust?.() || null;
+    // Web egress decision — gated by workspace truth ahead of searchPolicy (#136).
+    // The count heuristic alone used to escape to the web whenever
+    // substantiveResults was low, ignoring a fact it has no business overriding:
+    // when a workspace-source probe already returned data, that IS the answer.
+    // Web results cannot contain the user's board. This honors the probe signal
+    // the keyword-count heuristic dropped (the "found 5 deck cards, escaped to
+    // web anyway" case). searchPolicy then decides among the remaining cases.
     const workspaceAnswered = probeResults.some(
       p => WORKSPACE_KNOWLEDGE_SOURCES.has(p.source) && (p.results || []).length > 0
     );
     const wantsMore = substantiveResults < 2 || (contextSuggestsWeb && substantiveResults < 4);
-    const decision = MessageProcessor.decideWebFallback({ wantsMore, trust, workspaceAnswered, searchPolicy });
+    const decision = MessageProcessor.decideWebFallback({ wantsMore, workspaceAnswered, searchPolicy });
     let webSuppressed = false;
 
     if (decision.action === 'fire') {

--- a/test/unit/server/message-processor.test.js
+++ b/test/unit/server/message-processor.test.js
@@ -1160,14 +1160,17 @@ asyncTest('TC-OOO-004: setMode() stores the active mode', async () => {
 });
 
 // --- Web-fallback egress decision (#136) ---
-// decideWebFallback is pure: it encodes the two gates that sit AHEAD of the
-// searchPolicy preference. The precedence is the point — trust and workspace
-// truth must beat searchPolicy, never the other way round. These cases pin that
-// ordering so a future searchPolicy tweak can't silently widen egress.
+// decideWebFallback is pure: it encodes the single workspace-truth gate that
+// sits AHEAD of the searchPolicy preference. The precedence is the point —
+// workspace truth must beat searchPolicy, never the other way round. These
+// cases pin that ordering so a future searchPolicy tweak can't silently widen
+// egress. Trust no longer participates in the web-egress decision: the two
+// axes are independent (_probeWeb is SearXNG-only; trust governs which model
+// reasons, not whether the web is read).
 console.log('\n--- Web-fallback egress decision (#136) ---\n');
 
 const decide = (over) => MessageProcessor.decideWebFallback({
-  wantsMore: true, trust: 'cloud-ok', workspaceAnswered: false, searchPolicy: 'research', ...over
+  wantsMore: true, workspaceAnswered: false, searchPolicy: 'research', ...over
 });
 
 test('TC-WEB-136-01: sufficient local knowledge → none (no egress considered)', () => {
@@ -1175,7 +1178,7 @@ test('TC-WEB-136-01: sufficient local knowledge → none (no egress considered)'
   assert.strictEqual(d.action, 'none');
 });
 
-test('TC-WEB-136-02: cloud-ok + research → fire', () => {
+test('TC-WEB-136-02: research policy → fire', () => {
   assert.strictEqual(decide({}).action, 'fire');
 });
 
@@ -1187,18 +1190,6 @@ test('TC-WEB-136-04: sovereign → suppress', () => {
   assert.strictEqual(decide({ searchPolicy: 'sovereign' }).action, 'suppress');
 });
 
-test('TC-WEB-136-05: trust:local-only suppresses even under research policy (trust is the single control)', () => {
-  // The gate that matters most: searchPolicy can only narrow within cloud-ok,
-  // it cannot widen past trust. local-only + research must NOT fire.
-  const d = decide({ trust: 'local-only', searchPolicy: 'research' });
-  assert.strictEqual(d.action, 'suppress');
-  assert.ok(d.reason.includes('local-only'), 'reason should name the trust gate');
-});
-
-test('TC-WEB-136-06: trust:local-only beats workspace gate too (ordering is deterministic)', () => {
-  assert.strictEqual(decide({ trust: 'local-only', workspaceAnswered: true }).action, 'suppress');
-});
-
 test('TC-WEB-136-07: workspace probe answered suppresses web even under research policy', () => {
   // "found 5 deck cards, escaped to web anyway" — the case #136 closes.
   const d = decide({ workspaceAnswered: true, searchPolicy: 'research' });
@@ -1206,11 +1197,13 @@ test('TC-WEB-136-07: workspace probe answered suppresses web even under research
   assert.ok(d.reason.includes('workspace'), 'reason should name the workspace gate');
 });
 
-test('TC-WEB-136-08: null trust falls through to searchPolicy (resolver-absent, no widening)', () => {
-  // trust unknown (resolver absent) must not be treated as cloud permission;
-  // it simply defers to searchPolicy. research → fire, sovereign → suppress.
-  assert.strictEqual(decide({ trust: null, searchPolicy: 'research' }).action, 'fire');
-  assert.strictEqual(decide({ trust: null, searchPolicy: 'sovereign' }).action, 'suppress');
+test('TC-WEB-136-08: local-only roster still fires under research policy (trust no longer gates egress)', () => {
+  // Trust is the inference axis; searchPolicy is the egress axis. A local-only
+  // roster reads the web through SearXNG and synthesizes locally — the content
+  // never reaches a third-party model. Trust no longer participates in this
+  // decision at all.
+  assert.strictEqual(decide({ searchPolicy: 'research' }).action, 'fire');
+  assert.strictEqual(decide({ searchPolicy: 'sovereign' }).action, 'suppress');
 });
 
 // --- #133: _smartMixClassify domain custody ---


### PR DESCRIPTION
Refines #136. Addresses #181.

## What

`decideWebFallback` in `src/lib/server/message-processor.js` gated the knowledge-path web fallback on the **inference-trust** axis — `if (trust === 'local-only') return suppress`. This welded two independent concerns:

- **Inference residency** (`trust`: local-only / cloud-ok) — which model reasons over the content, and therefore whether private context reaches a third-party LLM.
- **Web egress** (`searchPolicy`) — whether the public web is read at all.

A local-only roster reading the public web through the self-hosted SearXNG and synthesizing locally is sovereign in the way that matters: no private context and no reasoning leave for a third-party model. The old code could not express "local models + web research"; this change makes it possible. Web is now governed by `searchPolicy` alone, with the workspace-truth gate ahead of it.

## The change (net deletion)

- Remove the `trust` branch and parameter from `decideWebFallback`.
- Drop the single-use `const trust = this.intentRouter?.getTrust?.()` read from `_handleKnowledgeQuery` (no other caller of `getTrust` in the file).
- Rewrite the stale "egress is cloud, not local / trust is the single control" framing in the JSDoc and the inline caller comment to describe the two axes as independent.
- Remove the coupling tests (old TC-WEB-136-05/06 asserting local-only forces suppress); repurpose TC-WEB-136-08 to pin a local-only roster firing under research.

Unchanged: `_probeWeb` is SearXNG-only, `WebReader` private/metadata blocks, and the EXTERNAL `[Source: web]` framing. Only the **decision** changes — not the fetch or the framing. No new config keys, tools, or guard layers. Workflow path, the AgentLoop `web_search` handler, and commercial providers are untouched (separate briefings).

## Verification

- `npm run test:unit` → 228/228 test files pass. `npm run lint` → 0 errors.
- Reviewer agent: APPROVE (no critical/warnings).
- **Live on the bot box** against the real self-hosted SearXNG, real `MessageProcessor._handleKnowledgeQuery`, and the real production trust chain (real `ModelResolver` → real `IntentRouter.getTrust` thunk):
  - **local-only + research** → real `_probeWeb` egressed, WebReader enriched 2/3, `web fallback added 3 result(s)`, real web content reached synthesis framed `[Source: web]`. *(pre-#136 this was suppressed — the decoupling.)*
  - **local-only + sovereign** → `web fallback suppressed: sovereign policy`, zero egress.
  - **cloud-ok + research** → web still fires (no regression).
  - **cloud-ok + research + workspace data** → `web fallback suppressed: workspace probe returned data` (gate intact).
  - Only the self-hosted SearXNG was wired — no commercial provider called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVv4sDCp6rA3XLoRmEcNRQ
