### PR TITLE
fix(workflow): code-own the research-beat footer; stop model-authored wikilinks and Message-ID (#206, #192)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -529,7 +529,9 @@ class WorkflowEngine {
       '**Instructions:**',
       'Follow the CONFIG instructions for this stack. The CONFIG card defines',
       'exactly what to do with cards in this stack.',
-      'Use workflow_deck_update_card to write or rewrite the card description.',
+      'Use workflow_deck_update_card to append the profile to the card description.',
+      'The section after the --- line (From, Date, and the "Open in Mail" link if present) is system-owned.',
+      'Do NOT rewrite or reformat that footer — append profile prose below the existing footer.',
       'Use workflow_deck_* tools with numeric IDs to move cards, add comments, etc.',
       'Comment on the card with what you did.',
       'If the CONFIG says to notify in Talk, use the talk_send tool.',
@@ -546,7 +548,7 @@ class WorkflowEngine {
     // Generic cards and other boards receive no grounding block.
     //
     // The From: footer is written by the email trigger ingest path (#185) as:
-    //   <body>\n\n---\nFrom: <Name> <addr>\nDate: ...\nMessage-ID: ...
+    //   <body>\n\n---\nFrom: <Name> <addr>\nDate: ...\n[Open the original email in Mail](...)
     // We parse from the RAW description (not the stripHtml version) because
     // stripHtml strips angle-bracket content (e.g. <alice@acme.com> → stripped).
     // This is structural parsing of a machine-authored marker — Rule 1 clean.
@@ -617,8 +619,12 @@ class WorkflowEngine {
           '  as distinct attributed sections in both the card description and the Collectives page.',
           '',
           'Write the profile to BOTH:',
-          '  1. The card description (appended below the email text) — the reviewer\'s primary surface.',
+          '  1. The card description (appended below the system-owned footer) — the reviewer\'s primary surface.',
           '  2. The partner\'s Collectives page — the durable record.',
+          'For the Collectives link written into the card description: use the exact URL returned by',
+          'the wiki_write tool result (the [View](...) URL in the tool response).',
+          'Do NOT construct a [[wikilink]] — NC Collectives has no wikilink resolver',
+          'and [[...]] syntax will not render as a link.',
         ].filter(Boolean).join('\n');
       } else {
         sectionB = [
@@ -626,6 +632,10 @@ class WorkflowEngine {
           'Web research is disabled by system policy (sovereign mode).',
           'Compile the profile from the email content and internal knowledge only.',
           'Write the profile to both the card description and the Collectives page.',
+          'For the Collectives link written into the card description: use the exact URL returned by',
+          'the wiki_write tool result (the [View](...) URL in the tool response).',
+          'Do NOT construct a [[wikilink]] — NC Collectives has no wikilink resolver',
+          'and [[...]] syntax will not render as a link.',
         ].join('\n');
       }
 
@@ -1260,8 +1270,7 @@ class WorkflowEngine {
       }
 
       let description = bodyText + '\n\n---\nFrom: ' + fromLine +
-        '\nDate: ' + (email.date || '') +
-        '\nMessage-ID: ' + key;
+        '\nDate: ' + (email.date || '');
 
       // Best-effort: append a deep-link back to the original message in NC Mail.
       // Only attempt resolution when the real Message-ID header is available
@@ -1272,10 +1281,10 @@ class WorkflowEngine {
           if (mailUrl) {
             description += '\n[Open the original email in Mail](' + mailUrl + ')';
           } else {
-            console.log('[Workflow] NC Mail back-link: no match for Message-ID ' + email.messageId + ' (message may not yet be synced) — keeping Message-ID footer');
+            console.log('[Workflow] NC Mail back-link: no match for Message-ID ' + email.messageId + ' (message may not yet be synced) — omitting Mail link');
           }
         } catch (err) {
-          console.log('[Workflow] NC Mail back-link: resolution errored for Message-ID ' + email.messageId + ': ' + err.message + ' — keeping Message-ID footer');
+          console.log('[Workflow] NC Mail back-link: resolution errored for Message-ID ' + email.messageId + ': ' + err.message + ' — omitting Mail link');
         }
       }
 

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -344,8 +344,8 @@ function makeEmail(overrides = {}) {
       'email should NOT be marked as ingested when card creation returned null');
   });
 
