### PR TITLE
feat(workflow): wire research stage to web, deterministic slots, structured grounding (#186, #188)

### DIFF
--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -437,7 +437,7 @@ class AgentLoop {
    * @param {number} [params.maxIterations] - Override max iterations (default: this.maxIterations)
    * @returns {Promise<string>} The agent's final text response
    */
-  async processWorkflowTask({ systemAddition, task, boardId, cardId, stackId, forceLocal, allowCloud, cloudTier, maxIterations }) {
+  async processWorkflowTask({ systemAddition, task, boardId, cardId, stackId, forceLocal, allowCloud, cloudTier, maxIterations, searchPolicy }) {
     const startTime = Date.now();
     const iterLimit = maxIterations || this.maxIterations;
     this.logger.info(`[AgentLoop] Workflow task: board=${boardId} card=${cardId} maxIter=${iterLimit}`);
@@ -462,7 +462,8 @@ class AgentLoop {
       tools = this.toolRegistry.getWorkflowToolDefinitions({ includeUpdateCard: cardId > 0 });
     } else {
       // Per-card processing (cardId > 0) gets update_card; schedules (cardId === 0) don't.
-      tools = this.toolRegistry.getCloudWorkflowToolDefinitions(systemAddition, { includeUpdateCard: cardId > 0 });
+      // searchPolicy gates web_search/web_read: excluded only when 'sovereign'.
+      tools = this.toolRegistry.getCloudWorkflowToolDefinitions(systemAddition, { includeUpdateCard: cardId > 0, searchPolicy });
     }
 
     const messages = [

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -161,9 +161,15 @@ class ToolRegistry {
    * Keeps tool count low (5-10 instead of 54) to reduce token cost.
    *
    * @param {string} [boardContext=''] - The workflow system addition (board rules, card info)
+   * @param {Object} [options]
+   * @param {boolean} [options.includeUpdateCard=false] - Include workflow_deck_update_card
+   * @param {string} [options.searchPolicy] - System search policy: 'research'|'internal-first'|'sovereign'.
+   *   When 'research' or 'internal-first' (default when undefined), web_search and web_read are
+   *   added to the palette. When 'sovereign', they remain excluded.
+   *   Gate is advertising-only (execution is uncaged, matching the #133 subset guardrail).
    * @returns {Array<{type: 'function', function: {name: string, description: string, parameters: Object}}>}
    */
-  getCloudWorkflowToolDefinitions(boardContext = '', { includeUpdateCard = false } = {}) {
+  getCloudWorkflowToolDefinitions(boardContext = '', { includeUpdateCard = false, searchPolicy } = {}) {
     // Base tools every workflow needs
     const allowed = new Set([
       'workflow_deck_move_card',
@@ -177,6 +183,15 @@ class ToolRegistry {
     // Schedules only create cards, never update existing ones.
     if (includeUpdateCard) {
       allowed.add('workflow_deck_update_card');
+    }
+
+    // Web tools: included when searchPolicy is not 'sovereign'.
+    // Default (undefined) is treated as 'research' — web is on.
+    // Both 'research' and 'internal-first' mean web is available in a research
+    // stage (the stage's purpose is the signal, not the policy mode).
+    if (searchPolicy !== 'sovereign') {
+      allowed.add('web_search');
+      allowed.add('web_read');
     }
 
     // Scan context for capabilities the board actually needs

--- a/src/lib/workflows/slot-proposer.js
+++ b/src/lib/workflows/slot-proposer.js
@@ -1,0 +1,422 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ */
+
+/**
+ * Slot Proposer — Deterministic meeting-slot generator (#186 / #188)
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: The workflow research beat proposes meeting slots by asking the LLM
+ * to compute dates, which causes systematic off-by-one weekday errors (#186).
+ * Date arithmetic is plumbing, not intelligence — it belongs in code.
+ *
+ * Pattern: Pure function that accepts busy blocks (from CalDAV) and scheduling
+ * config (from CONFIG markers), and produces formatted slot strings. The LLM
+ * receives the finished strings; it never does date math, timezone conversion,
+ * or business-hours filtering.
+ *
+ * Key Design Choices:
+ *   - `now` is injected so tests are deterministic (no Date.now() inside).
+ *   - Day-of-week and month names come exclusively from Intl.DateTimeFormat —
+ *     never hardcoded — so DE/PT/EN all work without code changes (Rule 3).
+ *   - Timezone abbreviation (e.g. "WEST") is computed by Intl and may vary
+ *     across environments; callers/tests assert presence, not a specific string.
+ *   - No LLM call, no I/O — testable in isolation.
+ *
+ * Dependency Map:
+ *   proposeSlots()
+ *     ← WorkflowEngine._processCard() (builds grounding block)
+ *     ← test/unit/workflows/slot-proposer.test.js
+ *
+ * @module workflows/slot-proposer
+ * @version 1.0.0
+ */
+
+'use strict';
+
+/**
+ * Days-of-week abbreviations accepted in the HOURS marker.
+ * Each value is the JS Date.getDay() equivalent (0=Sun, 1=Mon, ..., 6=Sat).
+ * @private
+ */
+const DAY_NAMES = {
+  sun: 0, sunday: 0,
+  mon: 1, monday: 1,
+  tue: 2, tuesday: 2,
+  wed: 3, wednesday: 3,
+  thu: 4, thursday: 4,
+  fri: 5, friday: 5,
+  sat: 6, saturday: 6
+};
+
+/**
+ * Parse a day string ("Mon", "Monday", "mon") to a JS day number (0–6).
+ * Returns null if unrecognized.
+ * @param {string} str
+ * @returns {number|null}
+ * @private
+ */
+function _parseDayName(str) {
+  return DAY_NAMES[str.toLowerCase().trim()] ?? null;
+}
+
+/**
+ * Expand a day range like "Mon-Fri" into the set of JS day numbers.
+ * Handles wraparound (e.g. "Sat-Sun") but not multi-segment ranges —
+ * those are not used in practice and would require a full parser.
+ * @param {string} rangeStr - e.g. "Mon-Fri", "Tue-Thu"
+ * @returns {Set<number>} JS getDay() values
+ * @private
+ */
+function _expandDayRange(rangeStr) {
+  const parts = rangeStr.split('-').map(s => s.trim());
+  if (parts.length === 1) {
+    const d = _parseDayName(parts[0]);
+    return d !== null ? new Set([d]) : new Set();
+  }
+  const start = _parseDayName(parts[0]);
+  const end   = _parseDayName(parts[1]);
+  if (start === null || end === null) return new Set();
+  const days = new Set();
+  let cur = start;
+  // Walk forward (with wraparound) from start to end inclusive
+  while (true) {
+    days.add(cur);
+    if (cur === end) break;
+    cur = (cur + 1) % 7;
+    // Safety: if we've gone all the way around, stop
+    if (cur === start) break;
+  }
+  return days;
+}
+
+/**
+ * Parse a time string like "09:00" into minutes-of-day (integer).
+ * Returns null if unparseable.
+ * @param {string} timeStr - "HH:MM"
+ * @returns {number|null}
+ * @private
+ */
+function _parseTime(timeStr) {
+  if (!timeStr) return null;
+  const m = timeStr.trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return null;
+  const h = parseInt(m[1], 10);
+  const min = parseInt(m[2], 10);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/**
+ * Parse an HOURS marker value into a structured object.
+ *
+ * Accepted formats:
+ *   "Mon-Fri 09:00-17:00"   → days=Set{1,2,3,4,5}, startMinutes=540, endMinutes=1020
+ *   "Tue-Thu 08:30-16:30"
+ *
+ * Returns null when the value cannot be parsed (caller falls through to default).
+ *
+ * @param {string} value - Raw value after "HOURS:"
+ * @returns {{ days: Set<number>, startMinutes: number, endMinutes: number }|null}
+ */
+function parseHoursMarker(value) {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+
+  // Expected: "<day-range> <start>-<end>"
+  // e.g. "Mon-Fri 09:00-17:00"
+  const m = trimmed.match(/^([A-Za-z]+(?:-[A-Za-z]+)?)\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$/);
+  if (!m) return null;
+
+  const days = _expandDayRange(m[1]);
+  if (days.size === 0) return null;
+
+  const startMinutes = _parseTime(m[2]);
+  const endMinutes   = _parseTime(m[3]);
+  if (startMinutes === null || endMinutes === null) return null;
+  if (startMinutes >= endMinutes) return null;
+
+  return { days, startMinutes, endMinutes };
+}
+
+/**
+ * Determine whether a candidate slot (start–end Date pair) overlaps any busy
+ * block.  Overlap: slot.start < block.end AND slot.end > block.start.
+ * @param {Date} slotStart
+ * @param {Date} slotEnd
+ * @param {Array<{start:Date,end:Date}>} busyBlocks
+ * @returns {boolean}
+ * @private
+ */
+function _overlaps(slotStart, slotEnd, busyBlocks) {
+  for (const block of busyBlocks) {
+    const bs = block.start instanceof Date ? block.start : new Date(block.start);
+    const be = block.end   instanceof Date ? block.end   : new Date(block.end);
+    if (slotStart < be && slotEnd > bs) return true;
+  }
+  return false;
+}
+
+/**
+ * Format a slot into a human-readable string using Intl, fully locale-aware.
+ * Example output (EN): "Wednesday, 25 June 2026, 09:00–09:30 (CEST)"
+ * Example output (DE): "Mittwoch, 25. Juni 2026, 09:00–09:30 (MESZ)"
+ * Example output (PT): "quarta-feira, 25 de junho de 2026, 09:00–09:30 (WEST)"
+ *
+ * @param {Date} start - Slot start (UTC Date)
+ * @param {Date} end   - Slot end   (UTC Date)
+ * @param {string} locale   - BCP-47 locale string, e.g. "en", "de", "pt"
+ * @param {string} timezone - IANA timezone, e.g. "Europe/Lisbon"
+ * @returns {string}
+ * @private
+ */
+function _formatSlot(start, end, locale, timezone) {
+  // Date portion: weekday, day, month, year
+  const dateFmt = new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: timezone
+  });
+
+  // Time start with short timezone name
+  const startFmt = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: timezone,
+    timeZoneName: 'short'
+  });
+
+  // Time end (no timezone — we grab it from the start formatter)
+  const endFmt = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: timezone
+  });
+
+  const datePart  = dateFmt.format(start);
+
+  // Extract time and timezone abbreviation from the start formatter parts.
+  const startParts   = startFmt.formatToParts(start);
+  const timeStartStr = endFmt.format(start);
+  const timeEndStr   = endFmt.format(end);
+  const tzPart = startParts.find(p => p.type === 'timeZoneName');
+  const tzStr  = tzPart ? tzPart.value : '';
+
+  const timePart = tzStr
+    ? `${timeStartStr}–${timeEndStr} (${tzStr})`
+    : `${timeStartStr}–${timeEndStr}`;
+
+  return `${datePart}, ${timePart}`;
+}
+
+/**
+ * Propose up to `maxSlots` meeting slots within the next `windowDays` business
+ * days, avoiding any overlap with the provided `busyBlocks`.
+ *
+ * This is a PURE function: no I/O, no LLM, no CalDAV calls.  Date arithmetic
+ * and weekday labeling are computed in code so the LLM never has to do it.
+ *
+ * @param {Object} opts
+ * @param {Array<{start:Date|string, end:Date|string}>} opts.busyBlocks
+ *   Known busy intervals (UTC Dates or ISO strings).
+ * @param {{ days: Set<number>, startMinutes: number, endMinutes: number }} opts.hours
+ *   Business-hours config from `_resolveSchedulingConfig`.
+ * @param {string} opts.timezone
+ *   IANA timezone, e.g. "Europe/Lisbon".
+ * @param {number} opts.slotDuration
+ *   Duration in minutes for each proposed slot.
+ * @param {string} [opts.locale='en']
+ *   BCP-47 locale for date/time formatting (DE/EN/PT all work).
+ * @param {Date} opts.now
+ *   The current instant. Injected so tests are deterministic.
+ * @param {number} [opts.maxSlots=3]
+ *   Maximum number of slot strings to return.
+ * @param {number} [opts.windowDays=5]
+ *   How many business days forward to search.
+ * @returns {string[]}
+ *   Array of formatted slot strings. Empty when no free slots found.
+ */
+function proposeSlots({
+  busyBlocks = [],
+  hours,
+  timezone,
+  slotDuration,
+  locale = 'en',
+  now,
+  maxSlots = 3,
+  windowDays = 5
+}) {
+  if (!hours || !timezone || !slotDuration || !now) return [];
+  if (hours.days.size === 0) return [];
+  if (slotDuration <= 0 || !Number.isFinite(slotDuration)) return [];
+
+  const results = [];
+
+  // Normalise busy blocks to Date pairs
+  const normalised = busyBlocks
+    .map(b => ({
+      start: b.start instanceof Date ? b.start : new Date(b.start),
+      end:   b.end   instanceof Date ? b.end   : new Date(b.end)
+    }))
+    .filter(b => !isNaN(b.start) && !isNaN(b.end));
+
+  // Start from the calendar day AFTER `now` in the target timezone.
+  // We use Intl to find the local date so DST offsets are respected.
+  //
+  // Strategy: find the midnight boundary of (now + 1 day) in the timezone,
+  // represented as a UTC Date.  We do this by walking forward day by day
+  // using UTC midnight + offset compensation, but because JS doesn't expose
+  // a clean "UTC-of-local-midnight" helper, we iterate using getFullYear/
+  // Month/Date in local time then pinning via explicit UTC construction.
+  //
+  // We keep things simple: increment day-of-month in the target timezone by
+  // constructing each candidate in the UTC reference and using Intl to check
+  // the wall-clock day.
+
+  // Build the UTC Date that corresponds to local midnight of the day after `now`.
+  const startDay = new Date(now);
+  startDay.setUTCDate(startDay.getUTCDate() + 1);
+  startDay.setUTCHours(0, 0, 0, 0);
+
+  // We will step day-by-day.  Use a counter capped at windowDays * 3 to avoid
+  // infinite loops on holiday configs, etc.
+  let businessDaysVisited = 0;
+  let currentDay = new Date(startDay);
+  const maxDaysToScan = windowDays * 3 + 7; // generous upper bound
+
+  for (let scan = 0; scan < maxDaysToScan && businessDaysVisited < windowDays && results.length < maxSlots; scan++) {
+    // Determine the local weekday in the target timezone.
+    // Intl.DateTimeFormat with weekday:'short' gives us the display name, but
+    // we need the numeric weekday.  Use 'en-US' to get an ASCII-safe name,
+    // then look it up in DAY_NAMES (which has 3-letter and full names).
+    const localWeekdayNum = _getLocalWeekday(currentDay, timezone);
+
+    if (!hours.days.has(localWeekdayNum)) {
+      // Not a business day — advance one day and continue
+      currentDay = _advanceDay(currentDay);
+      continue;
+    }
+
+    // It is a business day — iterate over SLOT_DURATION-aligned slots
+    businessDaysVisited++;
+
+    let slotStart = _setLocalTime(currentDay, hours.startMinutes, timezone);
+    const dayEnd  = _setLocalTime(currentDay, hours.endMinutes,   timezone);
+
+    while (slotStart < dayEnd && results.length < maxSlots) {
+      const slotEnd = new Date(slotStart.getTime() + slotDuration * 60 * 1000);
+
+      if (slotEnd > dayEnd) break; // slot would overrun business hours
+
+      if (!_overlaps(slotStart, slotEnd, normalised)) {
+        results.push(_formatSlot(slotStart, slotEnd, locale, timezone));
+      }
+
+      slotStart = slotEnd;
+    }
+
+    currentDay = _advanceDay(currentDay);
+  }
+
+  return results;
+}
+
+/**
+ * Return the numeric weekday (0=Sun … 6=Sat) of a UTC Date as seen in the
+ * given IANA timezone.  Uses Intl with 'en-US' to get a stable English name
+ * then maps it back via DAY_NAMES.
+ * @param {Date} date
+ * @param {string} timezone
+ * @returns {number} 0–6
+ * @private
+ */
+function _getLocalWeekday(date, timezone) {
+  const fmt = new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone: timezone });
+  const name = fmt.format(date).toLowerCase(); // "monday", "tuesday", etc.
+  return DAY_NAMES[name] ?? date.getUTCDay();
+}
+
+/**
+ * Return a UTC Date pointing to the local wall-clock time `minutesOfDay` on
+ * the same calendar day as `utcDate` in `timezone`.
+ *
+ * We approximate by:
+ * 1. Formatting utcDate in the target timezone to learn the local Y/M/D.
+ * 2. Constructing a date string at the desired local time.
+ * 3. Interpreting it as UTC (because we don't have a reliable "local→UTC"
+ *    path in Node without a library), then compensating with the offset.
+ *
+ * A simpler approach: compute local midnight via Intl, then add minutesOfDay.
+ *
+ * @param {Date} utcDate - Any Date on the target calendar day (UTC)
+ * @param {number} minutesOfDay - Minutes since midnight (e.g. 540 = 09:00)
+ * @param {string} timezone - IANA timezone
+ * @returns {Date} UTC Date corresponding to the local time
+ * @private
+ */
+function _setLocalTime(utcDate, minutesOfDay, timezone) {
+  // Get the local date parts for utcDate in the timezone
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    timeZone: timezone
+  });
+  const localDateStr = fmt.format(utcDate); // "YYYY-MM-DD"
+
+  // Build an ISO timestamp for the local time, then figure out the UTC offset.
+  // We use the trick: parse as UTC, then adjust by the real offset.
+  const hour   = Math.floor(minutesOfDay / 60);
+  const minute = minutesOfDay % 60;
+  const paddedHour   = String(hour).padStart(2, '0');
+  const paddedMinute = String(minute).padStart(2, '0');
+
+  // Construct a local datetime string (no TZ specifier — parse it as UTC first)
+  const localIso = `${localDateStr}T${paddedHour}:${paddedMinute}:00Z`;
+  const utcGuess = new Date(localIso);
+
+  // Find the actual UTC offset by formatting that UTC guess in the timezone
+  // and comparing to the assumed local time.  We use 'en-US' for stability.
+  const checkFmt = new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit', minute: '2-digit', hour12: false,
+    timeZone: timezone
+  });
+  const rendered = checkFmt.format(utcGuess); // e.g. "09:00" or "08:00"
+  const [rHour, rMin] = rendered.split(':').map(Number);
+  const renderedMinutes = rHour * 60 + rMin;
+  // rendered shows the local time that corresponds to utcGuess.
+  // We want local time = minutesOfDay, but rendered shows renderedMinutes.
+  // Correction: subtract (renderedMinutes - minutesOfDay) from the UTC guess.
+  // Example: timezone is UTC+1 (WEST). utcGuess=09:00 UTC, rendered=10:00 local.
+  //   We want 09:00 local → 08:00 UTC.
+  //   delta = renderedMinutes - minutesOfDay = 600 - 540 = 60 min.
+  //   result = 09:00 UTC - 60 min = 08:00 UTC. Correct.
+  const deltaMinutes = renderedMinutes - minutesOfDay;
+  return new Date(utcGuess.getTime() - deltaMinutes * 60 * 1000);
+}
+
+/**
+ * Advance a UTC Date by exactly one calendar day.
+ * @param {Date} d
+ * @returns {Date}
+ * @private
+ */
+function _advanceDay(d) {
+  return new Date(d.getTime() + 24 * 60 * 60 * 1000);
+}
+
+module.exports = { proposeSlots, parseHoursMarker };

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -7,6 +7,7 @@ const GateDetector = require('./gate-detector');
 const { ScheduleHandler, parseScheduleBlock, findConfigCard, stripHtml } = require('./schedule-handler');
 const { isStructuralCard, hasLabel } = require('../integrations/deck-card-classifier');
 const DeckClient = require('../integrations/deck-client');
+const { proposeSlots, parseHoursMarker } = require('./slot-proposer');
 
 const DEFAULT_DATA_DIR = path.resolve(process.cwd(), 'data');
 
@@ -505,8 +506,174 @@ class WorkflowEngine {
       'and assign the human reviewer. Do not proceed past the GATE point.',
     ].filter(Boolean).join('\n');
 
+    // ── Research grounding block (Part 5 / #188) ─────────────────────────────
+    // Self-scoping: only injected when the card description contains a parseable
+    // From: footer line (structural signal that this is an ingested inquiry card).
+    // Generic cards and other boards receive no grounding block.
+    //
+    // The From: footer is written by the email trigger ingest path (#185) as:
+    //   <body>\n\n---\nFrom: <Name> <addr>\nDate: ...\nMessage-ID: ...
+    // We parse from the RAW description (not the stripHtml version) because
+    // stripHtml strips angle-bracket content (e.g. <alice@acme.com> → stripped).
+    // This is structural parsing of a machine-authored marker — Rule 1 clean.
+    //
+    // Custody: the parse is bound to the trailing footer segment (after the last
+    // "\n---\n" delimiter the ingest path appends), NOT the whole description.
+    // A quoted/forwarded inbound body can contain its own "From: x@other.com"
+    // line; matching that would let third-party content masquerade as the
+    // established contact fact and steer the web_search domain anchor. The footer
+    // is always the final segment, so .pop() isolates the machine-authored region.
+    const searchPolicy = this.agent.cockpitManager?.cachedConfig?.system?.searchPolicy || 'research';
+    let groundingBlock = '';
+    const rawCardDesc = card.description || '';
+    const footerSegment = rawCardDesc.split(/\n---\n/).pop();
+    const fromFooterMatch = footerSegment.match(/^From:\s*(.+)$/im);
+    if (fromFooterMatch) {
+      const fromRaw = fromFooterMatch[1].trim();
+      // Parse "Name <addr>" or "<addr>" or "addr" forms structurally.
+      let contactName    = '';
+      let contactAddress = '';
+      const angleMatch = fromRaw.match(/^(.*?)\s*<([^>]+)>\s*$/);
+      if (angleMatch) {
+        contactName    = angleMatch[1].trim();
+        contactAddress = angleMatch[2].trim();
+      } else {
+        // No angle-bracket form — treat the whole string as the address
+        contactAddress = fromRaw;
+      }
+
+      // Mail link: the NC Mail deep-link is on a separate line in the footer
+      // as "[Open the original email in Mail](url)".  Extract it structurally.
+      let mailLinkLine = '';
+      const mailLinkMatch = footerSegment.match(/\[Open the original email in Mail\]\(([^)]+)\)/i);
+      if (mailLinkMatch) {
+        mailLinkLine = `\n- Source: [NC Mail thread](${mailLinkMatch[1]})`;
+      }
+
+      // ── Section A: structured contact facts (always present when From present)
+      const sectionA = [
+        '## Known contact details (from the inbound message)',
+        `- Name: ${contactName || '(not provided)'}`,
+        `- Email: ${contactAddress}`,
+        mailLinkLine || '',
+        '',
+        'These details are established facts. Include them in the profile as-is.',
+        'Do not omit or fabricate the email address.',
+      ].filter(s => s !== null).join('\n');
+
+      // ── Section B: research instructions (web-dependent)
+      let sectionB;
+      if (searchPolicy !== 'sovereign') {
+        // Derive the domain from the sender address as a concrete company anchor.
+        const domainMatch = contactAddress.match(/@([^@>]+)$/);
+        const senderDomain = domainMatch ? domainMatch[1] : '';
+        sectionB = [
+          '## Research task',
+          'Find publicly available information about the company associated with this inquiry.',
+          senderDomain ? `The sender's email domain is @${senderDomain} — use this as a concrete anchor.` : '',
+          'Identify the company from the inquiry text (do NOT fabricate a company name if one is not clear).',
+          '',
+          'Useful signals: what the company does, its size/stage, its relevance to the inquiry topic,',
+          'any public contact or team pages.',
+          '',
+          'Source attribution rules (strictly enforced):',
+          '- Every claim from web results MUST include its source URL.',
+          '- Claims without a source URL are NOT included in the profile.',
+          '- Keep internal facts (from the email), provided contact details, and web findings',
+          '  as distinct attributed sections in both the card description and the Collectives page.',
+          '',
+          'Write the profile to BOTH:',
+          '  1. The card description (appended below the email text) — the reviewer\'s primary surface.',
+          '  2. The partner\'s Collectives page — the durable record.',
+        ].filter(Boolean).join('\n');
+      } else {
+        sectionB = [
+          '## Research note',
+          'Web research is disabled by system policy (sovereign mode).',
+          'Compile the profile from the email content and internal knowledge only.',
+          'Write the profile to both the card description and the Collectives page.',
+        ].join('\n');
+      }
+
+      // ── Section C: scheduling slots (only when hoursExplicit)
+      let sectionC = '';
+      const schedulingCfg = this._resolveSchedulingConfig(wb, stack);
+      if (schedulingCfg.hoursExplicit) {
+        // Fetch busy events via CalDAV client (guard for null / absent client)
+        let busyBlocks = [];
+        const calClient = this.agent.toolRegistry?.clients?.calDAVClient;
+        if (calClient) {
+          try {
+            const now       = new Date();
+            // Search 5 business days forward (matches proposeSlots default windowDays)
+            const WINDOW_DAYS = 5;
+            const rangeEnd  = new Date(now.getTime() + WINDOW_DAYS * 24 * 60 * 60 * 1000);
+            // getEvents needs a calendarId; use the default calendar name.
+            // Fall back to 'personal' if not configured.
+            const calId     = calClient.defaultCalendar || 'personal';
+            const events    = await calClient.getEvents(calId, now, rangeEnd);
+            // Drop events with missing start/end (malformed ICS yields null DTSTART/
+            // DTEND → new Date(null) = epoch, a spurious busy block). proposeSlots
+            // also re-filters NaN, but excluding incomplete events here is cleaner.
+            busyBlocks = (events || [])
+              .filter(e => e && e.start && e.end)
+              .map(e => ({
+                start: e.start instanceof Date ? e.start : new Date(e.start),
+                end:   e.end   instanceof Date ? e.end   : new Date(e.end)
+              }));
+          } catch (err) {
+            console.warn(`[Workflow] Could not fetch calendar events for slot proposal: ${err.message}`);
+          }
+        }
+
+        // Detect locale from card language — but since the model handles language
+        // and the contact details determine the response language, we default to
+        // 'en' here and let the model render them in the appropriate language.
+        // The slot strings carry machine-correct dates; the model may translate
+        // surrounding prose but must not recompute the dates.
+        const slots = proposeSlots({
+          busyBlocks,
+          hours:        schedulingCfg.hours,
+          timezone:     schedulingCfg.timezone,
+          slotDuration: schedulingCfg.slotDuration,
+          locale:       'en',
+          now:          new Date(),
+          maxSlots:     3,
+          windowDays:   5
+        });
+
+        if (slots.length > 0) {
+          sectionC = [
+            '## Available meeting slots',
+            'The following slots are confirmed available and correctly labeled.',
+            'Include these in the profile as proposed meeting times.',
+            'Weekday labels are pre-computed and correct — do NOT recompute them.',
+            ...slots.map(s => `- ${s}`),
+          ].join('\n');
+        } else {
+          sectionC = '## Available meeting slots\nNo availability found in the current window. Omit scheduling from the profile.';
+        }
+      }
+
+      groundingBlock = [
+        '',
+        '---',
+        '## Structured Research Grounding',
+        '',
+        sectionA,
+        '',
+        sectionB,
+        sectionC ? '' : null,
+        sectionC || null,
+      ].filter(s => s !== null).join('\n');
+    }
+
+    const finalSystemAddition = groundingBlock
+      ? systemAddition + groundingBlock
+      : systemAddition;
+
     await this.agent.processWorkflowTask({
-      systemAddition,
+      systemAddition: finalSystemAddition,
       task: `Process workflow card: "${card.title}" according to the board rules.`,
       boardId: board.id,
       cardId: card.id,
@@ -514,7 +681,8 @@ class WorkflowEngine {
       forceLocal,
       allowCloud,
       cloudTier,
-      maxIterations
+      maxIterations,
+      searchPolicy
     });
   }
 
