### PR TITLE
fix(workflow): carry sender address into trigger-bridge ingest card (#185)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -984,7 +984,24 @@ class WorkflowEngine {
       // Build the card title and description.
       const title = email.subject || '(No subject)';
       const bodyText = (email.body || '').slice(0, 2000);
-      let description = bodyText + '\n\n---\nFrom: ' + (email.from || '') +
+
+      // Custody fix (#185): carry the canonical fromAddress so downstream beats
+      // do not need to re-derive or fabricate it. Use RFC 5322 "Name <addr>" form.
+      // Invariant: when the display string already contains the address, do NOT
+      // duplicate it (handles the common "Name <addr>" production from IMAP).
+      const fromDisplay = email.from || '';
+      const fromAddr    = email.fromAddress || '';
+      let fromLine;
+      if (!fromAddr || fromDisplay.includes(fromAddr)) {
+        // Address absent or already embedded in the display string — preserve as-is.
+        fromLine = fromDisplay;
+      } else if (fromDisplay) {
+        fromLine = fromDisplay + ' <' + fromAddr + '>';
+      } else {
+        fromLine = '<' + fromAddr + '>';
+      }
+
+      let description = bodyText + '\n\n---\nFrom: ' + fromLine +
         '\nDate: ' + (email.date || '') +
         '\nMessage-ID: ' + key;
 

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -329,6 +329,7 @@ function makeEmail(overrides = {}) {
     const email = makeEmail({
       messageId: '<footer-test@example.com>',
       from: 'Bob <bob@example.com>',
+      fromAddress: 'bob@example.com',
       date: new Date('2026-06-17T12:00:00Z'),
       body: 'Body content here.'
     });
@@ -525,6 +526,86 @@ function makeEmail(overrides = {}) {
       !desc.includes('[Open the original email in Mail]'),
       'no Mail link should appear when resolveThreadUrl threw'
     );
+  });
+
+  // TC-TRIGGER-20: from is display-name only, fromAddress present → From line is
+  //               "Name <addr>" — custody fix #185.
+  await asyncTest('TC-TRIGGER-20: from=display-name-only + fromAddress → From line is Name <addr>', async () => {
+    const email = makeEmail({
+      messageId: '<from-addr-20@example.com>',
+      from: 'Test Sender',
+      fromAddress: 'test@example.com',
+      body: 'Body.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1);
+    const desc = deck._calls[0].description;
+    assert.ok(
+      desc.includes('From: Test Sender <test@example.com>'),
+      'From line should be "Test Sender <test@example.com>" — got: ' + desc
+    );
+  });
+
+  // TC-TRIGGER-21: from is display-name only, fromAddress empty → From line is name
+  //               with NO empty angle brackets (custody fix #185).
+  await asyncTest('TC-TRIGGER-21: from=display-name-only + fromAddress="" → no empty <>', async () => {
+    const email = makeEmail({
+      messageId: '<from-addr-21@example.com>',
+      from: 'Test Sender',
+      fromAddress: '',
+      body: 'Body.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1);
+    const desc = deck._calls[0].description;
+    assert.ok(
+      !desc.includes('<>'),
+      'From line must NOT contain empty angle brackets <>'
+    );
+    assert.ok(
+      desc.includes('From: Test Sender'),
+      'From line should contain the display name — got: ' + desc
+    );
+  });
+
+  // TC-TRIGGER-22: from already contains the address → no duplication (no-duplication
+  //               invariant from custody fix #185; also guards TC-TRIGGER-13 regression).
+  await asyncTest('TC-TRIGGER-22: from already contains address → address appears exactly once', async () => {
+    const email = makeEmail({
+      messageId: '<from-addr-22@example.com>',
+      from: 'Dup <dup@example.com>',
+      fromAddress: 'dup@example.com',
+      body: 'Body.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1);
+    const desc = deck._calls[0].description;
+    // The address must not appear a second time after a closing '>'
+    assert.ok(
+      !desc.includes('dup@example.com> <dup@example.com>'),
+      'address must not be duplicated in the From line — got: ' + desc
+    );
+    // And it must appear at least once
+    const count = (desc.match(/dup@example\.com/g) || []).length;
+    assert.strictEqual(count, 1, 'dup@example.com should appear exactly once, found: ' + count);
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Summary

The email-trigger bridge (#170) ingests unread emails as Deck cards each heartbeat pulse. The card's `From:` footer was built from `email.from` (the display string) alone and dropped `email.fromAddress` — the canonical address parsed upstream in `EmailHandler._fetchEmails` from `parsed.from?.value?.[0]?.address`.

With no address in the card, a downstream profile-compile beat (instructed to "compile who the sender is") fabricated a `firstname.lastname@domain` address from the display name and a signature, and wrote it to a Knowledge page as fact. No tool produced it; no header contained it.

This is the **signals-keep-custody** class: a value known canonically upstream is dropped before its consumer, which then re-derives it by fabrication. The fix carries the canonical value so there is nothing to re-derive.

## Change

One surface — the card-description assembly in `workflow-engine.js`. The `From:` line now carries the address in RFC 5322 `Name <address>` form, sourced from the canonical `email.fromAddress`.

Invariants:
- **Additive** — when the display string already embeds the address, it is left as-is (no duplication).
- Address present and not embedded → ` <address>` appended.
- Address absent/empty → display name only, **no empty angle brackets**.
- Empty display + present address → `<address>` (no leading space).

The Date, Message-ID, and NC Mail link (#178/#179) lines are unchanged. No new tool, no output guard, no tool-registry change.

## Tests

`TC-TRIGGER-20/21/22` in `email-trigger-bridge.test.js`: name+address, empty address, and the no-duplication invariant. **228/228** unit test files pass, lint 0 errors.

## Not in this PR

- The WORKFLOW prompt-card grounding clause on the workflow board is a live Deck edit (secondary guard), applied at deploy time, not in code.
- The profile beat itself is unchanged (#188 reshapes it; this is its prerequisite).
- Existing Knowledge pages from prior runs retain the invented address until re-run.

## Verification

Test-level only so far. Live Verification Gate (send a test email → confirm the card `From:` carries the real address → confirm the beat writes the real address to Knowledge) is pending a Prime deploy and stays gated.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
