### PR TITLE
fix(workflow): dedup trigger email ingest on the Message-ID store, not \Seen (#194)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -59,7 +59,7 @@ class WorkflowEngine {
    * @param {import('../talk/talk-send-queue').TalkSendQueue} options.talkSendQueue
    * @param {string} options.talkToken - Primary Talk room token for notifications
    * @param {Object} [options.emailHandler] - EmailHandler instance; when provided, boards with a
-   *   TRIGGER: email:<folder> line will have unread emails ingested as cards each pulse.
+   *   TRIGGER: email:<folder> line will have new emails ingested as cards each pulse.
    * @param {Object} [options.ncMailClient] - NCMailClient instance; when provided, ingested cards
    *   receive a best-effort deep-link back to the original message in NC Mail.
    * @param {Object} [options.config]
@@ -1110,8 +1110,12 @@ class WorkflowEngine {
   }
 
   /**
-   * Ingest unread emails from a TRIGGER: email:<folder> declaration into this
-   * board as Deck cards. Idempotent on Message-ID; never mutates \Seen.
+   * Ingest emails from a TRIGGER: email:<folder> declaration into this board as
+   * Deck cards. Idempotent on the Message-ID store (data/workflow-ingested-emails.json),
+   * NOT on the IMAP \Seen flag (#194) — a flag the engine does not own. The mailbox
+   * is opened read-only and \Seen is never mutated. On a board's first pulse the
+   * folder's existing contents are seeded into the store (zero cards) so historical
+   * mail is not bulk-ingested.
    * @param {Object} wb - WorkflowBoard descriptor
    * @returns {Promise<number>} Number of cards created this pulse
    * @private
@@ -1145,12 +1149,15 @@ class WorkflowEngine {
       return 0;
     }
 
-    // Fetch unread emails — opens the mailbox READ-ONLY (never mutates \Seen).
+    // Fetch ALL emails in the folder — opens the mailbox READ-ONLY (never mutates
+    // \Seen). Dedup is the Message-ID store's job (#194), not the \Seen flag's: a
+    // human who reads then curates a mail into the trigger folder leaves it \Seen,
+    // and the old unreadOnly filter made that mail permanently invisible.
     let emails;
     try {
       emails = await this.emailHandler._fetchEmails({
         folder: trigger.locator,
-        unreadOnly: true,
+        unreadOnly: false,
         limit: 50
       });
     } catch (err) {
@@ -1160,12 +1167,35 @@ class WorkflowEngine {
 
     if (emails.length === 50) {
       // Soft warning: a full fetch window may silently cap a backlog.
-      console.warn('[Workflow] Email trigger fetch hit the limit (50) for folder ' + trigger.locator + ' — older unread may wait for the next pulse');
+      console.warn('[Workflow] Email trigger fetch hit the limit (50) for folder ' + trigger.locator + ' — older mail may wait for the next pulse');
     }
 
     // Process oldest-first so card order on the board reflects email arrival order.
     // _fetchEmails returns newest-first (sorted descending); reverse to get oldest-first.
     const orderedEmails = [...emails].reverse();
+
+    // First-run seeding (#194): now that the fetch returns ALL mail, a board whose
+    // trigger folder already holds messages would bulk-create a card per message on
+    // its first pulse. A board is on its first pulse when the store holds no entry
+    // for it (the .has() signal — NOT an empty set, which an empty starting folder
+    // would also produce, re-triggering seeding forever). Record the folder's
+    // current Message-IDs, persist the board entry even when the folder is empty,
+    // and create zero cards. Genuinely new mail arriving on later pulses ingests
+    // normally because the store entry now exists.
+    if (!this._ingestedEmails.has(String(wb.boardId))) {
+      for (const email of orderedEmails) {
+        const key = email.messageId || this._fallbackEmailKey(trigger.locator, email);
+        this._markEmailIngested(wb.boardId, key);
+      }
+      // Guarantee a board entry persists even when the folder was empty, so an
+      // email arriving on a later pulse is ingested rather than re-seeded.
+      if (!this._ingestedEmails.has(String(wb.boardId))) {
+        this._ingestedEmails.set(String(wb.boardId), new Set());
+        this._saveIngestedEmails();
+      }
+      console.log('[Workflow] Seeded ingested-emails store for board ' + wb.boardId + ' with ' + orderedEmails.length + ' existing Message-ID(s)');
+      return 0;
+    }
 
     let ingested = 0;
     for (const email of orderedEmails) {

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -105,6 +105,18 @@ function makeEngine({ emailHandler, deck, ncMailClient } = {}) {
   });
 }
 
+/**
+ * Mark a board as already-seeded (past its first pulse) so the normal
+ * ingest/dedup path runs. Seeding (#194) makes a board's FIRST pulse record the
+ * folder's existing mail without creating cards; tests that exercise ongoing
+ * ingestion start from a board that has already had that first pulse. An empty
+ * set is sufficient: it makes the .has() first-run check false while leaving no
+ * Message-ID marked, so any fetched mail flows through the normal ingest path.
+ */
+function markSeeded(engine, boardId = 1) {
+  engine._ingestedEmails.set(String(boardId), new Set());
+}
+
 /** Fixture: a single email with a Message-ID. */
 function makeEmail(overrides = {}) {
   return {
@@ -179,6 +191,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler(emails);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -204,6 +217,7 @@ function makeEmail(overrides = {}) {
     };
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -213,7 +227,9 @@ function makeEmail(overrides = {}) {
   });
 
   // TC-TRIGGER-07: _fetchEmails is called with the correct options.
-  await asyncTest('TC-TRIGGER-07: _fetchEmails called with {folder, unreadOnly:true, limit:50}', async () => {
+  // Post-#194 the trigger fetch is unreadOnly:false — dedup is the Message-ID
+  // store's job, not the IMAP \Seen flag's.
+  await asyncTest('TC-TRIGGER-07: _fetchEmails called with {folder, unreadOnly:false, limit:50}', async () => {
     const emailHandler = createMockEmailHandler([]);
     const engine = makeEngine({ emailHandler });
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
@@ -223,7 +239,7 @@ function makeEmail(overrides = {}) {
     assert.strictEqual(emailHandler._fetchCalls.length, 1);
     const opts = emailHandler._fetchCalls[0];
     assert.strictEqual(opts.folder, 'INBOX.INQUIRIES');
-    assert.strictEqual(opts.unreadOnly, true);
+    assert.strictEqual(opts.unreadOnly, false);
     assert.strictEqual(opts.limit, 50);
   });
 
@@ -232,6 +248,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([makeEmail()]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
 
     // Stacks intentionally out of order; lowest order=0 is id=30.
     const stacks = [
@@ -255,6 +272,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([makeEmail()]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
 
     const stacks = [
       { id: 10, title: 'Inbox', order: 0, cards: [] },
@@ -279,6 +297,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([emailNoId]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -313,6 +332,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler(emails);
     const deck = createMockDeck({ returnNull: true });
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -336,6 +356,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -405,6 +426,9 @@ function makeEmail(overrides = {}) {
         emailHandler: createMockEmailHandler([email]),
         config: { dataDir: tmpDir }
       });
+      // This board is already live (past its seeding pulse), so the email ingests
+      // rather than being seeded-and-skipped (#194).
+      markSeeded(engineA);
       await engineA._ingestTriggerEmails(makeWorkflowBoard({ description: desc }));
       assert.strictEqual(deckA._calls.length, 1, 'first engine creates the card');
       assert.ok(fs.existsSync(path.join(tmpDir, 'workflow-ingested-emails.json')),
@@ -446,6 +470,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
 
     await engine._ingestTriggerEmails(wb);
@@ -472,6 +497,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
 
     let threw = false;
@@ -505,6 +531,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
 
     let threw = false;
@@ -540,6 +567,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -564,6 +592,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -592,6 +621,7 @@ function makeEmail(overrides = {}) {
     const emailHandler = createMockEmailHandler([email]);
     const deck = createMockDeck();
     const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
     const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
 
     await engine._ingestTriggerEmails(wb);
@@ -606,6 +636,89 @@ function makeEmail(overrides = {}) {
     // And it must appear at least once
     const count = (desc.match(/dup@example\.com/g) || []).length;
     assert.strictEqual(count, 1, 'dup@example.com should appear exactly once, found: ' + count);
+  });
+
+  // TC-TRIGGER-23: A \Seen (read) email is ingested. Pre-#194 unreadOnly:true made
+  //               read mail invisible; now dedup is the store's job, not the flag's.
+  await asyncTest('TC-TRIGGER-23: read (isRead:true) email is ingested on a live board', async () => {
+    const email = makeEmail({ messageId: '<seen-mail@example.com>', isRead: true });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    const result = await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(result, 1, 'a \\Seen email should be ingested');
+    assert.strictEqual(deck._calls.length, 1, 'one card should be created from the read email');
+  });
+
+  // TC-TRIGGER-24: First pulse on a fresh board with existing mail → seed-and-skip.
+  //               Zero cards created; every Message-ID recorded in the store.
+  await asyncTest('TC-TRIGGER-24: first pulse seeds existing mail, creates zero cards', async () => {
+    const emails = [
+      makeEmail({ messageId: '<hist-1@example.com>', id: 1 }),
+      makeEmail({ messageId: '<hist-2@example.com>', id: 2 }),
+      makeEmail({ messageId: '<hist-3@example.com>', id: 3 })
+    ];
+    const emailHandler = createMockEmailHandler(emails);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck }); // NOT seeded → first run
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    const result = await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(result, 0, 'first pulse creates zero cards (seed-and-skip)');
+    assert.strictEqual(deck._calls.length, 0, 'no cards on the seeding pulse');
+    assert.strictEqual(engine._isEmailIngested(1, '<hist-1@example.com>'), true, 'hist-1 seeded');
+    assert.strictEqual(engine._isEmailIngested(1, '<hist-3@example.com>'), true, 'hist-3 seeded');
+  });
+
+  // TC-TRIGGER-25: After seeding, a genuinely new email on the next pulse is ingested;
+  //               the seeded historical mail stays skipped.
+  await asyncTest('TC-TRIGGER-25: second pulse ingests new mail, skips seeded history', async () => {
+    let callCount = 0;
+    const hist = makeEmail({ messageId: '<hist-only@example.com>', id: 1 });
+    const fresh = makeEmail({ messageId: '<brand-new@example.com>', id: 2 });
+    const emailSets = [[hist], [hist, fresh]];
+    const emailHandler = {
+      _fetchEmails: async () => emailSets[callCount++] || emailSets[1],
+      _fetchCalls: []
+    };
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck }); // NOT seeded → first run seeds
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb); // pulse 1: seeds [hist], zero cards
+    await engine._ingestTriggerEmails(wb); // pulse 2: hist skipped, fresh ingested
+
+    assert.strictEqual(deck._calls.length, 1, 'only the new email creates a card');
+    assert.strictEqual(deck._calls[0].title, fresh.subject, 'the card is from the new email');
+    assert.strictEqual(engine._isEmailIngested(1, '<hist-only@example.com>'), true, 'history stays seeded');
+  });
+
+  // TC-TRIGGER-26: An empty trigger folder on first run must NOT swallow the first
+  //               real email arriving later. This is why the first-run signal is
+  //               store.has(boardId), not set.size === 0 — an empty starting folder
+  //               would otherwise re-trigger seeding and skip the first message forever.
+  await asyncTest('TC-TRIGGER-26: empty-folder first run still ingests the first later email', async () => {
+    let callCount = 0;
+    const first = makeEmail({ messageId: '<first-ever@example.com>', id: 1 });
+    const emailSets = [[], [first]];
+    const emailHandler = {
+      _fetchEmails: async () => emailSets[callCount++] || emailSets[1],
+      _fetchCalls: []
+    };
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck }); // NOT seeded → first run
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb); // pulse 1: empty folder, seeds nothing but records board
+    await engine._ingestTriggerEmails(wb); // pulse 2: first real email must ingest
+
+    assert.strictEqual(deck._calls.length, 1, 'the first email after an empty-folder seed must ingest');
+    assert.strictEqual(engine._isEmailIngested(1, '<first-ever@example.com>'), true, 'first email recorded');
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## What

The email trigger bridge (#170) fetched the trigger mailbox with `unreadOnly: true`, gating card creation on the IMAP `\Seen` flag — a signal the engine does not own and never writes. A human who reads a mail in their inbox then moves it to the trigger folder (the natural curation workflow) leaves it `\Seen`, so the bridge never ingested it. Confirmed live on the card-2367 test: the same mail was invisible to every pulse while `\Seen`, and ingested only after a manual unread flip.

The engine already owns the correct idempotency signal: the per-board Message-ID store (`data/workflow-ingested-emails.json`), which guarantees once-only ingestion regardless of `\Seen`. `unreadOnly` was a redundant, contradictory second gate.

## Changes

- **Drop `unreadOnly`** at the trigger bridge call site (`unreadOnly: false`). The Message-ID store check is now the sole ingestion gate, positioned after the fetch and before card creation. `_fetchEmails` itself is unchanged (the parameter stays available for other callers); the mailbox stays read-only — `\Seen` is never mutated.
- **First-run seeding**: with all mail now visible, a board's first pulse on a folder with existing messages would bulk-create a card per message. When the store has no entry for a board, record the folder's current Message-IDs and create zero cards. The first-run signal is `store.has(boardId)`, **not** an empty set — an empty starting folder must not re-trigger seeding and swallow the first real email arriving later.

## Tests

`test/unit/workflows/email-trigger-bridge.test.js` (26/26 pass). Existing ongoing-ingest tests now mark the board as already-seeded (a live board past its first pulse); new cases:
- TC-23: a read (`\Seen`) email is ingested on a live board.
- TC-24: first pulse seeds existing mail, creates zero cards.
- TC-25: second pulse ingests genuinely new mail, skips seeded history.
- TC-26: empty-folder first run still ingests the first later email (the `set.size===0` vs `.has()` trap).

`npm run lint`: 0 errors. `npm run test:unit`: 233/233 files pass.

## Verification Gate (post-deploy)

Place a read (`\Seen`) email in the trigger folder → confirm not in the store → wait one pulse → confirm ingested + card created → confirm not re-ingested next pulse. To be run on board 165 after deploy to Prime.

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)