### PR TITLE
fix(workflow): resolve GATE reviewer from a declared marker, not board ownership (#183)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -1253,14 +1253,6 @@ class WorkflowEngine {
   }
 
   /**
-   * Get the human user for GATE assignments.
-   * @private
-   */
-  _getHumanUser() {
-    return this.config.adminUser || 'admin';
-  }
-
-  /**
    * Resolve the declared GATE reviewer uid for a given stack/board.
    * Never returns the bot uid — the convergence guard depends on this guarantee.
    *
@@ -1303,8 +1295,8 @@ class WorkflowEngine {
       if (uid && uid !== bot) return uid;
     }
 
-    // Step 3: deterministic config default — only the explicitly configured value
-    // (NOT _getHumanUser()'s 'admin' sentinel).
+    // Step 3: deterministic config default — only the explicitly configured
+    // value, never a fallback sentinel that could resolve to a non-existent user.
     const admin = this.config.adminUser;
     if (admin && admin !== bot) return admin;
 

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -540,8 +540,10 @@ class WorkflowEngine {
 
       // Handoff back: unassign human, assign bot for automated processing
       const botUser = this.deck.username || this.botUsername;
-      const humanUser = wb.board.owner?.uid || wb.board.owner || this._getHumanUser();
-      await this._safeUnassign(board.id, stack.id, card.id, humanUser);
+      const humanUser = this._resolveGateReviewer(wb, stack);
+      if (humanUser && humanUser !== botUser) {
+        await this._safeUnassign(board.id, stack.id, card.id, humanUser);
+      }
       await this._safeAssign(board.id, stack.id, card.id, botUser);
       console.log(`[Workflow] GATE resolution handoff: "${card.title}" → ${botUser}`);
 
@@ -638,13 +640,22 @@ class WorkflowEngine {
 
     // Safety net: if GATE card is still assigned to bot, reassign to human.
     // This catches cases where the LLM stamped GATE but forgot to reassign.
-    const botUser = this.deck.username || this.botUsername;
-    const assignedUids = (card.assignedUsers || []).map(u => u.participant?.uid);
-    if (assignedUids.includes(botUser)) {
-      const humanUser = wb.board.owner?.uid || wb.board.owner || this._getHumanUser();
-      await this._safeUnassign(board.id, stack.id, card.id, botUser);
-      await this._safeAssign(board.id, stack.id, card.id, humanUser);
-      console.log(`[Workflow] GATE safety net: reassigned "${card.title}" from ${botUser} to ${humanUser}`);
+    {
+      const bot = this.deck.username || this.botUsername;
+      const assignedUids = (card.assignedUsers || []).map(u => u.participant?.uid).filter(Boolean);
+      // Terminal: already assigned to a real (non-bot) human → done, never touch.
+      if (!assignedUids.some(uid => uid !== bot)) {
+        // Only act if the card is still assigned to the bot.
+        if (assignedUids.includes(bot)) {
+          const human = this._resolveGateReviewer(wb, stack);
+          // No human resolvable → do NOT churn (notification already fired once above).
+          if (human && human !== bot) {
+            await this._safeUnassign(board.id, stack.id, card.id, bot);
+            await this._safeAssign(board.id, stack.id, card.id, human);
+            console.log(`[Workflow] GATE safety net: reassigned "${card.title}" from ${bot} to ${human}`);
+          }
+        }
+      }
     }
 
     return false;
@@ -1206,7 +1217,8 @@ class WorkflowEngine {
     const isDone = this._isDoneStack(wb, stack);
     if (isDone) return; // Don't assign Done cards
 
-    const userId = isGate ? this._getHumanUser() : (this.deck.username || this.botUsername);
+    const userId = isGate ? this._resolveGateReviewer(wb, stack) : (this.deck.username || this.botUsername);
+    if (!userId) return;
     await this._safeAssign(wb.board.id, stack.id, card.id, userId);
   }
 
@@ -1246,6 +1258,58 @@ class WorkflowEngine {
    */
   _getHumanUser() {
     return this.config.adminUser || 'admin';
+  }
+
+  /**
+   * Resolve the declared GATE reviewer uid for a given stack/board.
+   * Never returns the bot uid — the convergence guard depends on this guarantee.
+   *
+   * Source of truth: a structural `REVIEWER: <uid>` marker declared in the board
+   * WORKFLOW rules card or the stack CONFIG card — same convention as TRIGGER:/MODEL:/
+   * SLA:/LLM: markers.  Board ownership and ACL are NOT consulted (declared intent
+   * is the only authority; inferring from NC ownership was the #183 generator).
+   *
+   * Resolution order (first hit wins):
+   * 1. Stack CONFIG card `REVIEWER: <uid>` — most specific override.
+   * 2. Board WORKFLOW rules `REVIEWER: <uid>` from wb._plainDescription.
+   * 3. config.adminUser, if explicitly set and !== bot.
+   * 4. null — no resolvable reviewer; callers must NOT churn assignments.
+   *
+   * @param {Object} wb    - Workflow board descriptor (wb._plainDescription)
+   * @param {Object} stack - Current stack (used to locate the CONFIG card)
+   * @returns {string|null}
+   * @private
+   */
+  _resolveGateReviewer(wb, stack) {
+    const bot = this.deck.username || this.botUsername;
+
+    // Step 1: stack CONFIG card — most specific (mirrors _extractStackLlmRouting pattern).
+    const configCard = findConfigCard(stack);
+    if (configCard?.description) {
+      const plain = stripHtml(configCard.description);
+      const m = plain.match(/^REVIEWER:\s*(\S+)\s*$/im);
+      if (m) {
+        const uid = m[1].trim();
+        // A declared reviewer that equals the bot uid is a misconfiguration — treat as absent.
+        if (uid && uid !== bot) return uid;
+      }
+    }
+
+    // Step 2: board WORKFLOW rules card.
+    const boardDesc = wb._plainDescription || '';
+    const bm = boardDesc.match(/^REVIEWER:\s*(\S+)\s*$/im);
+    if (bm) {
+      const uid = bm[1].trim();
+      if (uid && uid !== bot) return uid;
+    }
+
+    // Step 3: deterministic config default — only the explicitly configured value
+    // (NOT _getHumanUser()'s 'admin' sentinel).
+    const admin = this.config.adminUser;
+    if (admin && admin !== bot) return admin;
+
+    // Step 4: unresolvable — return null so callers never churn.
+    return null;
   }
 
   /**

--- a/test/unit/workflows/gate-llm-driven.test.js
+++ b/test/unit/workflows/gate-llm-driven.test.js
@@ -86,7 +86,7 @@ function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}
         ...extraCards
       ]
     }],
-    description: 'WORKFLOW: pipeline\nRULES: Process cards.',
+    description: 'WORKFLOW: pipeline\nREVIEWER: jordan\nRULES: Process cards.',
     workflowType: 'pipeline',
     boardId: 1
   };

--- a/test/unit/workflows/workflow-engine.test.js
+++ b/test/unit/workflows/workflow-engine.test.js
@@ -711,29 +711,6 @@ function createMockTalkQueue() {
     assert.strictEqual(putCalls.length, 0, 'Should never archive the rules card');
   });
 
-  // --- _getHumanUser ---
-
-  test('_getHumanUser() returns configured admin or default', () => {
-    const engine1 = new WorkflowEngine({
-      workflowDetector: createMockDetector(),
-      deckClient: createMockDeck(),
-      agentLoop: createMockAgentLoop(),
-      talkSendQueue: createMockTalkQueue(),
-      talkToken: 'test-token',
-      config: { adminUser: 'jordan' }
-    });
-    assert.strictEqual(engine1._getHumanUser(), 'jordan');
-
-    const engine2 = new WorkflowEngine({
-      workflowDetector: createMockDetector(),
-      deckClient: createMockDeck(),
-      agentLoop: createMockAgentLoop(),
-      talkSendQueue: createMockTalkQueue(),
-      talkToken: 'test-token'
-    });
-    assert.strictEqual(engine2._getHumanUser(), 'admin');
-  });
-
   // ─── _extractStackLlmRouting tests ────────────────────────────────────
 
   await asyncTest('_extractStackLlmRouting: extracts LLM: cloud from CONFIG card', async () => {

--- a/test/unit/workflows/workflow-engine.test.js
+++ b/test/unit/workflows/workflow-engine.test.js
@@ -1044,6 +1044,505 @@ function createMockTalkQueue() {
     assert.ok(relevant[0].includes('403'), 'Warning should include status code');
   });
 
+  // ---------------------------------------------------------------------------
+  // TC-GATE-183 — _resolveGateReviewer (declared REVIEWER: marker) + safety-net convergence guard
+  // ---------------------------------------------------------------------------
+
+  // TC-GATE-183-01: no REVIEWER declared in WORKFLOW or CONFIG, no adminUser set, bot-assigned card
+  // → resolver returns null → safety net makes ZERO assign/unassign PUTs (the #183 regression).
+  // (board.owner is intentionally the bot here to confirm ownership is never consulted.)
+  await asyncTest('TC-GATE-183-01: no REVIEWER declared, no adminUser → safety net makes zero PUTs', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+      // no config.adminUser
+    });
+    // deck.username is set to 'moltagent' via botUsername default
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' /* owner IS the bot */ },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: ...'
+    };
+    const stack = { id: 10, title: 'Review' };
+    // GATE label (not resolved), assigned to the bot
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    // Seed the gate as already notified so the Talk/comment path is skipped
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 0, 'TC-GATE-183-01: must make zero assign/unassign PUTs');
+  });
+
+  // TC-GATE-183-02: no REVIEWER declared, config.adminUser='jordan' → falls through to step 3
+  // → exactly one unassign(moltagent) + one assign(jordan).
+  await asyncTest('TC-GATE-183-02: config.adminUser=jordan (no REVIEWER declared) → unassign bot, assign jordan', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token',
+      config: { adminUser: 'jordan' }
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: ...'
+    };
+    const stack = { id: 10, title: 'Review' };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 2, 'TC-GATE-183-02: expect exactly 2 PUTs');
+    const unassign = puts.find(c => c.path.includes('unassignUser'));
+    const assign   = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(unassign, 'TC-GATE-183-02: must have an unassign call');
+    assert.strictEqual(unassign.body.userId, 'moltagent', 'TC-GATE-183-02: must unassign bot');
+    assert.ok(assign, 'TC-GATE-183-02: must have an assign call');
+    assert.strictEqual(assign.body.userId, 'jordan', 'TC-GATE-183-02: must assign jordan');
+  });
+
+  // TC-GATE-183-03: card already assigned to 'jordan' → zero PUTs; run twice → still zero.
+  await asyncTest('TC-GATE-183-03: already-assigned-to-human card → zero PUTs across two runs', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token',
+      config: { adminUser: 'jordan' }
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: ...'
+    };
+    const stack = { id: 10, title: 'Review' };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'jordan' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 0, 'TC-GATE-183-03: zero PUTs across both runs');
+  });
+
+  // TC-GATE-183-04: no REVIEWER declared, adminUser===bot → all three resolver steps exhausted → null → zero PUTs.
+  // (board.owner is also bot, confirming ownership is not a fallback.)
+  await asyncTest('TC-GATE-183-04: adminUser===bot, no REVIEWER declared → resolver returns null → zero PUTs', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token',
+      config: { adminUser: 'moltagent' } // adminUser IS the bot — resolver must skip
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: ...'
+    };
+    const stack = { id: 10, title: 'Review' };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 0, 'TC-GATE-183-04: no bot→bot reassign');
+  });
+
+  // TC-GATE-183-05a: stack CONFIG card declares `REVIEWER: sam`, board owner=bot, no adminUser
+  // → resolver reads CONFIG card first and assigns sam.
+  // Confirms board ownership is NOT consulted (owner is bot, yet a human is assigned).
+  await asyncTest('TC-GATE-183-05a: CONFIG card REVIEWER:sam + owner=bot → assigns sam (not owner)', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+      // no adminUser
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' /* bot — must not be used */ },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: ...'
+    };
+    // Stack with a CONFIG card that carries REVIEWER: sam
+    const stack = {
+      id: 10,
+      title: 'Review',
+      cards: [
+        { id: 901, title: 'CONFIG: Review Stack', description: 'REVIEWER: sam\nLLM: local', labels: [] }
+      ]
+    };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 2, 'TC-GATE-183-05a: expect 2 PUTs (unassign bot + assign sam)');
+    const assign = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(assign, 'TC-GATE-183-05a: must have an assign call');
+    assert.strictEqual(assign.body.userId, 'sam', 'TC-GATE-183-05a: must assign sam from CONFIG card');
+  });
+
+  // TC-GATE-183-05b: board WORKFLOW rules declare `REVIEWER: dana`, no CONFIG card override
+  // → resolver reads WORKFLOW rules (step 2) and assigns dana.
+  await asyncTest('TC-GATE-183-05b: board WORKFLOW REVIEWER:dana (no CONFIG) → assigns dana', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+      // no adminUser
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: dana\nRULES: ...'
+    };
+    // Stack has no CONFIG card
+    const stack = { id: 10, title: 'Review', cards: [] };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 2, 'TC-GATE-183-05b: expect 2 PUTs (unassign bot + assign dana)');
+    const assign = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(assign, 'TC-GATE-183-05b: must have an assign call');
+    assert.strictEqual(assign.body.userId, 'dana', 'TC-GATE-183-05b: must assign dana from WORKFLOW rules');
+  });
+
+  // TC-GATE-183-05c: CONFIG card REVIEWER:quinn overrides board WORKFLOW REVIEWER:dana
+  // → stack-specific wins (step 1 before step 2).
+  await asyncTest('TC-GATE-183-05c: CONFIG REVIEWER:quinn overrides WORKFLOW REVIEWER:dana', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'moltagent' },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: dana\nRULES: ...'
+    };
+    // Stack CONFIG card declares a different reviewer — must win over board-level
+    const stack = {
+      id: 10,
+      title: 'Review',
+      cards: [
+        { id: 901, title: 'CONFIG: Review Stack', description: 'REVIEWER: quinn', labels: [] }
+      ]
+    };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 2, 'TC-GATE-183-05c: expect 2 PUTs (unassign bot + assign quinn)');
+    const assign = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(assign, 'TC-GATE-183-05c: must have an assign call');
+    assert.strictEqual(assign.body.userId, 'quinn', 'TC-GATE-183-05c: CONFIG REVIEWER wins over WORKFLOW REVIEWER');
+  });
+
+  // TC-GATE-183-05d: board owner = real human 'pat', but REVIEWER: quinn declared
+  // → assigns quinn, NOT pat. Proves board.owner is never consulted.
+  await asyncTest('TC-GATE-183-05d: declared REVIEWER:quinn wins even when owner=pat (owner ignored)', async () => {
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop: createMockAgentLoop(),
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+      // no adminUser
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Test', owner: 'pat' /* real human — must NOT be picked */ },
+      stacks: [],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: quinn\nRULES: ...'
+    };
+    const stack = { id: 10, title: 'Review', cards: [] };
+    const card = {
+      id: 200,
+      title: 'GATE: Needs Review',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [{ participant: { uid: 'moltagent' } }]
+    };
+
+    engine._notifiedGates.add('1:200');
+
+    await engine._handleGate(wb, stack, card);
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    assert.strictEqual(puts.length, 2, 'TC-GATE-183-05d: expect 2 PUTs');
+    const assign = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(assign, 'TC-GATE-183-05d: must have an assign call');
+    assert.strictEqual(assign.body.userId, 'quinn', 'TC-GATE-183-05d: must assign quinn, not the board owner pat');
+  });
+
+  // TC-GATE-183-06: APPROVED card → final assign is bot, processWorkflowTask invoked.
+  await asyncTest('TC-GATE-183-06: APPROVED label → handoff to bot, processWorkflowTask called', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeck();
+    const requestCalls = [];
+    mockDeck._request = async (method, path, body) => {
+      requestCalls.push({ method, path, body });
+      return {};
+    };
+    // getBoard is called to fetch board labels on the resolution path
+    mockDeck.getBoard = async () => ({ labels: [] });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector(),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token',
+      config: { adminUser: 'jordan' }
+    });
+    engine.deck.username = 'moltagent';
+
+    const wb = {
+      board: { id: 1, title: 'Partner Inquiries', owner: 'jordan' },
+      stacks: [{ id: 10, title: 'Review', cards: [] }],
+      description: 'WORKFLOW: pipeline',
+      _plainDescription: 'RULES: After APPROVED move to Done.'
+    };
+    const stack = { id: 10, title: 'Review', cards: [] };
+    // Card has APPROVED label — resolution path fires
+    const card = {
+      id: 200,
+      title: 'GATE: Review Partner Proposal',
+      labels: [{ title: 'GATE' }, { title: 'APPROVED' }],
+      assignedUsers: [{ participant: { uid: 'jordan' } }]
+    };
+
+    const resolved = await engine._handleGate(wb, stack, card);
+
+    assert.strictEqual(resolved, true, 'TC-GATE-183-06: resolved gate must return true');
+    assert.strictEqual(agentLoop._calls.length, 1, 'TC-GATE-183-06: processWorkflowTask must be called');
+
+    const puts = requestCalls.filter(c => c.method === 'PUT');
+    // unassign jordan + assign moltagent
+    const unassign = puts.find(c => c.path.includes('unassignUser'));
+    const assign   = puts.find(c => c.path.endsWith('/assignUser'));
+    assert.ok(unassign, 'TC-GATE-183-06: must unassign human on resolution');
+    assert.strictEqual(unassign.body.userId, 'jordan', 'TC-GATE-183-06: unassigns jordan');
+    assert.ok(assign, 'TC-GATE-183-06: must assign bot on resolution');
+    assert.strictEqual(assign.body.userId, 'moltagent', 'TC-GATE-183-06: assigns moltagent');
+  });
+
+  // TC-GATE-183-07: _ensureAssignment on fresh unassigned GATE card uses _resolveGateReviewer.
+  // With adminUser===bot + no REVIEWER declared → resolver null → no assign PUT.
+  // With adminUser='jordan' → step 3 → assign(jordan).
+  await asyncTest('TC-GATE-183-07: _ensureAssignment GATE branch uses _resolveGateReviewer', async () => {
+    // Case A: no resolvable human → no PUT
+    {
+      const mockDeck = createMockDeck();
+      const requestCallsA = [];
+      mockDeck._request = async (method, path, body) => {
+        requestCallsA.push({ method, path, body });
+        return {};
+      };
+      const engineA = new WorkflowEngine({
+        workflowDetector: createMockDetector(),
+        deckClient: mockDeck,
+        agentLoop: createMockAgentLoop(),
+        talkSendQueue: createMockTalkQueue(),
+        talkToken: 'test-token',
+        config: { adminUser: 'moltagent' } // admin IS the bot
+      });
+      engineA.deck.username = 'moltagent';
+
+      const wb = {
+        board: { id: 1, title: 'Test', owner: 'moltagent' },
+        stacks: [],
+        description: 'WORKFLOW: pipeline'
+      };
+      const stack = { id: 10, title: 'Review' };
+      const card = { id: 200, title: 'GATE: Approval', labels: [{ title: 'GATE' }], assignedUsers: [] };
+
+      await engineA._ensureAssignment(wb, stack, card);
+
+      const putsA = requestCallsA.filter(c => c.method === 'PUT');
+      assert.strictEqual(putsA.length, 0, 'TC-GATE-183-07a: no PUT when no REVIEWER declared and adminUser===bot');
+    }
+
+    // Case B: adminUser='jordan' → assign(jordan)
+    {
+      const mockDeck = createMockDeck();
+      const requestCallsB = [];
+      mockDeck._request = async (method, path, body) => {
+        requestCallsB.push({ method, path, body });
+        return {};
+      };
+      const engineB = new WorkflowEngine({
+        workflowDetector: createMockDetector(),
+        deckClient: mockDeck,
+        agentLoop: createMockAgentLoop(),
+        talkSendQueue: createMockTalkQueue(),
+        talkToken: 'test-token',
+        config: { adminUser: 'jordan' }
+      });
+      engineB.deck.username = 'moltagent';
+
+      const wb = {
+        board: { id: 1, title: 'Test', owner: 'moltagent' },
+        stacks: [],
+        description: 'WORKFLOW: pipeline'
+      };
+      const stack = { id: 10, title: 'Review' };
+      const card = { id: 200, title: 'GATE: Approval', labels: [{ title: 'GATE' }], assignedUsers: [] };
+
+      await engineB._ensureAssignment(wb, stack, card);
+
+      const putsB = requestCallsB.filter(c => c.method === 'PUT' && c.path.includes('assignUser'));
+      assert.strictEqual(putsB.length, 1, 'TC-GATE-183-07b: exactly one assign PUT');
+      assert.strictEqual(putsB[0].body.userId, 'jordan', 'TC-GATE-183-07b: assigns jordan');
+    }
+  });
+
   summary();
   exitWithCode();
 })();


