### PR TITLE
fix(workflow): remove labels via PUT /removeLabel, not DELETE /assignLabel (#203)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -1818,7 +1818,15 @@ class WorkflowEngine {
 
   /**
    * Remove a workflow label from a card by title.
-   * Looks up the label ID from the full board then calls the DELETE API.
+   * Looks up the label ID from the full board then calls the Deck removeLabel API.
+   *
+   * The Deck label-removal endpoint is `PUT .../cards/{id}/removeLabel` (the
+   * mirror of `PUT .../assignLabel` for adding). An earlier implementation used
+   * `DELETE .../assignLabel`, which this Nextcloud/Deck build rejects with HTTP
+   * 405 Method Not Allowed — the error was swallowed by the catch below, so the
+   * label silently persisted (breaking, among others, #197's GATE→APPROVED swap
+   * and its idempotency). DeckClient.removeLabel already uses the PUT endpoint;
+   * this aligns with it.
    * @private
    */
   async _removeLabelFromCard(boardId, stackId, cardId, labelTitle) {
@@ -1831,8 +1839,8 @@ class WorkflowEngine {
         console.warn(`[Workflow] Label "${labelTitle}" not found on board ${boardId} — nothing to remove`);
         return;
       }
-      const apiPath = `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/assignLabel`;
-      await this.deck._request('DELETE', apiPath, { labelId: label.id });
+      const apiPath = `/index.php/apps/deck/api/v1.0/boards/${boardId}/stacks/${stackId}/cards/${cardId}/removeLabel`;
+      await this.deck._request('PUT', apiPath, { labelId: label.id });
       console.log(`[Workflow] Removed label "${labelTitle}" from card ${cardId}`);
     } catch (err) {
       console.warn(`[Workflow] Could not remove label "${labelTitle}" from card ${cardId}: ${err.message}`);

--- a/test/unit/workflows/gate-llm-driven.test.js
+++ b/test/unit/workflows/gate-llm-driven.test.js
@@ -425,12 +425,13 @@ function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}
     assert.strictEqual(results.gatesResolved, 1, 'Gate should be resolved');
     assert.strictEqual(agentLoop._calls.length, 1, 'processWorkflowTask should be called once');
 
-    // Label swap: DELETE for GATE (id:1), then PUT for APPROVED (id:2)
-    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
-    const gateRemoval = labelOps.find(c => c.method === 'DELETE' && c.body && c.body.labelId === 1);
-    const approvedAdd  = labelOps.find(c => c.method === 'PUT'    && c.body && c.body.labelId === 2);
-    assert.ok(gateRemoval, 'Should DELETE GATE label');
-    assert.ok(approvedAdd,  'Should PUT APPROVED label');
+    // Label swap: remove GATE (id:1) via PUT /removeLabel, then add APPROVED (id:2) via PUT /assignLabel
+    const gateRemoval = mockDeck._requestCalls.find(c =>
+      c.method === 'PUT' && c.path.includes('/removeLabel') && c.body && c.body.labelId === 1);
+    const approvedAdd = mockDeck._requestCalls.find(c =>
+      c.method === 'PUT' && c.path.includes('/assignLabel') && c.body && c.body.labelId === 2);
+    assert.ok(gateRemoval, 'Should remove GATE label via PUT /removeLabel');
+    assert.ok(approvedAdd,  'Should add APPROVED label via PUT /assignLabel');
 
     // Handoff context mentions approved
     const call = agentLoop._calls[0];
@@ -455,11 +456,12 @@ function makeBoard({ cardLabels = [], assignedUsers = [], extraCards = [] } = {}
 
     assert.strictEqual(results.gatesResolved, 1, 'Gate should be resolved');
 
-    const labelOps = mockDeck._requestCalls.filter(c => c.path.includes('assignLabel'));
-    const gateRemoval   = labelOps.find(c => c.method === 'DELETE' && c.body && c.body.labelId === 1);
-    const rejectedAdd   = labelOps.find(c => c.method === 'PUT'    && c.body && c.body.labelId === 3);
-    assert.ok(gateRemoval, 'Should DELETE GATE label');
-    assert.ok(rejectedAdd, 'Should PUT REJECTED label (not APPROVED)');
+    const gateRemoval = mockDeck._requestCalls.find(c =>
+      c.method === 'PUT' && c.path.includes('/removeLabel') && c.body && c.body.labelId === 1);
+    const rejectedAdd = mockDeck._requestCalls.find(c =>
+      c.method === 'PUT' && c.path.includes('/assignLabel') && c.body && c.body.labelId === 3);
+    assert.ok(gateRemoval, 'Should remove GATE label via PUT /removeLabel');
+    assert.ok(rejectedAdd, 'Should add REJECTED label via PUT /assignLabel (not APPROVED)');
 
     const call = agentLoop._calls[0];
     assert.ok(call.systemAddition.toLowerCase().includes('rejected'), 'systemAddition should mention rejected');

--- a/test/unit/workflows/workflow-card-states.test.js
+++ b/test/unit/workflows/workflow-card-states.test.js
@@ -187,11 +187,11 @@ function makeEngine({ detector, deck, agent, talkQueue, config } = {}) {
 
     await engine.processAll();
 
-    // The SCHEDULED label must have been removed: DELETE to assignLabel endpoint with labelId=5
+    // The SCHEDULED label must have been removed: PUT to removeLabel endpoint with labelId=5
     const removeCalls = deck._requestCalls.filter(r =>
-      r.method === 'DELETE' && r.path.includes('/assignLabel') && r.body && r.body.labelId === 5
+      r.method === 'PUT' && r.path.includes('/removeLabel') && r.body && r.body.labelId === 5
     );
-    assert.ok(removeCalls.length > 0, 'SCHEDULED label (id=5) must be removed via DELETE /assignLabel');
+    assert.ok(removeCalls.length > 0, 'SCHEDULED label (id=5) must be removed via PUT /removeLabel');
   });
 
   // Test 3: SCHEDULED card with no due date is skipped with warning
@@ -232,7 +232,7 @@ function makeEngine({ detector, deck, agent, talkQueue, config } = {}) {
     // PAUSED wins — card must be skipped, no SCHEDULED removal
     assert.strictEqual(agent._calls.length, 0, 'AgentLoop must not be called — PAUSED wins');
     const removeCalls = deck._requestCalls.filter(r =>
-      r.method === 'DELETE' && r.path.includes('/assignLabel') && r.body && r.body.labelId === 5
+      r.method === 'PUT' && r.path.includes('/removeLabel') && r.body && r.body.labelId === 5
     );
     assert.strictEqual(removeCalls.length, 0, 'SCHEDULED label must NOT be removed when PAUSED wins');
   });
