### PR TITLE
fix(workflow): CONFIG-declared iteration cap + preserve snake_case markers (#186, #188)

### DIFF
--- a/src/lib/workflows/schedule-handler.js
+++ b/src/lib/workflows/schedule-handler.js
@@ -77,7 +77,11 @@ function stripHtml(html) {
     .replace(/&nbsp;/g, ' ');
   // Strip Markdown bold/italic markers: **text**, __text__, *text*, _text_
   text = text.replace(/\*{1,2}([^*]+)\*{1,2}/g, '$1');
-  text = text.replace(/_{1,2}([^_]+)_{1,2}/g, '$1');
+  // Underscore emphasis only at word boundaries (CommonMark: intraword underscores
+  // are literal). This leaves snake_case intact — e.g. structural CONFIG markers
+  // SLOT_DURATION and MAX_ITERATIONS, which the naive global strip corrupted into
+  // SLOTDURATION/MAXITERATIONS whenever two underscores paired across lines.
+  text = text.replace(/(^|[^\w])_{1,2}([^_]+?)_{1,2}(?=[^\w]|$)/g, '$1$2');
   // Collapse runs of whitespace-only lines into single newlines, trim
   text = text.replace(/\n[ \t]*\n/g, '\n').trim();
   return text;

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -11,6 +11,28 @@ const { proposeSlots, parseHoursMarker } = require('./slot-proposer');
 
 const DEFAULT_DATA_DIR = path.resolve(process.cwd(), 'data');
 
+// Upper bound for a CONFIG-declared MAX_ITERATIONS. A research stage legitimately
+// needs more steps than the pipeline default of 3, but a typo (70 vs 7) must not
+// run cloud cost away — the cap is clamped to this ceiling.
+const MAX_ITERATION_CEILING = 15;
+
+/**
+ * Extract a CONFIG/WORKFLOW marker value from a plain-text block.
+ * Matches `^NAME: value$` (case-insensitive, multiline) and trims the capture —
+ * trailing whitespace in a marker value is never meaningful. Returns null when
+ * the marker is absent. Shared by the scheduling and iteration-cap resolvers so
+ * a single reader owns marker extraction.
+ * @param {string} text
+ * @param {string} name
+ * @returns {string|null}
+ */
+function getConfigMarker(text, name) {
+  if (!text) return null;
+  const re = new RegExp(`^${name}:\\s*(.+)$`, 'im');
+  const m = text.match(re);
+  return m ? m[1].trim() : null;
+}
+
 /**
  * WorkflowEngine
  *
@@ -368,8 +390,10 @@ class WorkflowEngine {
       }
     }
 
-    // Iteration cap: procedures get more steps (multi-phase), pipelines less
-    const maxIterations = wb.workflowType === 'procedure' ? 5 : 3;
+    // Iteration cap: stack CONFIG → board WORKFLOW → code default. A research/
+    // grounding stage writes a profile to two surfaces, attributes web sources,
+    // drafts a reply and moves the card — more steps than the pipeline default.
+    const maxIterations = this._resolveMaxIterations(wb, stack);
 
     console.log(`[Workflow] Processing card "${card.title}" in "${board.title}" / "${stack.title}" (maxIter=${maxIterations})`);
 
@@ -1490,6 +1514,48 @@ class WorkflowEngine {
   }
 
   /**
+   * Resolve the per-card iteration cap for a stack.
+   *
+   * Resolution chain (mirrors _resolveSchedulingConfig):
+   *   1. Stack CONFIG card `MAX_ITERATIONS:` — most specific override
+   *   2. Board WORKFLOW rules card `MAX_ITERATIONS:` — board-wide default
+   *   3. Code default: procedure ? 5 : 3
+   *
+   * The pipeline default of 3 is too few for a research/grounding stage that
+   * web-researches, writes a profile to two surfaces, drafts a reply and moves
+   * the card. Boards declare the cap they need in CONFIG rather than the cap
+   * being hardcoded per workflow type. The resolved value is clamped to
+   * [1, MAX_ITERATION_CEILING] so a typo cannot run cloud cost away.
+   *
+   * @param {Object} wb    - Workflow board descriptor (wb._plainDescription, wb.workflowType)
+   * @param {Object} stack - Current stack (used to locate the CONFIG card)
+   * @returns {number}
+   * @private
+   */
+  _resolveMaxIterations(wb, stack) {
+    const codeDefault = wb.workflowType === 'procedure' ? 5 : 3;
+
+    const configCard = findConfigCard(stack);
+    const stackPlain = configCard?.description ? stripHtml(configCard.description) : '';
+    const boardPlain = wb._plainDescription || '';
+
+    const raw = getConfigMarker(stackPlain, 'MAX_ITERATIONS')
+      || getConfigMarker(boardPlain, 'MAX_ITERATIONS');
+    if (raw === null) return codeDefault;
+
+    const parsed = parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      // Non-integer or non-positive → fall through to code default
+      return codeDefault;
+    }
+    if (parsed > MAX_ITERATION_CEILING) {
+      console.warn(`[Workflow] MAX_ITERATIONS ${parsed} exceeds ceiling ${MAX_ITERATION_CEILING} — clamping`);
+      return MAX_ITERATION_CEILING;
+    }
+    return parsed;
+  }
+
+  /**
    * Resolve scheduling CONFIG markers for a given stack/board.
    *
    * Reads HOURS:, TIMEZONE:, and SLOT_DURATION: markers from:
@@ -1527,13 +1593,8 @@ class WorkflowEngine {
     const stackPlain  = configCard?.description ? stripHtml(configCard.description) : '';
     const boardPlain  = wb._plainDescription || '';
 
-    // Helper: extract a marker value from a text block.  Returns null when absent.
-    function _getMarker(text, name) {
-      if (!text) return null;
-      const re = new RegExp(`^${name}:\\s*(.+)$`, 'im');
-      const m  = text.match(re);
-      return m ? m[1].trim() : null;
-    }
+    // Marker extraction (trim included) is shared via module-level getConfigMarker.
+    const _getMarker = getConfigMarker;
 
     // ── HOURS ──────────────────────────────────────────────────────────────
     // Resolution: stack CONFIG → board WORKFLOW → code default

--- a/test/unit/workflows/max-iterations-config.test.js
+++ b/test/unit/workflows/max-iterations-config.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/**
+ * Tests for WorkflowEngine._resolveMaxIterations (#186/#188 live-gate follow-up).
+ *
+ * Root cause this guards against: the research/grounding stage's workload
+ * (web research + dual-surface profile write + drafted reply + GATE move)
+ * outgrew the hardcoded pipeline iteration cap of 3, so the beat hit the cap
+ * having committed nothing and the card stranded. The cap is now CONFIG-declared.
+ *
+ * Covers:
+ *   - MAX_ITERATIONS parsed from stack CONFIG / board WORKFLOW card
+ *   - Resolution chain: stack CONFIG → board WORKFLOW → code default
+ *   - Code default depends on workflowType (procedure 5, pipeline 3)
+ *   - Invalid values fall through to the code default (no throw)
+ *   - Clamp to MAX_ITERATION_CEILING so a typo cannot run cloud cost away
+ *   - Trailing whitespace in the marker value is trimmed (board 165 CONFIG had it)
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const WorkflowEngine = require('../../../src/lib/workflows/workflow-engine');
+
+// ---------------------------------------------------------------------------
+// Minimal factory helpers (mirrors scheduling-config.test.js style)
+// ---------------------------------------------------------------------------
+
+function createEngine() {
+  return new WorkflowEngine({
+    workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
+    deckClient: { getComments: async () => [], addComment: async () => {}, username: 'moltagent' },
+    agentLoop: { processWorkflowTask: async () => 'done' },
+    talkSendQueue: { enqueue: async () => {} },
+    talkToken: 'tok'
+  });
+}
+
+/** Build a minimal stack with an optional CONFIG card description. */
+function makeStack(configDesc) {
+  const cards = [];
+  if (configDesc !== undefined) {
+    cards.push({
+      id: 1,
+      title: 'CONFIG: test',
+      description: configDesc,
+      labels: [{ title: 'System' }],
+      archived: false
+    });
+  }
+  return { id: 10, title: 'Researching', cards };
+}
+
+/** Build a minimal workflow board descriptor. workflowType defaults to 'pipeline'. */
+function makeWb(plainDescription = '', workflowType = 'pipeline') {
+  return { _plainDescription: plainDescription, workflowType };
+}
+
+const engine = createEngine();
+
+// ── Happy path: MAX_ITERATIONS from stack CONFIG card ───────────────────────
+
+test('parses MAX_ITERATIONS from stack CONFIG card', () => {
+  const stack = makeStack('LLM: cloud-writing\nMAX_ITERATIONS: 7');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb(), stack), 7);
+});
+
+test('the live-gate specimen MAX_ITERATIONS: 7 resolves to 7 (regression)', () => {
+  // board 165 Researching CONFIG, the value that fixes the stranded research beat
+  const stack = makeStack('LLM: cloud-writing\nHOURS: Mon-Fri 09:00-17:00\nTIMEZONE: Europe/Berlin\nSLOT_DURATION: 30\nMAX_ITERATIONS: 7');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 7);
+});
+
+// ── Fallback to board WORKFLOW card ─────────────────────────────────────────
+
+test('falls back MAX_ITERATIONS to board WORKFLOW card when no stack CONFIG', () => {
+  const stack = makeStack(); // no CONFIG card
+  const wb    = makeWb('WORKFLOW: pipeline\nMAX_ITERATIONS: 9');
+  assert.strictEqual(engine._resolveMaxIterations(wb, stack), 9);
+});
+
+test('stack CONFIG MAX_ITERATIONS overrides board WORKFLOW', () => {
+  const stack = makeStack('MAX_ITERATIONS: 6');
+  const wb    = makeWb('MAX_ITERATIONS: 12');
+  assert.strictEqual(engine._resolveMaxIterations(wb, stack), 6);
+});
+
+// ── Code defaults when nothing declared ─────────────────────────────────────
+
+test('pipeline code default is 3 when no MAX_ITERATIONS anywhere', () => {
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), makeStack()), 3);
+});
+
+test('procedure code default is 5 when no MAX_ITERATIONS anywhere', () => {
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'procedure'), makeStack()), 5);
+});
+
+// ── Invalid / missing values fall through to code default ────────────────────
+
+test('non-integer MAX_ITERATIONS falls through to code default', () => {
+  const stack = makeStack('MAX_ITERATIONS: seven');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 3);
+});
+
+test('zero MAX_ITERATIONS falls through to code default', () => {
+  const stack = makeStack('MAX_ITERATIONS: 0');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 3);
+});
+
+test('negative MAX_ITERATIONS falls through to code default', () => {
+  const stack = makeStack('MAX_ITERATIONS: -4');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'procedure'), stack), 5);
+});
+
+test('empty MAX_ITERATIONS line falls through to code default without throwing', () => {
+  const stack = makeStack('MAX_ITERATIONS:  ');
+  let val;
+  assert.doesNotThrow(() => { val = engine._resolveMaxIterations(makeWb('', 'pipeline'), stack); });
+  assert.strictEqual(val, 3);
+});
+
+// ── Clamp to ceiling ────────────────────────────────────────────────────────
+
+test('MAX_ITERATIONS above the ceiling is clamped to 15', () => {
+  const stack = makeStack('MAX_ITERATIONS: 70'); // typo for 7
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 15);
+});
+
+test('MAX_ITERATIONS exactly at the ceiling is allowed', () => {
+  const stack = makeStack('MAX_ITERATIONS: 15');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 15);
+});
+
+// ── Trailing whitespace (the board 165 CONFIG had trailing spaces) ──────────
+
+test('trailing whitespace in MAX_ITERATIONS value is trimmed and parsed', () => {
+  const stack = makeStack('LLM: cloud-writing  \nMAX_ITERATIONS: 8   ');
+  assert.strictEqual(engine._resolveMaxIterations(makeWb('', 'pipeline'), stack), 8);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/schedule-handler.test.js
+++ b/test/unit/workflows/schedule-handler.test.js
@@ -153,6 +153,18 @@ test('stripHtml: strips Markdown bold/italic markers', () => {
   assert.strictEqual(stripHtml('**bold** and *italic*'), 'bold and italic');
 });
 
+test('stripHtml: preserves intraword underscores (snake_case CONFIG markers)', () => {
+  // Regression: two underscore markers used to pair across lines and both got
+  // mangled (SLOT_DURATION → SLOTDURATION, MAX_ITERATIONS → MAXITERATIONS),
+  // breaking marker parsing. CommonMark: intraword underscores are literal.
+  assert.strictEqual(stripHtml('SLOT_DURATION: 30'), 'SLOT_DURATION: 30');
+  const both = stripHtml('SLOT_DURATION: 30\nMAX_ITERATIONS: 7');
+  assert.ok(both.includes('SLOT_DURATION: 30'), 'SLOT_DURATION intact');
+  assert.ok(both.includes('MAX_ITERATIONS: 7'), 'MAX_ITERATIONS intact');
+  // Boundary underscore emphasis still strips, mixed with snake_case present.
+  assert.strictEqual(stripHtml('_note_ MAX_ITERATIONS: 7'), 'note MAX_ITERATIONS: 7');
+});
+
 test('parseScheduleBlock: parses Markdown bold SCHEDULE header', () => {
   const desc = 'WORKFLOW: pipeline\n\n**SCHEDULE:**\nEvery 24h: Scan NC News feeds\nEvery 7d: Archive stale cards\n\n**STAGES:**\nInbox → Done';
   const schedules = parseScheduleBlock(desc);


### PR DESCRIPTION
## Summary

The research stage shipped in #190 (1a5873b) outgrew the hardcoded per-card iteration cap of 3 for `pipeline` boards. A research beat web-researches, writes a profile to two surfaces (card + Collectives), drafts a reply with deterministic slots, and moves the card past a GATE — far more tool-calling steps than 3. The beat hit the cap having committed nothing, and the processed-stamp dedup (which skips a card whose `lastModified` hasn't advanced past the last-processed stamp) then permanently stranded the unchanged card mid-pipeline.

Because the dedup strands any card that does not move stacks within a single beat, the whole stage must fit one beat's budget — so the cap must be tunable per board, not hardcoded per workflow type.

## Changes

- **`_resolveMaxIterations(wb, stack)`** — the per-card cap resolves stack CONFIG `MAX_ITERATIONS:` → board WORKFLOW card → code default (procedure 5, pipeline 3), mirroring `_resolveSchedulingConfig`. Clamped to a ceiling (15) so a typo (70 vs 7) cannot run cloud cost away. Marker extraction is centralised in one module-level `getConfigMarker` reader, shared with the scheduling resolver.

- **`stripHtml` underscore emphasis now respects word boundaries** (CommonMark: intraword underscores are literal). The naive global strip corrupted snake_case marker *names* — `SLOT_DURATION` and `MAX_ITERATIONS` paired across lines into `SLOTDURATION`/`MAXITERATIONS` — silently breaking marker parsing the moment two underscore markers coexisted on a card. This is the generator behind the latent bug; it protects every underscore marker at once. (The "trailing whitespace" hypothesis was a false lead — `getConfigMarker` and `parseHoursMarker` already trim; the real culprit was underscore emphasis.)

## Tests

14 new unit tests (max-iterations resolver incl. ceiling clamp + fallback chain; stripHtml snake_case regression). 233 test files pass, lint 0 errors.

## Live verification

Verified on the live Partner-Inquiries board against real Sonnet:
- With the cap raised via CONFIG, a previously-stranded research card reprocessed and the stage completed end-to-end in 8 iterations (no cap): URL-attributed profile written to the card + a Collectives page, deterministic slots, draft reply, card moved to Review with the GATE label and the review-prompt comment.
- Confirmed the cap is CONFIG-driven (the beat logged the declared maxIter, not the old hardcoded 3) and that Sonnet routing via `LLM: cloud-writing` holds.

Operational note: heavy research stages must declare `MAX_ITERATIONS` in their stack CONFIG (the Researching stage needs ~12). The default stays 3 for ordinary pipeline stages.

## Follow-ups (out of scope, filing separately)
- The research agent rewrites the whole card description and fabricates the `Message-ID` footer line instead of preserving it (Section A grounding only pins Name/Email/mail-link).
- The GATE card is assigned to the bot rather than the declared `REVIEWER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)