### PR TITLE
feat(workflow): GATE approval via stack move (drag-to-approve) (#197)

### DIFF
--- a/src/lib/workflows/gate-detector.js
+++ b/src/lib/workflows/gate-detector.js
@@ -11,21 +11,30 @@
  *            "no regex for intelligence" principle. It also scanned comments to
  *            determine approval/rejection, making comment content load-bearing.
  *
- * Pattern:   Label-based detection. A card IS a gate if it carries the "GATE"
- *            label. A gate IS resolved when the human replaces the GATE label with
- *            APPROVED or REJECTED. This makes the state machine explicit and
- *            auditable in the Deck UI with no comment scanning required.
+ * Pattern:   Label-based detection plus stack-move detection (#197). A card IS a
+ *            gate if it carries the "GATE" label. A gate IS resolved either when
+ *            the human applies APPROVED/REJECTED (legacy, backward-compatible) OR
+ *            when the human drags the still-GATE-labelled card OUT of the gate
+ *            stack — the move itself is the approval gesture (Option B, #197).
+ *            Forward moves are approvals; a move into a stack declared
+ *            `REJECTED: true` on its CONFIG card is a rejection. This makes the
+ *            state machine explicit and auditable in the Deck UI with no comment
+ *            scanning required.
  *
  *            Regex is still used on CONFIG card text in isGateStack() — that is
  *            human-authored structured config (not LLM output), so pattern
- *            matching there is plumbing, not intelligence.
+ *            matching there is plumbing, not intelligence. The REJECTED: marker is
+ *            read by the engine (_isRejectionStack, mirrors #196 TERMINAL) and the
+ *            resulting boolean is passed in, so this module stays lean (no
+ *            schedule-handler dependency).
  *
  * Key Dependencies: deck-card-classifier (hasLabel)
  *
  * Data Flow:
- *   card { labels } → isGate() → boolean
- *   cards[]         → isGateStack() → boolean (scans CONFIG card title/desc)
- *   card { labels } → checkGateResolution() → { resolved, decision }
+ *   card { labels }                       → isGate() → boolean
+ *   cards[]                               → isGateStack() → boolean (CONFIG scan)
+ *   card, currentStack, isRejectionStack  → checkGateResolution()
+ *                                         → { resolved, decision, via }
  *
  * Dependency Map:
  *   gate-detector  <──  workflow-engine
@@ -69,10 +78,18 @@ class GateDetector {
   /**
    * Check if a stack is configured as a GATE stack.
    *
-   * A stack is a GATE stack when its CONFIG card (identified by the "System"
-   * label) has the word "GATE" in its title or description. This is a regex
-   * on human-authored config text — not LLM output — so pattern matching is
-   * appropriate here.
+   * A stack is a GATE stack when its CONFIG card has the word "GATE" in its
+   * title or description. This is a regex on human-authored config text — not
+   * LLM output — so pattern matching is appropriate here.
+   *
+   * The CONFIG card is located by EITHER structural convention — a "System"
+   * label OR a "CONFIG:" title prefix — mirroring isStructuralCard() and the
+   * findConfigCard() helper used by the engine's TERMINAL/REJECTED/REVIEWER
+   * markers. This dual locator is load-bearing for #197: it decides whether a
+   * GATE card is still HELD (in the gate stack) or has been dragged OUT
+   * (approval). Matching by the System label alone would false-negate on a
+   * board whose gate CONFIG card uses only the "CONFIG:" title convention,
+   * silently reading a held gate as approved. Robust to both conventions.
    *
    * @param {Array<Object>} cards - All cards in a stack
    * @returns {boolean}
@@ -80,8 +97,12 @@ class GateDetector {
   static isGateStack(cards) {
     if (!Array.isArray(cards)) return false;
 
-    // Find the CONFIG card — it has the "System" label
-    const configCard = cards.find(c => hasLabel(c, 'System'));
+    // Locate the CONFIG card by either structural convention (System label OR
+    // "CONFIG:" title prefix) — the same dual rule isStructuralCard() applies.
+    const configCard = cards.find(c =>
+      hasLabel(c, 'System') ||
+      /^CONFIG:\s*/i.test((typeof c?.title === 'string' ? c.title : '').trimStart())
+    );
     if (!configCard) return false;
 
     const text = `${configCard.title || ''} ${configCard.description || ''}`;
@@ -90,37 +111,74 @@ class GateDetector {
   }
 
   /**
-   * Check whether a GATE card has been resolved by inspecting its labels.
+   * Check whether a GATE card has been resolved.
    *
-   * State machine:
-   *   APPROVED label  → resolved, decision = 'approved'
-   *   REJECTED label  → resolved, decision = 'rejected'
-   *   GATE label only → not resolved
-   *   No workflow label → pass-through (resolved with no decision)
+   * Resolution sources, evaluated IN ORDER:
    *
-   * @param {Object} card - Deck card object with labels array
-   * @returns {{ resolved: boolean, decision: string|null }}
+   *   1. APPROVED label  → resolved, decision = 'approved', via = 'label'
+   *   2. REJECTED label  → resolved, decision = 'rejected', via = 'label'
+   *      (Backward-compat MUST stay first: a transition card may carry GATE +
+   *       APPROVED while still sitting in the gate stack. It must resolve as
+   *       approved here, never be mis-read as an unresolved in-stack gate below.)
+   *   3. GATE label present (no APPROVED/REJECTED):
+   *        - still in a gate stack  → unresolved (decision = null, via = null)
+   *        - moved OUT of gate stack → resolved via the drag gesture (#197):
+   *            decision = isRejectionStack ? 'rejected' : 'approved', via = 'move'
+   *   4. No workflow label → pass-through (resolved with no decision, via = null)
+   *
+   * `currentStack` carries the cards needed to call isGateStack() on the card's
+   * present location. `isRejectionStack` is precomputed by the engine
+   * (_isRejectionStack, which reads the REJECTED: CONFIG marker off the same
+   * CONFIG card as #196 TERMINAL) and passed in, so this module needs no
+   * schedule-handler dependency. `allStacks` is intentionally NOT a parameter:
+   * both gate-stack and rejection-stack detection resolve from `currentStack`
+   * alone, so a board-wide list would be dead weight.
+   *
+   * When `currentStack` is omitted (legacy direct callers that cannot observe a
+   * move), a GATE-only card is reported unresolved — preserving prior behavior.
+   *
+   * @param {Object} card - Deck card object with labels array and title
+   * @param {Object|null} [currentStack] - The stack the card is in now ({ cards })
+   * @param {boolean} [isRejectionStack] - True when currentStack is a declared
+   *                                        REJECTED: true stack (engine-computed)
+   * @returns {{ resolved: boolean, decision: string|null, via: ('label'|'move'|null) }}
    */
-  static checkGateResolution(card) {
+  static checkGateResolution(card, currentStack = null, isRejectionStack = false) {
     if (!card || typeof card !== 'object') {
-      return { resolved: false, decision: null };
+      return { resolved: false, decision: null, via: null };
     }
 
+    // (1)/(2) Legacy label path — MUST stay first (see JSDoc).
     if (hasLabel(card, LABEL_APPROVED)) {
-      return { resolved: true, decision: 'approved' };
+      return { resolved: true, decision: 'approved', via: 'label' };
     }
 
     if (hasLabel(card, LABEL_REJECTED)) {
-      return { resolved: true, decision: 'rejected' };
+      return { resolved: true, decision: 'rejected', via: 'label' };
     }
 
+    // (3) GATE label present, no explicit decision label.
     if (hasLabel(card, LABEL_GATE)) {
-      // Gate exists and is unresolved
-      return { resolved: false, decision: null };
+      // Stack-move detection (#197).
+      if (currentStack) {
+        if (GateDetector.isGateStack(currentStack.cards)) {
+          // Card is still in the gate stack — waiting for human drag.
+          return { resolved: false, decision: null, via: null };
+        }
+        // Card has been dragged OUT of the gate stack — the move is the approval gesture.
+        return {
+          resolved: true,
+          decision: isRejectionStack ? 'rejected' : 'approved',
+          via: 'move'
+        };
+      }
+
+      // currentStack omitted — legacy caller, no move observable → unresolved.
+      return { resolved: false, decision: null, via: null };
     }
 
-    // Card has no workflow label — treat as pass-through
-    return { resolved: true, decision: null };
+    // (4) Card has no workflow label — treat as pass-through.
+    return { resolved: true, decision: null, via: null };
   }
 }
 

--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -728,12 +728,33 @@ class WorkflowEngine {
   async _handleGate(wb, stack, card) {
     const { board } = wb;
 
-    // Label-based resolution check — synchronous, no comment scanning
-    const resolution = GateDetector.checkGateResolution(card);
+    // Resolution check (#197): two sources, evaluated in GateDetector —
+    //   via 'label' → legacy APPROVED/REJECTED stamp (backward-compat)
+    //   via 'move'  → reviewer dragged the GATE card OUT of the gate stack.
+    // The engine computes whether the card's CURRENT stack is a declared
+    // rejection target; GateDetector decides gate-stack membership from `stack`.
+    const isRejectionStack = this._isRejectionStack(stack);
+    const resolution = GateDetector.checkGateResolution(card, stack, isRejectionStack);
 
     if (resolution.resolved && resolution.decision) {
-      // Human has applied APPROVED or REJECTED label
-      console.log(`[Workflow] GATE resolved: "${card.title}" -> ${resolution.decision}`);
+      // Post-resolution label swap (#197, Part 2). Only for via==='move' — a
+      // 'label' resolution already carries its record-keeping label, so re-stamping
+      // would be redundant. Run BEFORE the processWorkflowTask handoff so the
+      // record-keeping state is deterministic regardless of what the LLM does downstream.
+      if (resolution.via === 'move') {
+        await this._removeLabelFromCard(board.id, stack.id, card.id, 'GATE');
+        await this._addLabelToCard(board.id, stack.id, card.id,
+          resolution.decision === 'rejected' ? 'REJECTED' : 'APPROVED');
+        // Idempotency: removing the GATE label makes isGate() false next pulse,
+        // so the card is not re-handled. Known edge: isGate() also matches a
+        // "GATE:" TITLE prefix, so a move-resolved card whose title starts
+        // "GATE:" could re-enter via the APPROVED label path — tracked in #200.
+        console.log(`[Workflow] GATE resolved: card "${card.title}" ` +
+          `${resolution.decision} (moved from gate stack to "${stack.title}")`);
+      } else {
+        // Legacy label-stamp resolution (backward-compat path).
+        console.log(`[Workflow] GATE resolved: "${card.title}" -> ${resolution.decision}`);
+      }
 
       // Clear notification dedup so card can be re-gated later if needed
       const gateKey = `${board.id}:${card.id}`;
@@ -812,13 +833,18 @@ class WorkflowEngine {
     // Not resolved (has GATE label, no APPROVED/REJECTED) — notify human once
     const gateKey = `${board.id}:${card.id}`;
     if (!this._notifiedGates.has(gateKey)) {
-      // Label presence IS the notification state — no comment scan needed.
+      // Notification text reflects the new gesture (#197, Part 4): the approval
+      // signal is the stack MOVE, not a label. These are fixed system strings
+      // (not NL classification), so a static template is acceptable.
+      const rej = wb.stacks.find(s => this._isRejectionStack(s));
+      const declineLine = rej ? `\nMove to "${rej.title}" to decline.` : '';
+
       // Notify in Talk once per process lifecycle (in-memory dedup via _notifiedGates).
       if (this.talkQueue && this.talkToken) {
         await this.talkQueue.enqueue(this.talkToken,
           `\u23F8\uFE0F Workflow "${wb.board.title}" is waiting for your review.\n` +
           `Card: **${card.title}**\n` +
-          'Apply the \u2705 APPROVED or \u274C REJECTED label on the card to continue.'
+          'Move this card forward to approve.' + declineLine
         );
       }
 
@@ -828,7 +854,7 @@ class WorkflowEngine {
         try {
           await this.deck.addComment(card.id,
             `\u23F8\uFE0F **GATE**: Waiting for human review.\n` +
-            'Apply the APPROVED or REJECTED label to continue the workflow.'
+            'Move this card forward to approve.' + declineLine
           );
         } catch (_err) {
           // Non-fatal — Talk notification is the primary channel
@@ -1570,6 +1596,28 @@ class WorkflowEngine {
     const configCard = findConfigCard(stack);
     const stackPlain = configCard?.description ? stripHtml(configCard.description) : '';
     const raw = getConfigMarker(stackPlain, 'TERMINAL');
+    return raw !== null && raw.trim().toLowerCase() === 'true';
+  }
+
+  /**
+   * Is this stack a declared rejection target for GATE drag-to-decline (#197)?
+   *
+   * A stack is a rejection target when its CONFIG card declares `REJECTED: true`.
+   * The marker MUST live on the SAME CONFIG card as #196 TERMINAL — i.e. located
+   * via findConfigCard (the 'CONFIG:' title-prefix card), NOT GateDetector's
+   * 'System'-label gate-stack card — so a deployer declares all stack policy in
+   * one place. Explicit opt-in only: `REJECTED: false` or an absent marker both
+   * mean "not a rejection stack" (all other moves out of the gate stack are
+   * approvals).
+   *
+   * @param {Object} stack - Stack to test (used to locate the CONFIG card)
+   * @returns {boolean}
+   * @private
+   */
+  _isRejectionStack(stack) {
+    const configCard = findConfigCard(stack);
+    const stackPlain = configCard?.description ? stripHtml(configCard.description) : '';
+    const raw = getConfigMarker(stackPlain, 'REJECTED');
     return raw !== null && raw.trim().toLowerCase() === 'true';
   }
 

--- a/test/unit/workflows/gate-detector.test.js
+++ b/test/unit/workflows/gate-detector.test.js
@@ -66,6 +66,24 @@ const GateDetector = require('../../../src/lib/workflows/gate-detector');
     assert.strictEqual(GateDetector.isGateStack(null), false);
   });
 
+  test('isGateStack() finds CONFIG card by "CONFIG:" title prefix when no System label (#197 dual locator)', () => {
+    // A board whose gate CONFIG card uses ONLY the "CONFIG:" title convention,
+    // with NO System label. Must still be recognised as a gate stack — otherwise
+    // a held GATE card here would be silently read as approved-via-move.
+    const cards = [
+      { title: 'CONFIG: GATE review step', description: 'Human review required', labels: [] },
+      { title: 'Task A', description: '', labels: [] }
+    ];
+    assert.strictEqual(GateDetector.isGateStack(cards), true);
+  });
+
+  test('isGateStack() returns false for CONFIG-title card without GATE token', () => {
+    const cards = [
+      { title: 'CONFIG: Replied', description: 'TERMINAL: true', labels: [] }
+    ];
+    assert.strictEqual(GateDetector.isGateStack(cards), false);
+  });
+
   // ── checkGateResolution ──────────────────────────────────────────────────────
 
   test('checkGateResolution() returns approved when APPROVED label present', () => {
@@ -107,6 +125,87 @@ const GateDetector = require('../../../src/lib/workflows/gate-detector');
     const result = GateDetector.checkGateResolution(card);
     assert.strictEqual(result.resolved, true);
     assert.strictEqual(result.decision, 'approved');
+  });
+
+  // ── checkGateResolution (stack-move / #197) ──────────────────────────────────
+
+  // Reusable stacks for move-detection tests
+  const gateCurrentStack = { cards: [
+    { title: 'CONFIG: GATE review', description: 'Requires human GATE', labels: [{ title: 'System' }] }
+  ]};
+  const nonGateCurrentStack = { cards: [
+    { title: 'CONFIG: Replied', description: 'TERMINAL: true', labels: [{ title: 'System' }] }
+  ]};
+
+  test('checkGateResolution() GATE label + still in gate stack → unresolved', () => {
+    const card = { labels: [{ title: 'GATE' }] };
+    const result = GateDetector.checkGateResolution(card, gateCurrentStack, false);
+    assert.strictEqual(result.resolved, false);
+    assert.strictEqual(result.decision, null);
+    assert.strictEqual(result.via, null);
+  });
+
+  // Regression guard for the #197 false-approval BLOCKER: a gate stack whose
+  // CONFIG card uses ONLY the "CONFIG:" title convention (no System label) must
+  // still hold the gate, not auto-approve it.
+  test('checkGateResolution() GATE label + gate stack identified by CONFIG-title only → unresolved (no false approval)', () => {
+    const card = { labels: [{ title: 'GATE' }] };
+    const titleOnlyGateStack = { cards: [
+      { title: 'CONFIG: GATE review', description: 'Human review required', labels: [] }
+    ]};
+    const result = GateDetector.checkGateResolution(card, titleOnlyGateStack, false);
+    assert.strictEqual(result.resolved, false);
+    assert.strictEqual(result.decision, null);
+    assert.strictEqual(result.via, null);
+  });
+
+  test('checkGateResolution() GATE label + moved to non-gate stack → approved via move', () => {
+    const card = { labels: [{ title: 'GATE' }] };
+    const result = GateDetector.checkGateResolution(card, nonGateCurrentStack, false);
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.decision, 'approved');
+    assert.strictEqual(result.via, 'move');
+  });
+
+  test('checkGateResolution() GATE label + moved to rejection stack → rejected via move', () => {
+    const card = { labels: [{ title: 'GATE' }] };
+    const result = GateDetector.checkGateResolution(card, nonGateCurrentStack, true);
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.decision, 'rejected');
+    assert.strictEqual(result.via, 'move');
+  });
+
+  test('checkGateResolution() GATE+APPROVED labels in gate stack → approved via label (label-first backward compat)', () => {
+    const card = { labels: [{ title: 'GATE' }, { title: 'APPROVED' }] };
+    // APPROVED check fires first, regardless of currentStack
+    const result = GateDetector.checkGateResolution(card, gateCurrentStack, false);
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.decision, 'approved');
+    assert.strictEqual(result.via, 'label');
+  });
+
+  test('checkGateResolution() REJECTED label → rejected via label', () => {
+    const card = { labels: [{ title: 'REJECTED' }] };
+    const result = GateDetector.checkGateResolution(card, nonGateCurrentStack, false);
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.decision, 'rejected');
+    assert.strictEqual(result.via, 'label');
+  });
+
+  test('checkGateResolution() no workflow label → pass-through (via null)', () => {
+    const card = { labels: [] };
+    const result = GateDetector.checkGateResolution(card, nonGateCurrentStack, false);
+    assert.strictEqual(result.resolved, true);
+    assert.strictEqual(result.decision, null);
+    assert.strictEqual(result.via, null);
+  });
+
+  test('checkGateResolution() GATE-only, currentStack omitted (legacy 1-arg call) → unresolved', () => {
+    const card = { labels: [{ title: 'GATE' }] };
+    const result = GateDetector.checkGateResolution(card);
+    assert.strictEqual(result.resolved, false);
+    assert.strictEqual(result.decision, null);
+    assert.strictEqual(result.via, null);
   });
 
   summary();

--- a/test/unit/workflows/gate-llm-driven.test.js
+++ b/test/unit/workflows/gate-llm-driven.test.js
@@ -67,7 +67,11 @@ function createMockTalkQueue() {
   };
 }
 
-// Build a minimal workflow board object for tests
+// Build a minimal workflow board object for tests.
+// The stack includes a CONFIG card with the 'System' label whose title contains
+// "GATE" — required by GateDetector.isGateStack() so that GATE-labelled content
+// cards are correctly classified as UNRESOLVED (held) under #197's stack-move
+// detection, rather than mistaken for cards that have already been dragged out.
 function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}) {
   return {
     board: { id: 1, title: 'Test Workflow', owner: { uid: 'jordan' } },
@@ -75,6 +79,12 @@ function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}
       id: 10,
       title: 'Inbox',
       cards: [
+        {
+          id: 901,
+          title: 'CONFIG: GATE review',
+          description: 'Gate review step',
+          labels: [{ title: 'System' }]
+        },
         {
           id: 100,
           title: 'Content Card',
@@ -322,6 +332,265 @@ function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}
 
     assert.ok(result.startsWith('Failed to assign label:'), 'Should return failure message');
     assert.ok(result.includes('Network error'), 'Should include the original error message');
+  });
+
+  // ── Stack-move (drag-to-approve) tests (#197) ────────────────────────────────
+
+  /**
+   * Build a multi-stack workflow board for move-detection tests.
+   * @param {Object} opts
+   * @param {boolean} opts.cardInGateStack  - Place GATE card in gate stack (unresolved)
+   *                                         vs destination stack (resolved via move)
+   * @param {boolean} opts.hasRejectionStack - Add a second stack with REJECTED: true CONFIG
+   */
+  function makeGateBoard({ cardInGateStack = false, hasRejectionStack = false } = {}) {
+    const gateConfigCard = {
+      id: 901,
+      title: 'CONFIG: Gate',
+      description: 'GATE review step',
+      labels: [{ title: 'System' }]
+    };
+    const contentCard = {
+      id: 100,
+      title: 'Enquiry Card',
+      description: 'Some content',
+      labels: [{ title: 'GATE' }],
+      assignedUsers: [],
+      lastModified: new Date(Date.now() + 60000).toISOString()
+    };
+
+    const gateStack = {
+      id: 10,
+      title: 'Review',
+      cards: [
+        // WORKFLOW rules card (prevents createMockDetector prepend via rulesCardId set below)
+        { id: 900, title: 'WORKFLOW: pipeline', description: 'REVIEWER: jordan\nRULES: Send reply.', labels: [] },
+        gateConfigCard,
+        ...(cardInGateStack ? [contentCard] : [])
+      ]
+    };
+
+    const destStack = {
+      id: 20,
+      title: hasRejectionStack ? 'Rejected' : 'Replied',
+      cards: [
+        ...(hasRejectionStack ? [{ id: 902, title: 'CONFIG: Rejected', description: 'REJECTED: true', labels: [] }] : []),
+        ...(!cardInGateStack ? [contentCard] : [])
+      ]
+    };
+
+    const stacks = [gateStack, destStack];
+
+    return {
+      board: { id: 1, title: 'Test Workflow', owner: { uid: 'jordan' } },
+      stacks,
+      description: 'WORKFLOW: pipeline\nREVIEWER: jordan\nRULES: Send reply.',
+      _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: jordan\nRULES: Send reply.',
+      workflowType: 'pipeline',
+      boardId: 1,
+      rulesCardId: 900  // prevents createMockDetector from prepending a second rules card
+    };
+  }
+
+  // Helper: create a deck mock with board labels pre-populated for label ops
+  function createMockDeckWithLabels() {
+    const mock = createMockDeck();
+    mock.getBoard = async () => ({
+      labels: [
+        { id: 1, title: 'GATE' },
+        { id: 2, title: 'APPROVED' },
+        { id: 3, title: 'REJECTED' }
+      ]
+    });
+    return mock;
+  }
+
+  // Test 9: Approval via move — GATE card dragged to non-gate stack → label swap + handoff
+  await asyncTest('Approval via move: GATE card in non-gate stack → GATE removed, APPROVED added, processWorkflowTask called', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const wb = makeGateBoard({ cardInGateStack: false, hasRejectionStack: false });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+    });
+
+    const results = await engine.processAll();
+
+    assert.strictEqual(results.gatesFound, 1, 'One gate found');
+    assert.strictEqual(results.gatesResolved, 1, 'Gate should be resolved');
+    assert.strictEqual(agentLoop._calls.length, 1, 'processWorkflowTask should be called once');
+
+    // Label swap: DELETE for GATE (id:1), then PUT for APPROVED (id:2)
+    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
+    const gateRemoval = labelOps.find(c => c.method === 'DELETE' && c.body && c.body.labelId === 1);
+    const approvedAdd  = labelOps.find(c => c.method === 'PUT'    && c.body && c.body.labelId === 2);
+    assert.ok(gateRemoval, 'Should DELETE GATE label');
+    assert.ok(approvedAdd,  'Should PUT APPROVED label');
+
+    // Handoff context mentions approved
+    const call = agentLoop._calls[0];
+    assert.ok(call.systemAddition.toLowerCase().includes('approved'), 'systemAddition should mention approved');
+  });
+
+  // Test 10: Rejection via move — destination stack has REJECTED: true → REJECTED label applied
+  await asyncTest('Rejection via move: GATE card moved to REJECTED stack → GATE removed, REJECTED added', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const wb = makeGateBoard({ cardInGateStack: false, hasRejectionStack: true });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+    });
+
+    const results = await engine.processAll();
+
+    assert.strictEqual(results.gatesResolved, 1, 'Gate should be resolved');
+
+    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
+    const gateRemoval   = labelOps.find(c => c.method === 'DELETE' && c.body && c.body.labelId === 1);
+    const rejectedAdd   = labelOps.find(c => c.method === 'PUT'    && c.body && c.body.labelId === 3);
+    assert.ok(gateRemoval, 'Should DELETE GATE label');
+    assert.ok(rejectedAdd, 'Should PUT REJECTED label (not APPROVED)');
+
+    const call = agentLoop._calls[0];
+    assert.ok(call.systemAddition.toLowerCase().includes('rejected'), 'systemAddition should mention rejected');
+  });
+
+  // Test 11: Idempotency — card post-swap (APPROVED label, no GATE) is not re-processed as a gate
+  await asyncTest('Idempotency: APPROVED-only card is not treated as a gate (isGate returns false)', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+
+    // Card has only APPROVED label — simulates post-swap state where GATE was removed
+    const wb = makeBoard({ cardLabels: [{ title: 'APPROVED' }] });
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+    });
+
+    const results = await engine.processAll();
+
+    assert.strictEqual(results.gatesFound, 0, 'APPROVED-only card should NOT be counted as a gate');
+    // No gate label ops should occur
+    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
+    const gateSwapOps = labelOps.filter(c => c.body && (c.body.labelId === 1));
+    assert.strictEqual(gateSwapOps.length, 0, 'No GATE label operations should happen on post-swap card');
+  });
+
+  // Test 12: Unresolved gate in gate stack — no label swap, no processWorkflowTask
+  await asyncTest('Unresolved gate: GATE card still in gate stack → no label swap, no processWorkflowTask', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const wb = makeGateBoard({ cardInGateStack: true, hasRejectionStack: false });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: createMockTalkQueue(),
+      talkToken: 'test-token'
+    });
+
+    const results = await engine.processAll();
+
+    assert.strictEqual(results.gatesFound, 1, 'Gate should be found');
+    assert.strictEqual(results.gatesResolved, 0, 'Gate should NOT be resolved');
+    assert.strictEqual(agentLoop._calls.length, 0, 'processWorkflowTask should NOT be called');
+
+    // No GATE label swap
+    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
+    assert.strictEqual(labelOps.length, 0, 'No label swap should occur for unresolved gate');
+  });
+
+  // Test 13: Comment text — says "Move this card forward to approve" (not old label instruction)
+  await asyncTest('Comment text says "Move this card forward to approve" for unresolved gate', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const talkQueue = createMockTalkQueue();
+    const wb = makeGateBoard({ cardInGateStack: true, hasRejectionStack: false });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: talkQueue,
+      talkToken: 'test-token'
+    });
+
+    await engine.processAll();
+
+    // Card comment
+    assert.ok(mockDeck._comments.length > 0, 'Should add a comment to the card');
+    const comment = mockDeck._comments[0].message;
+    assert.ok(comment.includes('Move this card forward to approve'), 'Comment should say "Move this card forward to approve"');
+    assert.ok(!comment.toLowerCase().includes('apply'), 'Comment should NOT say "apply ... label"');
+
+    // Talk message
+    assert.ok(talkQueue._messages.length > 0, 'Should send a Talk notification');
+    const talkMsg = talkQueue._messages[0].msg;
+    assert.ok(talkMsg.includes('Move this card forward to approve'), 'Talk message should say "Move this card forward to approve"');
+  });
+
+  // Test 14: Comment includes decline line when rejection stack exists
+  await asyncTest('Comment includes rejection stack decline instruction when REJECTED stack declared', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const talkQueue = createMockTalkQueue();
+    // Gate card in gate stack; board also has a rejection stack
+    const wb = makeGateBoard({ cardInGateStack: true, hasRejectionStack: true });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: talkQueue,
+      talkToken: 'test-token'
+    });
+
+    await engine.processAll();
+
+    const comment = (mockDeck._comments[0] || {}).message || '';
+    assert.ok(comment.includes('Rejected'), 'Comment should include the rejection stack name');
+    assert.ok(comment.includes('to decline'), 'Comment should include "to decline" instruction');
+
+    const talkMsg = (talkQueue._messages[0] || {}).msg || '';
+    assert.ok(talkMsg.includes('Rejected'), 'Talk message should include the rejection stack name');
+  });
+
+  // Test 15: Comment omits decline line when no rejection stack declared
+  await asyncTest('Comment omits decline line when no REJECTED stack on board', async () => {
+    const agentLoop = createMockAgentLoop();
+    const mockDeck = createMockDeckWithLabels();
+    const talkQueue = createMockTalkQueue();
+    const wb = makeGateBoard({ cardInGateStack: true, hasRejectionStack: false });
+
+    const engine = new WorkflowEngine({
+      workflowDetector: createMockDetector([wb]),
+      deckClient: mockDeck,
+      agentLoop,
+      talkSendQueue: talkQueue,
+      talkToken: 'test-token'
+    });
+
+    await engine.processAll();
+
+    const comment = (mockDeck._comments[0] || {}).message || '';
+    assert.ok(!comment.includes('to decline'), 'Comment should NOT include "to decline" when no rejection stack');
+
+    const talkMsg = (talkQueue._messages[0] || {}).msg || '';
+    assert.ok(!talkMsg.includes('to decline'), 'Talk message should NOT include "to decline" when no rejection stack');
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/workflow-engine.test.js
+++ b/test/unit/workflows/workflow-engine.test.js
@@ -1053,7 +1053,11 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'RULES: ...'
     };
-    const stack = { id: 10, title: 'Review' };
+    // Gate CONFIG card gives isGateStack() a true result so the card is held
+    // (unresolved) rather than treated as "moved out → approved" (#197).
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     // GATE label (not resolved), assigned to the bot
     const card = {
       id: 200,
@@ -1097,7 +1101,9 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'RULES: ...'
     };
-    const stack = { id: 10, title: 'Review' };
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     const card = {
       id: 200,
       title: 'GATE: Needs Review',
@@ -1144,7 +1150,9 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'RULES: ...'
     };
-    const stack = { id: 10, title: 'Review' };
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     const card = {
       id: 200,
       title: 'GATE: Needs Review',
@@ -1187,7 +1195,9 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'RULES: ...'
     };
-    const stack = { id: 10, title: 'Review' };
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     const card = {
       id: 200,
       title: 'GATE: Needs Review',
@@ -1230,12 +1240,14 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'RULES: ...'
     };
-    // Stack with a CONFIG card that carries REVIEWER: sam
+    // Stack with a CONFIG card that carries REVIEWER: sam.
+    // System label + "GATE" in title satisfies isGateStack() (#197) so the card
+    // is held (unresolved) rather than treated as a post-move approval.
     const stack = {
       id: 10,
       title: 'Review',
       cards: [
-        { id: 901, title: 'CONFIG: Review Stack', description: 'REVIEWER: sam\nLLM: local', labels: [] }
+        { id: 901, title: 'CONFIG: GATE Review Stack', description: 'REVIEWER: sam\nLLM: local', labels: [{ title: 'System' }] }
       ]
     };
     const card = {
@@ -1282,8 +1294,11 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: dana\nRULES: ...'
     };
-    // Stack has no CONFIG card
-    const stack = { id: 10, title: 'Review', cards: [] };
+    // Gate CONFIG card satisfies isGateStack() (#197). No REVIEWER on CONFIG card
+    // so the resolver falls through to wb._plainDescription (REVIEWER: dana).
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     const card = {
       id: 200,
       title: 'GATE: Needs Review',
@@ -1327,12 +1342,13 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: dana\nRULES: ...'
     };
-    // Stack CONFIG card declares a different reviewer — must win over board-level
+    // Stack CONFIG card declares a different reviewer — must win over board-level.
+    // System label + "GATE" in title satisfies isGateStack() (#197).
     const stack = {
       id: 10,
       title: 'Review',
       cards: [
-        { id: 901, title: 'CONFIG: Review Stack', description: 'REVIEWER: quinn', labels: [] }
+        { id: 901, title: 'CONFIG: GATE Review Stack', description: 'REVIEWER: quinn', labels: [{ title: 'System' }] }
       ]
     };
     const card = {
@@ -1379,7 +1395,11 @@ function createMockTalkQueue() {
       description: 'WORKFLOW: pipeline',
       _plainDescription: 'WORKFLOW: pipeline\nREVIEWER: quinn\nRULES: ...'
     };
-    const stack = { id: 10, title: 'Review', cards: [] };
+    // Gate CONFIG card satisfies isGateStack() (#197). No REVIEWER on CONFIG card
+    // so the resolver falls through to wb._plainDescription (REVIEWER: quinn).
+    const stack = { id: 10, title: 'Review', cards: [
+      { id: 901, title: 'CONFIG: GATE review', description: 'Gate review step', labels: [{ title: 'System' }] }
+    ] };
     const card = {
       id: 200,
       title: 'GATE: Needs Review',


### PR DESCRIPTION
Closes #197.

## What & why
The GATE mechanism had a mismatch between the human gesture and the engine's detection: the reviewer drags the card out of the gate (Review) stack as the natural Deck approval gesture, but the engine only detected the `APPROVED`/`REJECTED` label — and the GATE status comment told reviewers to "apply the APPROVED label," contradicting board rules that say "move to Replied to approve."

Per the locked #197 decision (Option B): **the stack move is the approval signal.** Labels are demoted to engine-applied record-keeping.

## Changes
- **`GateDetector.checkGateResolution(card, currentStack, isRejectionStack)`** — adds a `via: 'label' | 'move' | null` field. Legacy `APPROVED`/`REJECTED` checks stay **first** (a transition card carrying `GATE`+`APPROVED` in the gate stack must resolve approved, not be re-read as unresolved). `GATE` + still in a gate stack → unresolved; `GATE` + moved out → resolved via the drag (rejected if the destination declares `REJECTED: true`, else approved). `currentStack` omitted → unresolved (legacy callers unchanged).
- **`isGateStack` hardening** — locates the CONFIG card by **either** structural convention (`System` label **OR** `CONFIG:` title prefix), mirroring `isStructuralCard`/`findConfigCard`. Matching the `System` label alone would false-negate on a board whose gate CONFIG card uses only the title convention, silently reading a held gate as approved. This locator is the load-bearing held-vs-approved decision, so it must be robust to both conventions.
- **`_isRejectionStack(stack)`** — reads a `REJECTED: true` CONFIG marker, mirroring `_isTerminalStack` (#196) on the same CONFIG card. Absent/`false` → approval.
- **`_handleGate`** — on move-resolution, swaps `GATE` → `APPROVED`/`REJECTED` **before** the LLM handoff (deterministic record-keeping + idempotency). Notify/comment text changes to "Move this card forward to approve.", appending `Move to "<stack>" to decline.` when a rejection stack is declared.

## Not in scope (per briefing)
- **No auto-send.** This build makes the approval event detectable; it does not wire anything to fire on it (the Replied stack is `TERMINAL: true`, #196).
- **Safety net (#183) unchanged** — still fires only for unresolved gates in the gate stack.

## Review-driven follow-ups (filed, not shipped here)
- **#200** — a move-resolved card whose *title* starts `GATE:` can re-enter `_handleGate` via the `isGate()` title-prefix fallback.
- **#201** — the move heuristic has no "was previously gated" check, so a `GATE`-labelled card sitting outside any gate stack is auto-approved (the locked Q2 briefing decision; surfaced for tracking).

## Tests
- `gate-detector` 26, `gate-llm-driven` 15, `workflow-engine` 46; full unit suite **234/234 files pass**; `npm run lint` **0 errors**.
- Covers briefing Part 6 (move-approve, move-reject, label backward-compat both, pass-through, idempotency, comment text with/without rejection stack) **plus** a regression guard proving a gate stack identified by `CONFIG:` title only still holds the gate (no false approval).

## Verification Gate (live, not yet run)
The briefing's live gate runs on Prime / board 165 (send a test email → reaches Review with GATE → drag to Replied → confirm label swap + idempotency). That requires the deploy + un-pause and is **not** part of this PR; flagged for the deploy session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)