### PR TITLE
feat(workflow): skip terminal stacks declared via CONFIG marker (#196)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -379,6 +379,16 @@ class WorkflowEngine {
    */
   async _processCard(wb, stack, card) {
     const { board, description, stacks } = wb;
+
+    // Terminal stack: the pipeline's end. A card resting here has nothing
+    // further to do, so skip the beat entirely — no LLM call, no cost. A stack
+    // is terminal only when its CONFIG card explicitly declares TERMINAL: true
+    // (opt-in; the default is non-terminal).
+    if (this._isTerminalStack(stack)) {
+      console.log(`[Workflow] Skipping terminal stack "${stack.title}" for card "${card.title}"`);
+      return;
+    }
+
     let { forceLocal } = this._getRoleForCard(wb, card);
 
     // Budget check before cloud processing
@@ -1541,6 +1551,26 @@ class WorkflowEngine {
 
     // Step 4: unresolvable — return null so callers never churn.
     return null;
+  }
+
+  /**
+   * Is this stack a declared terminal stack?
+   *
+   * A terminal stack is the pipeline's end (e.g. "Replied"): a card resting
+   * there needs no further processing. Declared by a TERMINAL: true marker on
+   * the stack's CONFIG card. This is explicit opt-in only — there is no
+   * resolution chain and no code default. TERMINAL: false or an absent marker
+   * both mean non-terminal.
+   *
+   * @param {Object} stack - Current stack (used to locate the CONFIG card)
+   * @returns {boolean}
+   * @private
+   */
+  _isTerminalStack(stack) {
+    const configCard = findConfigCard(stack);
+    const stackPlain = configCard?.description ? stripHtml(configCard.description) : '';
+    const raw = getConfigMarker(stackPlain, 'TERMINAL');
+    return raw !== null && raw.trim().toLowerCase() === 'true';
   }
 
   /**

--- a/test/unit/workflows/terminal-stack-config.test.js
+++ b/test/unit/workflows/terminal-stack-config.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Tests for WorkflowEngine._isTerminalStack (#196).
+ *
+ * Root cause this guards against: the engine had no concept of a terminal
+ * stack. A card resting in the pipeline's end stack (e.g. "Replied") still
+ * cost a wasted LLM beat every pulse — one model call per pulse with no
+ * mutation — until the card fell out of the processing window. A stack is now
+ * declared terminal by a TERMINAL: true marker on its CONFIG card; the engine
+ * skips the beat entirely for cards there.
+ *
+ * Covers:
+ *   - TERMINAL: true on the stack CONFIG card → terminal
+ *   - No marker / no CONFIG card → non-terminal (default)
+ *   - TERMINAL: false → non-terminal (explicit opt-in only)
+ *   - Whitespace/case tolerance on the value
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const WorkflowEngine = require('../../../src/lib/workflows/workflow-engine');
+
+function createEngine() {
+  return new WorkflowEngine({
+    workflowDetector: { getWorkflowBoards: async () => [], invalidateCache: () => {} },
+    deckClient: { getComments: async () => [], addComment: async () => {}, username: 'moltagent' },
+    agentLoop: { processWorkflowTask: async () => 'done' },
+    talkSendQueue: { enqueue: async () => {} },
+    talkToken: 'tok'
+  });
+}
+
+/** Build a minimal stack with an optional CONFIG card description. */
+function makeStack(configDesc) {
+  const cards = [];
+  if (configDesc !== undefined) {
+    cards.push({
+      id: 1,
+      title: 'CONFIG: test',
+      description: configDesc,
+      labels: [{ title: 'System' }],
+      archived: false
+    });
+  }
+  return { id: 10, title: 'Replied', cards };
+}
+
+const engine = createEngine();
+
+// ── Terminal when explicitly declared ───────────────────────────────────────
+
+test('TERMINAL: true on the stack CONFIG card marks the stack terminal', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack('TERMINAL: true')), true);
+});
+
+test('TERMINAL: true alongside other markers still resolves terminal', () => {
+  const stack = makeStack('LLM: cloud-writing\nTERMINAL: true');
+  assert.strictEqual(engine._isTerminalStack(stack), true);
+});
+
+// ── Non-terminal: the default ───────────────────────────────────────────────
+
+test('no CONFIG card means non-terminal', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack()), false);
+});
+
+test('CONFIG card without TERMINAL marker means non-terminal', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack('LLM: cloud-writing\nMAX_ITERATIONS: 7')), false);
+});
+
+test('TERMINAL: false means non-terminal (explicit opt-in only)', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack('TERMINAL: false')), false);
+});
+
+// ── Tolerance on the value ──────────────────────────────────────────────────
+
+test('TERMINAL value is case- and whitespace-insensitive', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack('TERMINAL:  True  ')), true);
+});
+
+test('a non-boolean TERMINAL value is treated as non-terminal', () => {
+  assert.strictEqual(engine._isTerminalStack(makeStack('TERMINAL: maybe')), false);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Problem

A card resting in the pipeline's end stack (e.g. "Replied") still cost a wasted LLM beat every pulse — one model call, one iteration, no mutation — until it fell out of the processing window. The engine had no concept of a terminal stack.

## Fix

A `TERMINAL: true` marker on a stack's CONFIG card. `_isTerminalStack` reads it (same shape as `_resolveMaxIterations` / `_resolveSchedulingConfig`), and `_processCard` returns before the LLM call for cards in that stack, logging an informative skip line.

Explicit opt-in only: no resolution chain, no code default — `TERMINAL: false` or an absent marker both mean non-terminal.

## Tests

`test/unit/workflows/terminal-stack-config.test.js` (7/7):
- `TERMINAL: true` → terminal (alone and alongside other markers)
- no CONFIG card / no marker → non-terminal
- `TERMINAL: false` → non-terminal (explicit opt-in only)
- case/whitespace tolerance; non-boolean value → non-terminal

Lint 0 errors. Adjacent suites green (max-iterations 13/13, workflow-engine 46/46).

## Verification gate (post-merge, on Prime)

Deploy to Prime, create the Replied-stack `TERMINAL: true` CONFIG card on board 165, un-pause with card 2367 sitting in Replied, observe terminal-skip log + zero beats over two pulses, re-pause. Pending merge.

Closes #196.