@@ -506,7 +506,7 @@ function makeEngine({ detector, deck, agent, talkQueue, config } = {}) {
     assert.strictEqual(agent._calls.length, 0, 'PAUSED card must be skipped');
     // No label removal calls (SCHEDULED handler must not run)
     const scheduledRemovals = deck._requestCalls.filter(r =>
-      r.method === 'DELETE' && r.path.includes('/assignLabel') && r.body && r.body.labelId === 5
+      r.method === 'PUT' && r.path.includes('/removeLabel') && r.body && r.body.labelId === 5
     );
     assert.strictEqual(scheduledRemovals.length, 0, 'SCHEDULED handler must not run when card is PAUSED');
   });


### PR DESCRIPTION
Closes #203. Found during #197 live verification on Prime.

## Bug
`WorkflowEngine._removeLabelFromCard` removed labels with `DELETE /…/assignLabel`, which the production Deck build rejects with **HTTP 405 Method Not Allowed**. The call sits in a try/catch that only warns, so removal **failed silently** and the label persisted. The correct endpoint is `PUT /…/removeLabel` (mirror of `PUT /…/assignLabel` for adding) — `DeckClient.removeLabel` already uses it; the engine helper was the lone outlier.

## Live evidence
- `DELETE /…/assignLabel { labelId }` → **405**
- `PUT /…/removeLabel { labelId }` → **200**, label actually removed (verified by fresh re-read)

## Impact
`_removeLabelFromCard` backs ERROR, SCHEDULED, and GATE (#197) removal — all silently failed on this Deck build. For **#197 drag-to-approve**, the GATE→APPROVED swap removed GATE then added APPROVED; with removal failing, the card kept **both**, so every subsequent pulse re-resolved via the APPROVED-label path and re-fired the handoff — **idempotency broken**.

## Why tests missed it (BUILT ≠ VERIFIED)
Unit tests mock the Deck transport, which accepted the `DELETE`. Three assertions in `workflow-card-states.test.js` had **codified the wrong endpoint**, so green tests reinforced the bug. Only live verification on Prime caught it.

## Fix
- `_removeLabelFromCard` → `PUT /…/removeLabel`.
- Corrected 5 test assertions (3 in `workflow-card-states`, 2 in `gate-llm-driven` #197 move-resolution tests) to assert the real endpoint.
- Full unit suite **234/234**, lint **0 errors**.

## Note
This is a companion to #197 — that feature's idempotency cannot work in production without this fix. Also repairs long-silent ERROR/SCHEDULED label removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)