@@ -1319,6 +1487,97 @@ class WorkflowEngine {
 
     // Step 4: unresolvable — return null so callers never churn.
     return null;
+  }
+
+  /**
+   * Resolve scheduling CONFIG markers for a given stack/board.
+   *
+   * Reads HOURS:, TIMEZONE:, and SLOT_DURATION: markers from:
+   *   1. Stack CONFIG card  — most specific override
+   *   2. Board WORKFLOW rules card (wb._plainDescription) — board-wide default
+   *   3. System timezone from Intl  (TIMEZONE only)
+   *   4. Code defaults: Mon-Fri 09:00-17:00, system tz, 30 min
+   *
+   * Each marker resolves independently — a stack CONFIG can override TIMEZONE
+   * while the board WORKFLOW card supplies HOURS.
+   *
+   * `hoursExplicit` is true only when a HOURS: marker was actually found
+   * (at stack or board level).  The grounding block (Part 5) uses this flag
+   * to decide whether to inject Section C (scheduling slots).
+   *
+   * @param {Object} wb    - Workflow board descriptor (wb._plainDescription)
+   * @param {Object} stack - Current stack (used to locate the CONFIG card)
+   * @returns {{
+   *   hours: { days: Set<number>, startMinutes: number, endMinutes: number },
+   *   timezone: string,
+   *   slotDuration: number,
+   *   hoursExplicit: boolean
+   * }}
+   * @private
+   */
+  _resolveSchedulingConfig(wb, stack) {
+    const DEFAULT_HOURS     = { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 };
+    const DEFAULT_SLOT      = 30;
+    const systemTz          = (() => {
+      try { return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'; }
+      catch (_) { return 'UTC'; }
+    })();
+
+    const configCard  = findConfigCard(stack);
+    const stackPlain  = configCard?.description ? stripHtml(configCard.description) : '';
+    const boardPlain  = wb._plainDescription || '';
+
+    // Helper: extract a marker value from a text block.  Returns null when absent.
+    function _getMarker(text, name) {
+      if (!text) return null;
+      const re = new RegExp(`^${name}:\\s*(.+)$`, 'im');
+      const m  = text.match(re);
+      return m ? m[1].trim() : null;
+    }
+
+    // ── HOURS ──────────────────────────────────────────────────────────────
+    // Resolution: stack CONFIG → board WORKFLOW → code default
+    let hours = null;
+    let hoursExplicit = false;
+    const hoursRaw = _getMarker(stackPlain, 'HOURS') || _getMarker(boardPlain, 'HOURS');
+    if (hoursRaw) {
+      const parsed = parseHoursMarker(hoursRaw);
+      if (parsed) {
+        hours = parsed;
+        hoursExplicit = true;
+      }
+      // Invalid value → fall through to code default (hoursExplicit stays false)
+    }
+    if (!hours) hours = DEFAULT_HOURS;
+
+    // ── TIMEZONE ───────────────────────────────────────────────────────────
+    // Resolution: stack CONFIG → board WORKFLOW → system tz → 'UTC'
+    let timezone = systemTz;
+    const tzRaw = _getMarker(stackPlain, 'TIMEZONE') || _getMarker(boardPlain, 'TIMEZONE');
+    if (tzRaw) {
+      // Validate: Intl.DateTimeFormat throws on unknown identifiers
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: tzRaw }).resolvedOptions();
+        timezone = tzRaw;
+      } catch (_) {
+        // Unknown timezone string — fall through to system tz (already set)
+        console.warn(`[Workflow] Unknown TIMEZONE value "${tzRaw}" — falling back to system tz`);
+      }
+    }
+
+    // ── SLOT_DURATION ──────────────────────────────────────────────────────
+    // Resolution: stack CONFIG → board WORKFLOW → code default (30 min)
+    let slotDuration = DEFAULT_SLOT;
+    const sdRaw = _getMarker(stackPlain, 'SLOT_DURATION') || _getMarker(boardPlain, 'SLOT_DURATION');
+    if (sdRaw !== null) {
+      const parsed = parseInt(sdRaw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        slotDuration = parsed;
+      }
+      // Non-integer or non-positive → fall through to default
+    }
+
+    return { hours, timezone, slotDuration, hoursExplicit };
   }
 
   /**

--- a/test/unit/workflows/cloud-workflow-tools-policy.test.js
+++ b/test/unit/workflows/cloud-workflow-tools-policy.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * Tests for getCloudWorkflowToolDefinitions searchPolicy gate (Part 3 / #188).
+ *
+ * Verifies:
+ *   - searchPolicy 'research'      → web_search + web_read INCLUDED
+ *   - searchPolicy 'internal-first' → web_search + web_read INCLUDED
+ *   - searchPolicy 'sovereign'     → web_search + web_read EXCLUDED
+ *   - searchPolicy undefined       → web_search + web_read INCLUDED (default = 'research')
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { ToolRegistry } = require('../../../src/lib/agent/tool-registry');
+
+// ---------------------------------------------------------------------------
+// Minimal ToolRegistry with stub clients
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal stub DeckClient so the ToolRegistry can register
+ * workflow_deck_* tools alongside the web tools.
+ */
+function makeStubDeckClient() {
+  return {
+    baseUrl: 'https://nc.test',
+    username: 'moltagent',
+    stackNames: { inbox: 'Inbox', done: 'Done' },
+    getAllCards: async () => ({}),
+    getCardsInStack: async () => [],
+    createCard: async (_, c) => ({ id: 1, ...c }),
+    moveCard: async () => {},
+    ensureBoard: async () => ({ boardId: 1, stacks: {} }),
+    listBoards: async () => [],
+    getBoard: async (id) => ({ id, title: 'Board', owner: { uid: 'moltagent' }, stacks: [], labels: [] }),
+    getStacks: async () => [],
+    getCard: async (id) => ({ id, title: 'Card', description: '', duedate: null, type: 'plain', owner: { uid: 'moltagent' }, assignedUsers: [], labels: [] }),
+    getComments: async () => [],
+    addComment: async () => ({ id: 99 }),
+    updateCard: async () => ({}),
+    assignLabel: async () => ({}),
+    stackHasPausedConfig: () => false
+  };
+}
+
+/**
+ * Build a ToolRegistry with stub deck + web clients so all tested tools
+ * are registered.
+ */
+function makeRegistry() {
+  const stubSearxng = { search: async () => ({ results: [] }) };
+  const stubWebReader = { read: async () => ({ content: '' }) };
+  return new ToolRegistry({
+    deckClient: makeStubDeckClient(),
+    searxngClient: stubSearxng,
+    webReader: stubWebReader
+  });
+}
+
+const registry = makeRegistry();
+
+function toolNames(toolDefs) {
+  return toolDefs.map(t => t.function.name);
+}
+
+// ---------------------------------------------------------------------------
+// searchPolicy: 'research'
+// ---------------------------------------------------------------------------
+
+test("searchPolicy 'research' includes web_search", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'research' });
+  assert.ok(toolNames(tools).includes('web_search'), `web_search not in ${toolNames(tools).join(', ')}`);
+});
+
+test("searchPolicy 'research' includes web_read", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'research' });
+  assert.ok(toolNames(tools).includes('web_read'), `web_read not in ${toolNames(tools).join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// searchPolicy: 'internal-first'
+// ---------------------------------------------------------------------------
+
+test("searchPolicy 'internal-first' includes web_search", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'internal-first' });
+  assert.ok(toolNames(tools).includes('web_search'), `web_search not in ${toolNames(tools).join(', ')}`);
+});
+
+test("searchPolicy 'internal-first' includes web_read", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'internal-first' });
+  assert.ok(toolNames(tools).includes('web_read'), `web_read not in ${toolNames(tools).join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// searchPolicy: 'sovereign'
+// ---------------------------------------------------------------------------
+
+test("searchPolicy 'sovereign' excludes web_search", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'sovereign' });
+  assert.ok(!toolNames(tools).includes('web_search'), `web_search should NOT be in ${toolNames(tools).join(', ')}`);
+});
+
+test("searchPolicy 'sovereign' excludes web_read", () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'sovereign' });
+  assert.ok(!toolNames(tools).includes('web_read'), `web_read should NOT be in ${toolNames(tools).join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// searchPolicy: undefined (default = 'research')
+// ---------------------------------------------------------------------------
+
+test('searchPolicy undefined (default) includes web_search', () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('');
+  assert.ok(toolNames(tools).includes('web_search'), `web_search not in default tools: ${toolNames(tools).join(', ')}`);
+});
+
+test('searchPolicy undefined (default) includes web_read', () => {
+  const tools = registry.getCloudWorkflowToolDefinitions('');
+  assert.ok(toolNames(tools).includes('web_read'), `web_read not in default tools: ${toolNames(tools).join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// Web tool count difference: sovereign has 2 fewer tools than research
+// ---------------------------------------------------------------------------
+
+test('sovereign policy results in 2 fewer tools than research (web_search + web_read excluded)', () => {
+  const sovereign = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'sovereign' });
+  const research  = registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'research' });
+  // research has web_search + web_read that sovereign does not
+  assert.strictEqual(research.length - sovereign.length, 2,
+    `Expected exactly 2 more tools in research vs sovereign (got research=${research.length}, sovereign=${sovereign.length})`);
+});
+
+test('searchPolicy changes do not add or remove any non-web tools', () => {
+  const sovereign     = new Set(toolNames(registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'sovereign' })));
+  const research      = new Set(toolNames(registry.getCloudWorkflowToolDefinitions('', { searchPolicy: 'research' })));
+  // Non-web tools in sovereign should also be in research (research is a superset)
+  for (const name of sovereign) {
+    assert.ok(research.has(name), `Tool ${name} present in sovereign but missing in research`);
+  }
+  // The extras in research should ONLY be the web tools
+  const extras = [...research].filter(n => !sovereign.has(n)).sort();
+  assert.deepStrictEqual(extras, ['web_read', 'web_search']);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/research-grounding.test.js
+++ b/test/unit/workflows/research-grounding.test.js
@@ -1,0 +1,297 @@
+'use strict';
+
+/**
+ * Tests for the research grounding block injected by WorkflowEngine._processCard
+ * (Part 5 / #188).
+ *
+ * Strategy: spy on agentLoop.processWorkflowTask to capture systemAddition,
+ * then assert the grounding block was (or was not) injected with the right
+ * sections.
+ *
+ * Covers:
+ *   - Section A: contact facts template includes the From address from the footer
+ *   - Section B: web-research section present when searchPolicy !== 'sovereign'
+ *   - Section B: replaced with sovereign note when searchPolicy === 'sovereign'
+ *   - Self-scoping: block ABSENT when no From footer in card description
+ *   - searchPolicy threaded from cockpitManager through to processWorkflowTask
+ */
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const WorkflowEngine = require('../../../src/lib/workflows/workflow-engine');
+
+// ---------------------------------------------------------------------------
+// Minimal mock factories
+// ---------------------------------------------------------------------------
+
+function makeDeck() {
+  return {
+    getComments: async () => [],
+    addComment:  async () => {},
+    getBoard:    async () => ({ labels: [] }),
+    _request:    async () => ({}),
+    username:    'moltagent',
+    stackHasPausedConfig: () => false
+  };
+}
+
+function makeAgent(searchPolicy, capturedCalls) {
+  // Simulate cockpitManager.cachedConfig.system.searchPolicy
+  const agent = {
+    cockpitManager: {
+      cachedConfig: {
+        system: { searchPolicy }
+      }
+    },
+    toolRegistry: {
+      // No CalDAV client → Section C skipped (tested separately)
+      clients: { calDAVClient: null },
+      getWorkflowToolDefinitions:      () => [],
+      getCloudWorkflowToolDefinitions: () => []
+    },
+    processWorkflowTask: async (params) => {
+      capturedCalls.push(params);
+      return 'done';
+    }
+  };
+  return agent;
+}
+
+function makeDetector(wb) {
+  return {
+    getWorkflowBoards: async () => [wb],
+    invalidateCache:   () => {}
+  };
+}
+
+/**
+ * Build a minimal workflow board with one card in one stack.
+ * The WORKFLOW rules card (rulesCardId) is always present so the board is not
+ * treated as PAUSED.
+ */
+function makeWb({ cardDescription = '' } = {}) {
+  const rulesCard = {
+    id: 900,
+    title: 'WORKFLOW: partner-inquiries',
+    description: 'WORKFLOW: Partner Inquiries board',
+    labels: []   // no PAUSED label
+  };
+  const card = {
+    id: 100,
+    title: 'Inquiry from Acme Corp',
+    description: cardDescription,
+    labels: [],
+    lastModified: new Date(Date.now() - 3600 * 1000).toISOString(), // 1h ago → should process
+    duedate: null,
+    assignedUsers: []
+  };
+  const stack = {
+    id: 10,
+    title: 'Researching',
+    cards: [rulesCard, card]
+  };
+  return {
+    boardId: 165,
+    board: { id: 165, title: 'Partner Inquiries' },
+    description: 'WORKFLOW: Partner Inquiries',
+    _plainDescription: 'WORKFLOW: Partner Inquiries',
+    stacks: [stack],
+    rulesCardId: 900,
+    workflowType: 'pipeline'
+  };
+}
+
+const FROM_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\nMessage-ID: <abc123@mail.acme.com>';
+const MAIL_LINK_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\nMessage-ID: <abc123@mail.acme.com>\n[Open the original email in Mail](https://nc.example.com/apps/mail/inbox/1234)';
+
+// ---------------------------------------------------------------------------
+// Helper: run engine against one wb, return captured processWorkflowTask calls
+// ---------------------------------------------------------------------------
+async function runEngine(wb, searchPolicy) {
+  const calls = [];
+  const agent = makeAgent(searchPolicy, calls);
+  const engine = new WorkflowEngine({
+    workflowDetector: makeDetector(wb),
+    deckClient:       makeDeck(),
+    agentLoop:        agent,
+    talkSendQueue:    { enqueue: async () => {} },
+    talkToken:        'tok'
+  });
+  await engine.processAll();
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// Self-scoping: no From footer → no grounding block
+// ---------------------------------------------------------------------------
+
+asyncTest('no grounding block when card has no From footer', async () => {
+  const wb    = makeWb({ cardDescription: 'Just a regular description with no footer.' });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1, 'processWorkflowTask should have been called');
+  const sys = calls[0].systemAddition;
+  assert.ok(!sys.includes('## Structured Research Grounding'),
+    'grounding block should NOT be injected for cards without a From footer');
+});
+
+// ---------------------------------------------------------------------------
+// Section A: contact facts always present when From footer exists
+// ---------------------------------------------------------------------------
+
+asyncTest('Section A includes the email address from the From footer', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1);
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('## Structured Research Grounding'),
+    'grounding block should be present');
+  assert.ok(sys.includes('alice@acme.com'),
+    `systemAddition should contain the email address, got:\n${sys}`);
+});
+
+asyncTest('Section A includes the contact name from the From footer', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('Alice Example'),
+    `systemAddition should contain the contact name, got:\n${sys}`);
+});
+
+asyncTest('Section A includes the NC Mail link when present in footer', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + MAIL_LINK_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('NC Mail thread'),
+    `systemAddition should include NC Mail link reference, got:\n${sys}`);
+});
+
+asyncTest('Section A works when From footer has no display name (bare address)', async () => {
+  const bareAddr = '\n\n---\nFrom: <bareaddr@corp.io>\nDate: 2026-06-22\nMessage-ID: <x>';
+  const wb = makeWb({ cardDescription: 'Hello\n' + bareAddr });
+  const calls = await runEngine(wb, 'research');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('bareaddr@corp.io'),
+    `systemAddition should contain bare email address, got:\n${sys}`);
+});
+
+asyncTest('custody: decoy From: in quoted body does NOT override the footer address', async () => {
+  // A forwarded/quoted inbound email whose BODY contains its own From: line.
+  // The machine-authored footer (appended last, after the final \n---\n) is the
+  // only trusted source. The body decoy must not become the contact fact or the
+  // web_search domain anchor (#188 custody / reintroduced #185 break).
+  const bodyWithDecoy =
+    'Forwarding the thread below:\n\n' +
+    'From: Mallory Attacker <mallory@evil.example>\n' +
+    'Subject: Re: partnership\n\n' +
+    'original message text';
+  const wb    = makeWb({ cardDescription: bodyWithDecoy + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('alice@acme.com'),
+    `Footer address (alice@acme.com) must be the contact fact, got:\n${sys}`);
+  assert.ok(!sys.includes('mallory@evil.example'),
+    `Decoy body address must NOT appear in the grounding block, got:\n${sys}`);
+  assert.ok(!sys.includes('evil.example'),
+    `Decoy domain must NOT become the web_search anchor, got:\n${sys}`);
+});
+
+// ---------------------------------------------------------------------------
+// Section B: web research instructions (policy !== 'sovereign')
+// ---------------------------------------------------------------------------
+
+asyncTest("Section B: research instructions present when searchPolicy='research'", async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('## Research task'),
+    `Section B heading not found in:\n${sys}`);
+  assert.ok(sys.includes('source URL'),
+    `Source-URL attribution requirement not found in:\n${sys}`);
+});
+
+asyncTest("Section B: research instructions present when searchPolicy='internal-first'", async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'internal-first');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('## Research task'),
+    `Section B should be present for internal-first policy, got:\n${sys}`);
+});
+
+asyncTest("Section B: research instructions present when searchPolicy=undefined (default)", async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, undefined);
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('## Research task'),
+    `Section B should be present when policy is undefined (defaults to research), got:\n${sys}`);
+});
+
+// ---------------------------------------------------------------------------
+// Section B: sovereign mode — web disabled note
+// ---------------------------------------------------------------------------
+
+asyncTest("Section B replaced with sovereign note when searchPolicy='sovereign'", async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'sovereign');
+  const sys = calls[0].systemAddition;
+  assert.ok(!sys.includes('## Research task'),
+    `Section B research heading should NOT be present in sovereign mode, got:\n${sys}`);
+  assert.ok(sys.includes('sovereign'),
+    `Sovereign-mode note should appear in systemAddition, got:\n${sys}`);
+  assert.ok(sys.includes('## Research note') || sys.includes('disabled'),
+    `Sovereign-mode note (## Research note or "disabled") not found in:\n${sys}`);
+});
+
+asyncTest("sovereign mode: Section A contact facts still present", async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'sovereign');
+  const sys = calls[0].systemAddition;
+  assert.ok(sys.includes('alice@acme.com'),
+    `Contact address should still be in sovereign mode: got:\n${sys}`);
+});
+
+// ---------------------------------------------------------------------------
+// searchPolicy threaded to processWorkflowTask
+// ---------------------------------------------------------------------------
+
+asyncTest('searchPolicy is passed to processWorkflowTask', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'sovereign');
+  assert.ok(calls.length >= 1);
+  assert.strictEqual(calls[0].searchPolicy, 'sovereign',
+    `searchPolicy 'sovereign' should be forwarded to processWorkflowTask`);
+});
+
+asyncTest('searchPolicy research is passed to processWorkflowTask', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1);
+  assert.strictEqual(calls[0].searchPolicy, 'research');
+});
+
+asyncTest('searchPolicy defaults to "research" when cockpitManager absent', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = [];
+  // Agent with NO cockpitManager
+  const agent = {
+    cockpitManager: null,
+    toolRegistry: {
+      clients: { calDAVClient: null },
+      getWorkflowToolDefinitions:      () => [],
+      getCloudWorkflowToolDefinitions: () => []
+    },
+    processWorkflowTask: async (params) => { calls.push(params); return 'done'; }
+  };
+  const engine = new WorkflowEngine({
+    workflowDetector: makeDetector(wb),
+    deckClient:       makeDeck(),
+    agentLoop:        agent,
+    talkSendQueue:    { enqueue: async () => {} },
+    talkToken:        'tok'
+  });
+  await engine.processAll();
+  assert.ok(calls.length >= 1);
+  assert.strictEqual(calls[0].searchPolicy, 'research',
+    `Default searchPolicy should be 'research' when cockpitManager absent`);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/scheduling-config.test.js
+++ b/test/unit/workflows/scheduling-config.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+/**
+ * Tests for WorkflowEngine._resolveSchedulingConfig (Part 1 / #188).
+ *
+ * Covers:
+ *   - HOURS / TIMEZONE / SLOT_DURATION parsed from a CONFIG card description
+ *   - Fallback chain: stack CONFIG present/absent, WORKFLOW card fallback,
+ *     system tz fallback, code defaults
+ *   - Invalid/missing values handled gracefully (no throw)
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const WorkflowEngine = require('../../../src/lib/workflows/workflow-engine');
+
+// ---------------------------------------------------------------------------
+// Minimal factory helpers (mirrors existing workflow-engine.test.js style)
+// ---------------------------------------------------------------------------
+
+function createMockDeck() {
+  return {
+    getComments: async () => [],
+    addComment: async () => {},
+    username: 'moltagent'
+  };
+}
+
+function createMockAgentLoop() {
+  return { processWorkflowTask: async () => 'done' };
+}
+
+function createMockDetector(boards = []) {
+  return {
+    getWorkflowBoards: async () => boards,
+    invalidateCache: () => {}
+  };
+}
+
+function createEngine() {
+  return new WorkflowEngine({
+    workflowDetector: createMockDetector([]),
+    deckClient: createMockDeck(),
+    agentLoop: createMockAgentLoop(),
+    talkSendQueue: { enqueue: async () => {} },
+    talkToken: 'tok'
+  });
+}
+
+/**
+ * Build a minimal stack with an optional CONFIG card description.
+ * CONFIG cards have a title matching /^CONFIG:/i and are otherwise plain objects.
+ */
+function makeStack(configDesc) {
+  const cards = [];
+  if (configDesc !== undefined) {
+    cards.push({
+      id: 1,
+      title: 'CONFIG: test',
+      description: configDesc,
+      labels: [{ title: 'System' }],
+      archived: false
+    });
+  }
+  return { id: 10, title: 'Researching', cards };
+}
+
+/**
+ * Build a minimal workflow board descriptor (wb) with the given plain description.
+ */
+function makeWb(plainDescription = '') {
+  return { _plainDescription: plainDescription };
+}
+
+// ---------------------------------------------------------------------------
+// Part 1 tests
+// ---------------------------------------------------------------------------
+
+const engine = createEngine();
+
+// ── Happy path: full marker set from stack CONFIG card ──────────────────────
+
+test('parses HOURS from stack CONFIG card', () => {
+  const stack = makeStack('LLM: cloud\nHOURS: Mon-Fri 09:00-17:00\nTIMEZONE: Europe/Lisbon\nSLOT_DURATION: 30');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.ok(cfg.hours, 'hours should be present');
+  assert.deepStrictEqual([...cfg.hours.days].sort(), [1, 2, 3, 4, 5]);
+  assert.strictEqual(cfg.hours.startMinutes, 9 * 60);
+  assert.strictEqual(cfg.hours.endMinutes, 17 * 60);
+  assert.strictEqual(cfg.hoursExplicit, true);
+});
+
+test('parses TIMEZONE from stack CONFIG card', () => {
+  const stack = makeStack('HOURS: Mon-Fri 09:00-17:00\nTIMEZONE: America/New_York');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.strictEqual(cfg.timezone, 'America/New_York');
+});
+
+test('parses SLOT_DURATION from stack CONFIG card', () => {
+  const stack = makeStack('HOURS: Mon-Fri 09:00-17:00\nSLOT_DURATION: 45');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.strictEqual(cfg.slotDuration, 45);
+});
+
+// ── Fallback to board WORKFLOW card when stack CONFIG absent ─────────────────
+
+test('falls back HOURS to board WORKFLOW card when no stack CONFIG', () => {
+  const stack = makeStack(); // no CONFIG card
+  const wb    = makeWb('HOURS: Tue-Thu 10:00-15:00\nSLOT_DURATION: 60');
+  const cfg   = engine._resolveSchedulingConfig(wb, stack);
+  assert.deepStrictEqual([...cfg.hours.days].sort(), [2, 3, 4]);
+  assert.strictEqual(cfg.hours.startMinutes, 10 * 60);
+  assert.strictEqual(cfg.hours.endMinutes,   15 * 60);
+  assert.strictEqual(cfg.hoursExplicit, true);
+});
+
+test('falls back TIMEZONE to board WORKFLOW card when stack CONFIG absent', () => {
+  const stack = makeStack();
+  const wb    = makeWb('TIMEZONE: Asia/Tokyo');
+  const cfg   = engine._resolveSchedulingConfig(wb, stack);
+  assert.strictEqual(cfg.timezone, 'Asia/Tokyo');
+});
+
+test('falls back SLOT_DURATION to board WORKFLOW card when stack CONFIG absent', () => {
+  const stack = makeStack();
+  const wb    = makeWb('SLOT_DURATION: 90');
+  const cfg   = engine._resolveSchedulingConfig(wb, stack);
+  assert.strictEqual(cfg.slotDuration, 90);
+});
+
+// ── Stack CONFIG takes precedence over board WORKFLOW ────────────────────────
+
+test('stack CONFIG HOURS overrides board WORKFLOW HOURS', () => {
+  const stack = makeStack('HOURS: Mon-Wed 08:00-12:00');
+  const wb    = makeWb('HOURS: Mon-Fri 09:00-17:00');
+  const cfg   = engine._resolveSchedulingConfig(wb, stack);
+  assert.deepStrictEqual([...cfg.hours.days].sort(), [1, 2, 3]);
+  assert.strictEqual(cfg.hours.startMinutes, 8 * 60);
+});
+
+test('stack CONFIG SLOT_DURATION overrides board WORKFLOW SLOT_DURATION', () => {
+  const stack = makeStack('SLOT_DURATION: 15');
+  const wb    = makeWb('SLOT_DURATION: 60');
+  const cfg   = engine._resolveSchedulingConfig(wb, stack);
+  assert.strictEqual(cfg.slotDuration, 15);
+});
+
+// ── Code defaults when nothing is declared ──────────────────────────────────
+
+test('uses code default Mon-Fri 09:00-17:00 when no HOURS anywhere', () => {
+  const cfg = engine._resolveSchedulingConfig(makeWb(), makeStack());
+  assert.deepStrictEqual([...cfg.hours.days].sort(), [1, 2, 3, 4, 5]);
+  assert.strictEqual(cfg.hours.startMinutes, 9 * 60);
+  assert.strictEqual(cfg.hours.endMinutes,   17 * 60);
+  assert.strictEqual(cfg.hoursExplicit, false, 'hoursExplicit must be false when using default');
+});
+
+test('uses code default 30 min when no SLOT_DURATION anywhere', () => {
+  const cfg = engine._resolveSchedulingConfig(makeWb(), makeStack());
+  assert.strictEqual(cfg.slotDuration, 30);
+});
+
+test('timezone is a non-empty string when nothing declared (system tz fallback)', () => {
+  const cfg = engine._resolveSchedulingConfig(makeWb(), makeStack());
+  assert.ok(typeof cfg.timezone === 'string' && cfg.timezone.length > 0);
+});
+
+// ── Invalid / missing values ─────────────────────────────────────────────────
+
+test('invalid HOURS value falls through to default without throwing', () => {
+  const stack = makeStack('HOURS: weekdays 9am to 5pm');
+  let cfg;
+  assert.doesNotThrow(() => { cfg = engine._resolveSchedulingConfig(makeWb(), stack); });
+  // Should fall through to default
+  assert.deepStrictEqual([...cfg.hours.days].sort(), [1, 2, 3, 4, 5]);
+  assert.strictEqual(cfg.hoursExplicit, false);
+});
+
+test('empty HOURS: line falls through to default without throwing', () => {
+  const stack = makeStack('HOURS:  ');
+  let cfg;
+  assert.doesNotThrow(() => { cfg = engine._resolveSchedulingConfig(makeWb(), stack); });
+  assert.strictEqual(cfg.hoursExplicit, false);
+});
+
+test('unknown TIMEZONE value falls through to system tz without throwing', () => {
+  const stack = makeStack('HOURS: Mon-Fri 09:00-17:00\nTIMEZONE: NotA/RealTimezone');
+  let cfg;
+  assert.doesNotThrow(() => { cfg = engine._resolveSchedulingConfig(makeWb(), stack); });
+  // Should not be the invalid value
+  assert.notStrictEqual(cfg.timezone, 'NotA/RealTimezone');
+});
+
+test('non-integer SLOT_DURATION falls through to default 30', () => {
+  const stack = makeStack('SLOT_DURATION: thirty');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.strictEqual(cfg.slotDuration, 30);
+});
+
+test('zero SLOT_DURATION falls through to default 30', () => {
+  const stack = makeStack('SLOT_DURATION: 0');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.strictEqual(cfg.slotDuration, 30);
+});
+
+test('negative SLOT_DURATION falls through to default 30', () => {
+  const stack = makeStack('SLOT_DURATION: -10');
+  const cfg = engine._resolveSchedulingConfig(makeWb(), stack);
+  assert.strictEqual(cfg.slotDuration, 30);
+});
+
+// ── hoursExplicit flag ───────────────────────────────────────────────────────
+
+test('hoursExplicit is true only when HOURS marker was found', () => {
+  const withHours    = engine._resolveSchedulingConfig(makeWb(), makeStack('HOURS: Mon-Fri 09:00-17:00'));
+  const withoutHours = engine._resolveSchedulingConfig(makeWb(), makeStack('TIMEZONE: Europe/Lisbon'));
+  assert.strictEqual(withHours.hoursExplicit, true);
+  assert.strictEqual(withoutHours.hoursExplicit, false);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/slot-proposer.test.js
+++ b/test/unit/workflows/slot-proposer.test.js
@@ -1,0 +1,496 @@
+'use strict';
+
+/**
+ * Tests for slot-proposer.js — pure deterministic slot-proposal helper (#186 / #188).
+ *
+ * Key regression: 24/25/26 June 2026 are Wed/Thu/Fri (not Tue/Wed/Thu).
+ * All tests inject `now` so results are deterministic regardless of wall time.
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { proposeSlots, parseHoursMarker } = require('../../../src/lib/workflows/slot-proposer');
+
+// ---------------------------------------------------------------------------
+// parseHoursMarker tests
+// ---------------------------------------------------------------------------
+
+test('parseHoursMarker: parses "Mon-Fri 09:00-17:00"', () => {
+  const result = parseHoursMarker('Mon-Fri 09:00-17:00');
+  assert.ok(result, 'should parse successfully');
+  assert.deepStrictEqual([...result.days].sort(), [1, 2, 3, 4, 5]);
+  assert.strictEqual(result.startMinutes, 9 * 60);
+  assert.strictEqual(result.endMinutes, 17 * 60);
+});
+
+test('parseHoursMarker: parses "Tue-Thu 08:30-16:30"', () => {
+  const result = parseHoursMarker('Tue-Thu 08:30-16:30');
+  assert.ok(result);
+  assert.deepStrictEqual([...result.days].sort(), [2, 3, 4]);
+  assert.strictEqual(result.startMinutes, 8 * 60 + 30);
+  assert.strictEqual(result.endMinutes, 16 * 60 + 30);
+});
+
+test('parseHoursMarker: returns null for empty string', () => {
+  assert.strictEqual(parseHoursMarker(''), null);
+});
+
+test('parseHoursMarker: returns null for null', () => {
+  assert.strictEqual(parseHoursMarker(null), null);
+});
+
+test('parseHoursMarker: returns null for invalid format', () => {
+  assert.strictEqual(parseHoursMarker('Weekdays 9am-5pm'), null);
+});
+
+test('parseHoursMarker: returns null for inverted time range (start >= end)', () => {
+  assert.strictEqual(parseHoursMarker('Mon-Fri 17:00-09:00'), null);
+});
+
+test('parseHoursMarker: parses single day "Mon Mon 09:00-17:00"', () => {
+  // Single day via range with same start/end
+  const result = parseHoursMarker('Mon-Mon 09:00-17:00');
+  assert.ok(result);
+  assert.deepStrictEqual([...result.days], [1]);
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — #186 regression: weekday correctness
+// ---------------------------------------------------------------------------
+
+// Fixed anchor: Monday 22 June 2026 12:00 UTC
+// Next business day = Tuesday 23 June 2026
+// 24 June = Wednesday, 25 June = Thursday, 26 June = Friday
+const MON_22_JUNE_2026_UTC = new Date('2026-06-22T12:00:00Z');
+
+const STD_HOURS = { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 };
+const STD_TZ    = 'Europe/Lisbon'; // UTC+1 in June (WEST)
+const STD_SLOT  = 30;
+
+test('#186 regression: 24 June 2026 is Wednesday (EN)', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1, `expected slots, got ${slots.length}`);
+  // First slot should fall on Tuesday 23 June
+  assert.ok(slots[0].toLowerCase().includes('tuesday') || slots[0].toLowerCase().includes('23'),
+    `First slot should be Tue 23 June: "${slots[0]}"`);
+});
+
+test('#186 regression: correct weekday sequence Tue/Wed/Thu over 3 consecutive days', () => {
+  // now = Sunday 21 June 2026 (weekend), so next business day = Mon 22 June
+  const SUN_21_JUNE = new Date('2026-06-21T12:00:00Z');
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: SUN_21_JUNE,
+    maxSlots: 3,
+    windowDays: 3
+  });
+  assert.ok(slots.length >= 1);
+  // Slot 0 = Mon 22, slot 1 (if same day still collecting) or next day
+  // More importantly, each slot string should contain a valid date
+  for (const s of slots) {
+    assert.ok(s.length > 10, `slot string should be non-trivial: "${s}"`);
+  }
+});
+
+test('#186 regression: slots span correct calendar dates', () => {
+  // now = Mon 22 June 2026 noon UTC → next biz day = Tue 23 June
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 5
+  });
+  // June 2026 dates in the strings
+  const allText = slots.join(' ');
+  // At least one of 23, 24, 25, 26, 27 should appear (they are biz days)
+  assert.ok(
+    ['23', '24', '25', '26', '27'].some(d => allText.includes(d)),
+    `Expected a June 23–27 date in slots: ${allText}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — #186 concrete weekday regression (EN / DE / PT)
+// now = Tue 23 June 2026 noon UTC → next business day = Wed 24 June 2026
+// This is the canonical check: if off-by-one, the slot shows "Tuesday" not "Wednesday".
+// ---------------------------------------------------------------------------
+
+const TUE_23_JUNE_2026_UTC = new Date('2026-06-23T12:00:00Z');
+
+test('#186 concrete: 24 June 2026 labeled Wednesday in EN (UTC timezone)', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: 'UTC',
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: TUE_23_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 1
+  });
+  assert.ok(slots.length === 1, `Expected 1 slot, got ${slots.length}`);
+  assert.ok(
+    slots[0].toLowerCase().includes('wednesday'),
+    `24 June 2026 must be labeled Wednesday, got: "${slots[0]}"`
+  );
+  assert.ok(slots[0].includes('24'), `Slot must contain date "24", got: "${slots[0]}"`);
+});
+
+test('#186 concrete: 24 June 2026 labeled Mittwoch in DE (UTC timezone)', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: 'UTC',
+    slotDuration: STD_SLOT,
+    locale: 'de',
+    now: TUE_23_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 1
+  });
+  assert.ok(slots.length === 1, `Expected 1 slot, got ${slots.length}`);
+  assert.ok(
+    slots[0].toLowerCase().includes('mittwoch'),
+    `24 June 2026 must be "Mittwoch" in DE, got: "${slots[0]}"`
+  );
+});
+
+test('#186 concrete: 24 June 2026 labeled quarta-feira in PT (UTC timezone)', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: 'UTC',
+    slotDuration: STD_SLOT,
+    locale: 'pt',
+    now: TUE_23_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 1
+  });
+  assert.ok(slots.length === 1, `Expected 1 slot, got ${slots.length}`);
+  assert.ok(
+    slots[0].toLowerCase().includes('quarta'),
+    `24 June 2026 must be "quarta-feira" in PT, got: "${slots[0]}"`
+  );
+});
+
+// DST correctness: Europe/Lisbon summer (WEST, UTC+1) — slot at 09:00 local must be 08:00 UTC
+test('_setLocalTime DST: Europe/Lisbon summer slot at 09:00 local is 08:00 UTC', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 10 * 60 },
+    timezone: 'Europe/Lisbon',
+    slotDuration: 60,
+    locale: 'en',
+    now: TUE_23_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 1
+  });
+  // 09:00 WEST = 08:00 UTC, so the slot's UTC representation is 08:00-09:00 UTC.
+  // The formatted string should show "09:00" (local wall-clock time in WEST).
+  assert.ok(slots.length === 1, `Expected 1 slot, got ${slots.length}`);
+  assert.ok(
+    slots[0].includes('09:00'),
+    `Slot in Europe/Lisbon summer should show 09:00 local wall-clock: "${slots[0]}"`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — business hours filtering
+// ---------------------------------------------------------------------------
+
+test('slot before business hours start is excluded', () => {
+  // HOURS: 09:00-17:00; if a "busy" block covers 00:00-09:00, slots should start at 09:00
+  // We test by checking no slot string contains "08:" in the time portion
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    timezone: 'UTC',
+    slotDuration: 60, // 1h slots to keep output small
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 1
+  });
+  assert.ok(slots.length >= 1, 'should produce at least one slot');
+  // The time portion in UTC should start at or after 09:00
+  // Slot string contains "09:00" (or similar depending on locale)
+  assert.ok(slots[0].includes('09'), `First slot should start at 09:00 UTC, got: "${slots[0]}"`);
+});
+
+test('slot at exactly business hours end is excluded (end exclusive)', () => {
+  // HOURS: 09:00-17:00 with 60-min slots → last valid slot starts at 16:00
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    timezone: 'UTC',
+    slotDuration: 60,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 20, // get all slots for one day
+    windowDays: 1
+  });
+  // None of the slots should START at 17:00 or later
+  // The check is that no slot starting at 17:00 exists
+  // (a slot ending at 17:00 is fine — "16:00–17:00")
+  // Since we just check the string, look for "17:00–" pattern
+  const startsAt17 = slots.filter(s => /\b17:00[–-]/.test(s));
+  assert.strictEqual(startsAt17.length, 0, `No slot should start at 17:00: ${startsAt17.join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — busy-block conflict skipping
+// ---------------------------------------------------------------------------
+
+test('conflicting busy block causes slot to be skipped', () => {
+  // Busy 09:00–10:00 UTC on 2026-06-23 (Tuesday)
+  const busy = [{
+    start: new Date('2026-06-23T08:00:00Z'), // 09:00 WEST
+    end:   new Date('2026-06-23T09:00:00Z')  // 10:00 WEST
+  }];
+  const slots = proposeSlots({
+    busyBlocks: busy,
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 1
+  });
+  // The 09:00–09:30 WEST slot on Tue 23 should be skipped.
+  // All returned slots should start at or after 10:00 WEST on that day.
+  // We simply verify no slot contains "09:00–09:30" in its time portion
+  const hasConflict = slots.some(s => /09:00.09:30/.test(s) || /09:00–09:30/.test(s));
+  assert.strictEqual(hasConflict, false, `Conflicting slot should have been skipped: ${slots.join(', ')}`);
+});
+
+test('non-conflicting busy block does not prevent surrounding slots', () => {
+  // Busy only 10:00–10:30 WEST on Tue 23 June
+  const busy = [{
+    start: new Date('2026-06-23T09:00:00Z'), // 10:00 WEST
+    end:   new Date('2026-06-23T09:30:00Z')  // 10:30 WEST
+  }];
+  const slots = proposeSlots({
+    busyBlocks: busy,
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 1
+  });
+  // Should still produce slots (09:00–09:30 is free, 10:30–11:00 is free, etc.)
+  assert.ok(slots.length >= 1, `Expected free slots around the busy block, got: ${slots.join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — empty availability
+// ---------------------------------------------------------------------------
+
+test('empty window returns []', () => {
+  const result = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 0  // zero business days
+  });
+  assert.deepStrictEqual(result, []);
+});
+
+test('no free slots when entire window is busy returns []', () => {
+  // Fill the entire day with busy blocks
+  const busy = [];
+  for (let h = 9; h < 17; h++) {
+    busy.push({
+      start: new Date(`2026-06-23T0${h < 10 ? '0' : ''}${h - 1}:00:00Z`), // WEST = UTC+1
+      end:   new Date(`2026-06-23T0${h < 10 ? '0' : ''}${h - 1}:30:00Z`)
+    });
+  }
+  // Just use a very wide busy block covering 09:00–17:00 WEST (08:00–16:00 UTC)
+  const result = proposeSlots({
+    busyBlocks: [{
+      start: new Date('2026-06-23T08:00:00Z'), // 09:00 WEST
+      end:   new Date('2026-06-23T16:00:00Z')  // 17:00 WEST
+    }],
+    hours: { days: new Set([1, 2, 3, 4, 5]), startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 3,
+    windowDays: 1  // only look at Tue 23
+  });
+  assert.deepStrictEqual(result, [], `Expected [] when whole day is busy, got: ${result}`);
+});
+
+test('missing required params returns []', () => {
+  assert.deepStrictEqual(proposeSlots({ busyBlocks: [], hours: null, timezone: 'UTC', slotDuration: 30, now: new Date() }), []);
+  assert.deepStrictEqual(proposeSlots({ busyBlocks: [], hours: STD_HOURS, timezone: 'UTC', slotDuration: 0, now: new Date() }), []);
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — maxSlots cap
+// ---------------------------------------------------------------------------
+
+test('maxSlots=1 returns at most 1 slot', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.strictEqual(slots.length, 1);
+});
+
+test('default maxSlots=3 returns at most 3 slots', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    windowDays: 5
+  });
+  assert.ok(slots.length <= 3, `Got ${slots.length} slots, expected ≤ 3`);
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — locale-aware names (DE / PT)
+// ---------------------------------------------------------------------------
+
+test('German locale produces German weekday names', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'de',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1);
+  // German weekday names: Dienstag, Mittwoch, Donnerstag, Freitag, etc.
+  const germanDays = ['montag', 'dienstag', 'mittwoch', 'donnerstag', 'freitag', 'samstag', 'sonntag'];
+  const slotLower = slots[0].toLowerCase();
+  assert.ok(
+    germanDays.some(d => slotLower.includes(d)),
+    `Expected a German weekday name in "${slots[0]}"`
+  );
+});
+
+test('Portuguese locale produces Portuguese weekday names', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'pt',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1);
+  // Portuguese weekday names
+  const ptDays = ['segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado', 'domingo'];
+  const slotLower = slots[0].toLowerCase();
+  assert.ok(
+    ptDays.some(d => slotLower.includes(d)),
+    `Expected a Portuguese weekday name in "${slots[0]}"`
+  );
+});
+
+test('English locale produces English weekday names', () => {
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1);
+  const enDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+  const slotLower = slots[0].toLowerCase();
+  assert.ok(
+    enDays.some(d => slotLower.includes(d)),
+    `Expected an English weekday name in "${slots[0]}"`
+  );
+});
+
+test('slot string contains a timezone abbreviation', () => {
+  // Tz abbreviation (e.g. "WEST", "CET") is env-dependent — assert presence not value
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: STD_TZ,
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: MON_22_JUNE_2026_UTC,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1);
+  // A timezone abbreviation is typically 2-5 uppercase letters in parentheses
+  // or a UTC offset like "UTC+1"
+  assert.ok(
+    /\([A-Z]{2,6}[+\-]?\d*\)|\(UTC[+\-]\d+\)/.test(slots[0]),
+    `Expected a timezone abbreviation in "${slots[0]}"`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// proposeSlots — weekend exclusion
+// ---------------------------------------------------------------------------
+
+test('weekends are excluded when not in days set', () => {
+  // now = Friday 19 June 2026 17:30 UTC (end of business)
+  // Next slot should be Monday 22 June 2026 (not Saturday)
+  const FRI_19_JUNE = new Date('2026-06-19T16:30:00Z');
+  const slots = proposeSlots({
+    busyBlocks: [],
+    hours: STD_HOURS,
+    timezone: 'UTC',
+    slotDuration: STD_SLOT,
+    locale: 'en',
+    now: FRI_19_JUNE,
+    maxSlots: 1,
+    windowDays: 5
+  });
+  assert.ok(slots.length >= 1);
+  // First slot should be on Monday 22 (not Sat 20 or Sun 21)
+  assert.ok(
+    slots[0].toLowerCase().includes('monday') || slots[0].includes('22'),
+    `First slot after Friday should be Monday, got: "${slots[0]}"`
+  );
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## What & why

The Partner-Inquiries research beat promised research it could not do: no web egress, weekday labels off-by-one (the LLM did date math), and the carried From address omitted from the profile. Three coupled fixes on one custody spine.

Closes #186, #188.

## Changes

- **Web tools by Search Policy (#188).** `getCloudWorkflowToolDefinitions` gains a `searchPolicy` option; `web_search`/`web_read` enter the workflow palette unless the policy is `sovereign`. The gate is at palette-construction (advertising-only, matching the #133 subset guardrail). Egress is governed by Search Policy, **not** the inference-trust axis — the two stay decoupled (#181/#182 sibling on the conversational path).

- **Deterministic slot proposer (#186).** New pure module `src/lib/workflows/slot-proposer.js` computes meeting slots in code: weekday/month names from `Intl` (DE/EN/PT), business-hours filtering, busy-block skipping, DST-correct local↔UTC. The model receives finished slot strings and never does date arithmetic — that is the #186 fix.

- **Structured grounding (#185 follow-through).** `_processCard` builds a contact-facts template pre-filled from the machine-authored `From:` footer, web-research instructions (or a sovereign note), and the injected slots. Self-scoped to ingested inquiry cards (`From:` footer present); generic cards/boards are untouched.

- **CONFIG resolver.** `_resolveSchedulingConfig` reads `HOURS:`/`TIMEZONE:`/`SLOT_DURATION:` markers: stack CONFIG → board WORKFLOW card → system tz → code default, mirroring `_resolveGateReviewer`.

## Custody

- `searchPolicy` is resolved once and threaded to **both** the prompt (Section B) and the palette gate, so they cannot disagree.
- The `From:` parse is bound to the trailing machine-authored footer segment, so a decoy `From:` in a quoted/forwarded body cannot masquerade as the established contact fact or steer the `web_search` domain anchor (the #185 break, guarded against one layer down). Regression test included.

## Model routing

Routing the research beat to a sonnet-class model is a **live CONFIG edit, not code**: set the Researching stack's `LLM:` marker to `cloud-writing` (→ job `coding` → Sonnet). Note: the original briefing said `LLM: cloud`, which actually routes to Opus — the correct sonnet marker is `cloud-writing` (per `agent-loop.js:486-489`).

## Tests

65 new unit tests across slot-proposer, scheduling-config, palette gating, and grounding — including the #186 weekday regression (concrete names in EN/DE/PT) and the decoy-`From:` custody guard. **232 test files pass, lint 0 errors.**

## Not yet verified in production

BUILT ≠ VERIFIED. The live Verification Gate is pending and requires two manual steps on Prime:
1. Set board 165 Researching CONFIG: `LLM: cloud-writing`, `HOURS:`, `TIMEZONE:`, `SLOT_DURATION:`.
2. Test email → ingest → sonnet research beat → confirm real address surfaced, sourced web findings, correct weekday labels on card + Collectives page, journal shows sonnet + `web_search`. Then re-pause and clean up test artifacts.

Deferred nit to check live: the CalDAV `calId` fallback is `'personal'` — confirm the real default-calendar id on board 165's host, else busy-block conflict filtering silently no-ops.

## Related
- #185 (carry From address, merged c4877ad, prerequisite)
- #181 / #182 (conversational-path sibling, same two-axis decoupling)
- #168 (conversational calendar weekday bug, sibling of #186, different path)
- #187 (gate stale-snapshot, independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)