### PR DESCRIPTION
Fixes #183.

## Problem

The GATE handler inferred the human reviewer from NC board ownership (`wb.board.owner`). On a board the agent **owns** — a valid configuration (the agent's own workspace) — that resolves to the bot itself, so `botUser === humanUser`. The unresolved-gate safety net then unassigned and reassigned the same uid on every heartbeat pulse and never handed the card to a human.

**Confirmed on the live journal** (not the originating stamp-race hypothesis): ~90 consecutive pulses across three parked GATE cards logged `GATE safety net: reassigned "<card>" from <bot> to <bot>`, `0 card(s) / 0 gate(s) resolved`, until the board was force-PAUSED. GATE cards `continue` before `_shouldProcess` ever runs, so the idempotency stamp was never the active generator here; the assignee resolution was.

## Fix (generator-level)

Stop reading board ownership; resolve a reviewer the operator **declares**. New `_resolveGateReviewer(wb, stack)` reads a structural `REVIEWER: <uid>` marker — same convention as the existing `TRIGGER:` / `MODEL:` / `SLA:` / `LLM:` markers — in deterministic order:

1. stack CONFIG card `REVIEWER:`
2. board WORKFLOW rules `REVIEWER:`
3. configured admin default (`config.adminUser`, if set and not the bot)
4. `null`

It can never return the bot uid; `board.owner` and the ACL are removed from the reviewer path entirely. One path serves both models: a user-owned board declares that user, an agent-owned board declares the human.

The safety net now **converges**: terminal once a non-bot human is assigned, and a no-op when no reviewer resolves (the once-per-process notification already fired) — never a bot-to-bot reassignment. The resolution handoff and `_ensureAssignment` route through the same resolver, collapsing the two divergent definitions of "the human" into one.

Out of scope (separate later design): conditional multi-human routing.

## Tests

`TC-GATE-183-01..07` (10 cases), including **05d** — a declared reviewer wins even when the board owner is a real human, proving ownership is never consulted (would fail under the old logic). 228/228 unit files pass, lint 0 errors.

## Verification status

BUILT + unit-verified. **Not yet live-verified** — the board remains PAUSED. Live gate: deploy, declare the reviewer (or rely on the admin-default fallback), un-pause, and confirm a GATE card sits stable across ≥2 pulses assigned to the declared human with no assign/unassign churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)