-  // TC-TRIGGER-13: Card description contains sender, date, and Message-ID footer.
-  await asyncTest('TC-TRIGGER-13: Card description has From/Date/Message-ID footer', async () => {
+  // TC-TRIGGER-13: Card description contains sender and date footer (no Message-ID after B2).
+  await asyncTest('TC-TRIGGER-13: Card description has From/Date footer (no Message-ID)', async () => {
     const email = makeEmail({
       messageId: '<footer-test@example.com>',
       from: 'Bob <bob@example.com>',
@@ -364,9 +364,9 @@ function makeEmail(overrides = {}) {
     assert.strictEqual(deck._calls.length, 1);
     const desc = deck._calls[0].description;
     assert.ok(desc.includes('Bob <bob@example.com>'), 'description should contain sender');
-    assert.ok(desc.includes('<footer-test@example.com>'), 'description should contain Message-ID');
     // date is included (any format — it's the raw Date object converted to string)
     assert.ok(desc.includes('Date:'), 'description should contain Date: label');
+    assert.ok(!desc.includes('Message-ID'), 'description must NOT contain Message-ID after B2');
   });
 
   // TC-TRIGGER-14: Unsupported kind (files:) → returns 0, _fetchEmails NOT called.
@@ -455,9 +455,9 @@ function makeEmail(overrides = {}) {
     }
   });
 
-  // TC-TRIGGER-17: ncMailClient resolves a URL → description contains Markdown link AND
-  //               still contains the Message-ID: footer.
-  await asyncTest('TC-TRIGGER-17: ncMailClient resolves URL → description has link AND Message-ID footer', async () => {
+  // TC-TRIGGER-17: ncMailClient resolves a URL → description contains Markdown link,
+  //               no Message-ID in footer (B2: Message-ID dropped from footer).
+  await asyncTest('TC-TRIGGER-17: ncMailClient resolves URL → description has Mail link, no Message-ID', async () => {
     const MAIL_URL = 'https://nc.example.com/apps/mail/box/99/thread/555';
     const ncMailClient = {
       resolveThreadUrl: async (_folder, _msgId) => MAIL_URL
@@ -482,14 +482,14 @@ function makeEmail(overrides = {}) {
       'description should contain Markdown link to NC Mail'
     );
     assert.ok(
-      desc.includes('Message-ID: <link-test@example.com>'),
-      'description should still contain the Message-ID footer'
+      !desc.includes('Message-ID'),
+      'description must NOT contain Message-ID after B2 removal'
     );
   });
 
-  // TC-TRIGGER-18: ncMailClient.resolveThreadUrl returns null → description falls back to
-  //               Message-ID footer with NO Mail link; ingestion returns 1 card (no throw).
-  await asyncTest('TC-TRIGGER-18: ncMailClient returns null → Message-ID footer intact, no link, ingestion completes', async () => {
+  // TC-TRIGGER-18: ncMailClient.resolveThreadUrl returns null → no Mail link, no Message-ID;
+  //               ingestion returns 1 card (no throw). (B2: Message-ID dropped from footer.)
+  await asyncTest('TC-TRIGGER-18: ncMailClient returns null → no Mail link, no Message-ID, ingestion completes', async () => {
     const ncMailClient = {
       resolveThreadUrl: async (_folder, _msgId) => null
     };
@@ -512,18 +512,21 @@ function makeEmail(overrides = {}) {
     assert.strictEqual(result, 1, 'should return 1 ingested card');
     const desc = deck._calls[0].description;
     assert.ok(
-      desc.includes('Message-ID: <null-link-test@example.com>'),
-      'Message-ID footer must be present'
+      !desc.includes('Message-ID'),
+      'Message-ID must NOT appear in footer after B2 removal'
     );
     assert.ok(
       !desc.includes('[Open the original email in Mail]'),
       'no Mail link should be present when resolveThreadUrl returned null'
     );
+    assert.ok(desc.includes('From:'), 'From: line must still be present');
+    assert.ok(desc.includes('Date:'), 'Date: line must still be present');
   });
 
   // TC-TRIGGER-19: ncMailClient.resolveThreadUrl throws → ingestion still completes
-  //               (try/catch swallows it), footer is intact, returns 1 card.
-  await asyncTest('TC-TRIGGER-19: ncMailClient throws → ingestion completes, footer intact', async () => {
+  //               (try/catch swallows it), no Mail link, no Message-ID, returns 1 card.
+  //               (B2: Message-ID dropped from footer.)
+  await asyncTest('TC-TRIGGER-19: ncMailClient throws → ingestion completes, no Message-ID, no link', async () => {
     const ncMailClient = {
       resolveThreadUrl: async () => { throw new Error('simulated NC Mail error'); }
     };
@@ -546,13 +549,15 @@ function makeEmail(overrides = {}) {
     assert.strictEqual(result, 1, 'should return 1 ingested card');
     const desc = deck._calls[0].description;
     assert.ok(
-      desc.includes('Message-ID: <throw-test@example.com>'),
-      'Message-ID footer must be present after resolveThreadUrl threw'
+      !desc.includes('Message-ID'),
+      'Message-ID must NOT appear in footer after B2 removal'
     );
     assert.ok(
       !desc.includes('[Open the original email in Mail]'),
       'no Mail link should appear when resolveThreadUrl threw'
     );
+    assert.ok(desc.includes('From:'), 'From: line must still be present');
+    assert.ok(desc.includes('Date:'), 'Date: line must still be present');
   });
 
   // TC-TRIGGER-20: from is display-name only, fromAddress present → From line is
@@ -719,6 +724,61 @@ function makeEmail(overrides = {}) {
 
     assert.strictEqual(deck._calls.length, 1, 'the first email after an empty-folder seed must ingest');
     assert.strictEqual(engine._isEmailIngested(1, '<first-ever@example.com>'), true, 'first email recorded');
+  });
+
+  // TC-TRIGGER-27: (#192 / B2) The assembled ingest footer contains no Message-ID substring.
+  //               Key is still computed and used for dedup — only the card TEXT is free of it.
+  await asyncTest('TC-TRIGGER-27: assembled footer contains no Message-ID substring (B2)', async () => {
+    const email = makeEmail({
+      messageId: '<msgid-absent-test@example.com>',
+      from: 'Dana <dana@example.com>',
+      fromAddress: 'dana@example.com',
+      date: new Date('2026-06-26T08:00:00Z'),
+      body: 'Some body text.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck });
+    markSeeded(engine);
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.TEST' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'one card should be created');
+    const desc = deck._calls[0].description;
+    assert.ok(!desc.includes('Message-ID'), 'footer must contain no "Message-ID" substring');
+    // Dedup store should still have the key — only card text is scrubbed.
+    assert.ok(engine._isEmailIngested(1, '<msgid-absent-test@example.com>'),
+      'Message-ID key must still be stored in the dedup store');
+  });
+
+  // TC-TRIGGER-28: (#195 / B2) The footer is From line + standalone Mail link, no Message-ID.
+  await asyncTest('TC-TRIGGER-28: footer is From + Date + standalone Mail link, no Message-ID (B2)', async () => {
+    const MAIL_URL = 'https://nc.example.com/apps/mail/inbox/thread/42';
+    const ncMailClient = {
+      resolveThreadUrl: async (_folder, _msgId) => MAIL_URL
+    };
+    const email = makeEmail({
+      messageId: '<footer-shape-test@example.com>',
+      from: 'Eve <eve@example.com>',
+      fromAddress: 'eve@example.com',
+      date: new Date('2026-06-26T09:00:00Z'),
+      body: 'Footer shape test.'
+    });
+    const emailHandler = createMockEmailHandler([email]);
+    const deck = createMockDeck();
+    const engine = makeEngine({ emailHandler, deck, ncMailClient });
+    markSeeded(engine);
+    const wb = makeWorkflowBoard({ description: 'WORKFLOW: pipeline\nTRIGGER: email:INBOX.INQUIRIES' });
+
+    await engine._ingestTriggerEmails(wb);
+
+    assert.strictEqual(deck._calls.length, 1, 'one card should be created');
+    const desc = deck._calls[0].description;
+    assert.ok(/\nFrom:/.test(desc), 'footer must contain \\nFrom: line');
+    assert.ok(/\[Open the original email in Mail\]\(/.test(desc),
+      'footer must contain standalone [Open the original email in Mail](...) link');
+    assert.ok(!desc.includes('Message-ID'), 'footer must NOT contain Message-ID');
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/workflows/research-grounding.test.js
+++ b/test/unit/workflows/research-grounding.test.js
@@ -101,8 +101,9 @@ function makeWb({ cardDescription = '' } = {}) {
   };
 }
 
-const FROM_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\nMessage-ID: <abc123@mail.acme.com>';
-const MAIL_LINK_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\nMessage-ID: <abc123@mail.acme.com>\n[Open the original email in Mail](https://nc.example.com/apps/mail/inbox/1234)';
+// Post-B2 footer format: no Message-ID line (dropped by _ingestTriggerEmails after #206 fix).
+const FROM_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22';
+const MAIL_LINK_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\n[Open the original email in Mail](https://nc.example.com/apps/mail/inbox/1234)';
 
 // ---------------------------------------------------------------------------
 // Helper: run engine against one wb, return captured processWorkflowTask calls
@@ -166,7 +167,8 @@ asyncTest('Section A includes the NC Mail link when present in footer', async ()
 });
 
 asyncTest('Section A works when From footer has no display name (bare address)', async () => {
-  const bareAddr = '\n\n---\nFrom: <bareaddr@corp.io>\nDate: 2026-06-22\nMessage-ID: <x>';
+  // Post-B2 footer: no Message-ID line.
+  const bareAddr = '\n\n---\nFrom: <bareaddr@corp.io>\nDate: 2026-06-22';
   const wb = makeWb({ cardDescription: 'Hello\n' + bareAddr });
   const calls = await runEngine(wb, 'research');
   const sys = calls[0].systemAddition;
@@ -292,6 +294,74 @@ asyncTest('searchPolicy defaults to "research" when cockpitManager absent', asyn
   assert.ok(calls.length >= 1);
   assert.strictEqual(calls[0].searchPolicy, 'research',
     `Default searchPolicy should be 'research' when cockpitManager absent`);
+});
+
+// ---------------------------------------------------------------------------
+// B1: wiki_write URL directive (#206 — no [[wikilink]] for Collectives link)
+// ---------------------------------------------------------------------------
+
+asyncTest('B1: grounding instructs to use the exact wiki_write returned URL for Collectives link', async () => {
+  // Both non-sovereign and sovereign branches must carry the directive.
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1);
+  const sys = calls[0].systemAddition;
+  assert.ok(
+    sys.includes('wiki_write'),
+    `systemAddition must reference wiki_write tool so model knows to use its returned URL; got:\n${sys}`
+  );
+  assert.ok(
+    sys.includes('[View](') || sys.includes('[View](...)'),
+    `systemAddition must reference the [View](...) URL pattern from wiki_write result; got:\n${sys}`
+  );
+});
+
+asyncTest('B1-sovereign: sovereign branch also carries the wiki_write URL directive', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'sovereign');
+  assert.ok(calls.length >= 1);
+  const sys = calls[0].systemAddition;
+  assert.ok(
+    sys.includes('wiki_write'),
+    `sovereign systemAddition must reference wiki_write tool; got:\n${sys}`
+  );
+});
+
+asyncTest('B1: grounding forbids [[wikilink]] syntax for the Collectives link', async () => {
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1);
+  const sys = calls[0].systemAddition;
+  // The prohibition must be present so the model knows not to construct [[...]] links.
+  assert.ok(
+    sys.includes('[[wikilink]]') || sys.includes('[['),
+    `systemAddition must name the [[...]] pattern to forbid it; got:\n${sys}`
+  );
+  // The instruction must forbid it, not recommend it.
+  // We check for the prohibition phrase that the implementation uses.
+  assert.ok(
+    sys.includes('Do NOT construct a [[wikilink]]') ||
+    sys.includes('Do NOT construct') ||
+    sys.includes('wikilink resolver'),
+    `systemAddition must contain a prohibition on [[wikilink]] construction; got:\n${sys}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// B2: no Message-ID in assembled grounding (#192 / #206)
+// ---------------------------------------------------------------------------
+
+asyncTest('B2: assembled systemAddition contains no Message-ID substring (B2 removal)', async () => {
+  // The card description uses a post-B2 footer (no Message-ID line).
+  // The grounding block (Sections A+B) must not include Message-ID either.
+  const wb    = makeWb({ cardDescription: 'Hello\n' + FROM_FOOTER });
+  const calls = await runEngine(wb, 'research');
+  assert.ok(calls.length >= 1);
+  const sys = calls[0].systemAddition;
+  assert.ok(
+    !sys.includes('Message-ID'),
+    `systemAddition must contain no "Message-ID" substring after B2 removal; got:\n${sys}`
+  );
 });
 
 setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
Part B of the #205 briefing. One generator, three symptoms: the card description is model-authored, so canonical identifiers that should be code-owned were at the mercy of a full-description rewrite each beat.

- **#206** — model wrote the Collectives link as `[[People/Name]]` (a wikilink NC Collectives does not render) instead of the real `wiki_write` page URL.
- **#192** — model fabricated the Message-ID (the ingest footer carried one for a rewrite to invent values from).
- **#195 (concat half)** — footer spacing mangled in the rewrite.

## Approach — interim, prompt-side + footer removal
The true generator fix (engine owns final description assembly by carrying the `wiki_write` URL out of `processWorkflowTask`) is **deferred to #208** — `processWorkflowTask` returns only `lastResponse` and discards tool results, so capturing the URL needs a multi-file change to the agent-loop return contract.

- **B1 (prompt)** — instruct the model to write the Collectives link as the EXACT URL returned by `wiki_write` (`[View](url)`), never a `[[...]]` wikilink. Applied to both research branches (non-sovereign + sovereign). Mirrors #185.
- **B2 (code)** — drop the Message-ID from the ingest footer in `_ingestTriggerEmails`. Nothing to fabricate. Footer is now `From` / `Date` / standalone "Open in Mail" link. Safe: dedup store keys on `email.messageId` in its own JSON, the grounding parser anchors on `\n---\n` + `From:` (not Message-ID), the Mail link is resolved at ingest. Resolves #192 by removal and the #195 concat half.
- **B3 (prompt)** — change the description instruction from "write or rewrite" to append-only, footer named system-owned/off-limits.

## Tests
`email-trigger-bridge.test.js`: footer carries no `Message-ID` substring, is `From` + standalone Mail link. `research-grounding.test.js`: grounding instructs the exact `wiki_write` URL, forbids `[[`, carries no `Message-ID`. Full unit suite 234/234; lint 0.

## Live Verification Gate (post-merge, per briefing)
After deploy + un-pause: confirm the card's Collectives link is a real clickable URL (no `[[...]]`), the footer is the From line + one standalone Mail link with no `Message-ID` anywhere, and no fabricated Message-ID appears in journal or card.

Closes #206 and #192 on production evidence (manual close after merge into `next`). #195 stays open, narrowed to the wrong-thread Mail link only. Follow-up generator fix tracked in #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)