### PR TITLE
fix(calendar): consolidate overlapping calendar tools onto one creation path (#169)

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -31,7 +31,7 @@ Moltagent is a sovereign AI assistant that lives entirely inside a Nextcloud ins
 You have 55+ tools across these domains: Deck (task management), Calendar (CalDAV events), Files (WebDAV read/write/share), Wiki (Collectives knowledge pages), Web (search + fetch), Contacts (address book), Memory (search + recall), Email (draft/send with approval), and Workflows (board processing). Tool definitions are provided separately — use them as documented.
 
 Domain-specific notes (not in tool schemas):
-- **Calendar**: When scheduling with a person, use `contacts_resolve` to find their email first. Never guess email addresses. Use `calendar_check_availability` before creating, or use `calendar_quick_schedule` which checks automatically.
+- **Calendar**: When scheduling with a person, use `contacts_resolve` to find their email first. Never guess email addresses. Use `calendar_check_availability` to check a slot, or pass `check_availability: true` to `calendar_create_event` to check and create in one step.
 - **Wiki**: Use `type` param for auto-templating (research, person, project, procedure). Decay rates: research 30d, project 60d, person 90d, procedure 180d. Include frontmatter with `type`, `confidence`, `decay_days`, `last_verified`. Use [[wikilinks]] in wiki content (auto-resolved). In Deck cards, use absolute markdown links instead.
 - **Web**: Cite sources. Prefer web_search for discovery, web_read for deep reading. Web content has EXTERNAL trust level — flag uncertain claims.
 - **Email**: Always requires human approval. Emails include AI disclosure footer.

--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -23,8 +23,6 @@ const SENSITIVE_TOOLS = new Set([
   'calendar_create_event',
   'calendar_update_event',
   'calendar_delete_event',
-  'calendar_quick_schedule',
-  'calendar_schedule_meeting',
   'calendar_cancel_meeting',
   'wiki_write',
   'wiki_delete',
@@ -36,8 +34,6 @@ const EDITABLE_TOOLS = new Set([
   'mail_reply',
   'calendar_create_event',
   'calendar_update_event',
-  'calendar_quick_schedule',
-  'calendar_schedule_meeting',
   'wiki_write',
 ]);
 
@@ -50,8 +46,6 @@ const TOOL_CATEGORIES = {
   calendar_create_event:  'CALENDAR — creates a new calendar event',
   calendar_update_event:  'CALENDAR — modifies an existing calendar event',
   calendar_delete_event:  'CALENDAR — deletes a calendar event',
-  calendar_quick_schedule:'CALENDAR — checks availability and creates an event',
-  calendar_schedule_meeting:'CALENDAR — schedules a meeting with attendee invitations',
   calendar_cancel_meeting:'CALENDAR — cancels a meeting and sends cancellation notices',
   wiki_write:             'KNOWLEDGE BASE — creates or updates a wiki page in shared knowledge',
   wiki_delete:            'KNOWLEDGE BASE — permanently trashes a wiki page',
@@ -65,8 +59,6 @@ const KEYWORD_FALLBACK_MAP = {
   calendar_create_event:  ['calendar event', 'schedule meeting'],
   calendar_update_event:  ['calendar event', 'modify calendar'],
   calendar_delete_event:  ['delete event', 'cancel event'],
-  calendar_quick_schedule:['schedule meeting', 'book meeting', 'calendar event'],
-  calendar_schedule_meeting:['schedule meeting', 'meeting invitation', 'calendar event'],
   calendar_cancel_meeting:['cancel meeting', 'meeting cancellation', 'cancel event'],
   wiki_write:             ['knowledge base', 'wiki', 'knowledge change'],
   wiki_delete:            ['delete wiki', 'wiki page deletion', 'remove wiki page'],
@@ -81,7 +73,7 @@ const HIGH_SEVERITY_TOOLS = new Set([
   'execute_shell', 'run_command',
   'notification_send', 'external_api_call',
   'file_share', 'deck_share_board',
-  'calendar_schedule_meeting', 'calendar_cancel_meeting',
+  'calendar_cancel_meeting',
 ]);
 
 const TOOL_APPROVAL_LABELS = {
@@ -104,8 +96,6 @@ const TOOL_APPROVAL_LABELS = {
   deck_share_board:     'Share board',
   access_new_credential:'Access credential',
   wiki_delete:          'Delete wiki page',
-  calendar_quick_schedule:  'Schedule event',
-  calendar_schedule_meeting:'Schedule meeting with invitations',
   calendar_cancel_meeting:  'Cancel meeting',
 };
 
@@ -528,8 +518,6 @@ class GuardrailEnforcer {
         return this._buildFileMoveConfirmation(toolArgs, guardrailLine);
       case 'calendar_create_event':
       case 'calendar_update_event':
-      case 'calendar_quick_schedule':
-      case 'calendar_schedule_meeting':
         return this._buildCalendarConfirmation(toolName, toolArgs, guardrailLine);
       case 'calendar_delete_event':
       case 'calendar_cancel_meeting':
@@ -603,8 +591,6 @@ class GuardrailEnforcer {
     const actionMap = {
       calendar_create_event: 'Create event',
       calendar_update_event: 'Update event',
-      calendar_quick_schedule: 'Quick schedule',
-      calendar_schedule_meeting: 'Schedule meeting',
     };
     const action = actionMap[toolName] || 'Calendar action';
     const attendees = Array.isArray(args.attendees) ? args.attendees.join(', ') : (args.attendee || '');
@@ -671,8 +657,6 @@ class GuardrailEnforcer {
       deck_delete_card: 'delete a Deck card',
       deck_share_board: 'share a Deck board',
       file_share: 'share a file',
-      calendar_quick_schedule: 'schedule an event',
-      calendar_schedule_meeting: 'schedule a meeting with invitations',
       calendar_cancel_meeting: 'cancel a meeting',
     };
     const action = actionMap[toolName] || `perform an action (${toolName})`;
@@ -854,18 +838,6 @@ class GuardrailEnforcer {
           patterns.push(new RegExp(`\\bshare\\b.*${escaped}`, 'i'));
         }
         break;
-      case 'calendar_quick_schedule':
-        patterns.push(
-          /\b(?:schedule|book|set up)\b/,
-          /\bfind\s+(?:a\s+)?time\b/
-        );
-        break;
-      case 'calendar_schedule_meeting':
-        patterns.push(
-          /\b(?:schedule|book|set up|arrange)\b.*\bmeeting\b/,
-          /\bmeeting\b.*\b(?:schedule|book|set up|arrange)\b/
-        );
-        break;
       case 'calendar_cancel_meeting':
         patterns.push(
           /\b(?:cancel|call off)\b.*\bmeeting\b/,
@@ -1027,18 +999,6 @@ class GuardrailEnforcer {
       case 'wiki_delete':
         lines.push(`Page: **${args.page_title || '?'}**`);
         lines.push('\u26a0\ufe0f This cannot be undone.');
-        break;
-      case 'calendar_quick_schedule':
-        lines.push(`Event: **${args.summary || '?'}**`);
-        lines.push(`Time: ${args.date_time || '?'} (${args.duration_minutes || 60} min)`);
-        if (args.attendees?.length) lines.push(`Attendees: ${args.attendees.join(', ')}`);
-        break;
-      case 'calendar_schedule_meeting':
-        lines.push(`Meeting: **${args.summary || '?'}**`);
-        lines.push(`Time: ${args.start || '?'} – ${args.end || '?'}`);
-        lines.push(`Attendees: ${(args.attendees || []).join(', ')}`);
-        if (args.location) lines.push(`Location: ${args.location}`);
-        lines.push('\u26a0\ufe0f Invitations will be sent to all attendees.');
         break;
       case 'calendar_cancel_meeting':
         lines.push(`Event UID: **${args.event_uid || '?'}**`);

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -199,7 +199,7 @@ class ToolRegistry {
     if (ctx.includes('wiki') || ctx.includes('[['))
       ['wiki_write', 'wiki_read', 'wiki_search', 'wiki_delete'].forEach(t => allowed.add(t));
     if (ctx.includes('calendar') || ctx.includes('schedule') || ctx.includes('meeting') || ctx.includes('kickoff'))
-      ['calendar_create_event', 'calendar_list_events', 'calendar_check_availability', 'calendar_quick_schedule', 'calendar_schedule_meeting', 'calendar_cancel_meeting'].forEach(t => allowed.add(t));
+      ['calendar_create_event', 'calendar_list_events', 'calendar_check_availability', 'calendar_cancel_meeting'].forEach(t => allowed.add(t));
     if (ctx.includes('folder') || ctx.includes('/clients/') || ctx.includes('file'))
       ['file_mkdir', 'file_write'].forEach(t => allowed.add(t));
     if (ctx.includes('email') || ctx.includes('mail'))
@@ -259,9 +259,6 @@ class ToolRegistry {
         'calendar_list_events',
         'calendar_create_event',
         'calendar_check_availability',
-        'calendar_check_conflicts',
-        'calendar_quick_schedule',
-        'calendar_schedule_meeting',
         'calendar_update_event',
         'calendar_delete_event',
         'meeting_compose',
@@ -1752,13 +1749,15 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_create_event',
-      description: 'Create a new calendar event. When attendees are provided, Nextcloud automatically sends invitation emails to them.',
+      description: 'Create a calendar event. Optionally checks availability first (set check_availability: true). Supports attendees with automatic invitation emails. Use duration_minutes OR end to set the event length (default: 60 minutes).',
       parameters: {
         type: 'object',
         properties: {
           title: { type: 'string', description: 'Event title' },
           start: { type: 'string', description: 'Start datetime as ISO 8601 string' },
-          end: { type: 'string', description: 'End datetime as ISO 8601 string (default: 1 hour after start)' },
+          end: { type: 'string', description: 'End datetime as ISO 8601 string. Overrides duration_minutes if both are given (default: start + duration_minutes, or +1 hour).' },
+          duration_minutes: { type: 'number', description: 'Event length in minutes. Used to compute end when end is omitted (default: 60).' },
+          check_availability: { type: 'boolean', description: 'When true, check the slot is free before creating; if not, report conflicts and create nothing (default: false).' },
           description: { type: 'string', description: 'Event description (optional)' },
           location: { type: 'string', description: 'Location (optional)' },
           attendees: {
@@ -1782,23 +1781,36 @@ class ToolRegistry {
           return `Invalid start date: "${args.start}". Use ISO 8601 format (e.g. 2026-02-26T14:00:00).`;
         }
 
-        // Reject dates more than 24 hours in the past — likely an LLM date hallucination
-        const now = new Date();
-        const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-        if (startDate < twentyFourHoursAgo) {
-          return `Rejected: start date ${startDate.toISOString()} is in the past. Current date/time is ${now.toISOString()}. Please use the correct date.`;
-        }
+        // Past-date rejection lives in the CalDAVClient.createEvent substrate (#169),
+        // so every creation path inherits it; do not duplicate it here.
 
-        const endDate = args.end
-          ? new Date(args.end)
-          : new Date(startDate.getTime() + 60 * 60 * 1000);
-
-        if (args.end && isNaN(endDate.getTime())) {
-          return `Invalid end date: "${args.end}". Use ISO 8601 format (e.g. 2026-02-26T15:00:00).`;
+        // end wins when both end and duration_minutes are supplied; otherwise
+        // duration_minutes computes end; otherwise default to a 60-minute event.
+        let endDate;
+        if (args.end) {
+          endDate = new Date(args.end);
+          if (isNaN(endDate.getTime())) {
+            return `Invalid end date: "${args.end}". Use ISO 8601 format (e.g. 2026-02-26T15:00:00).`;
+          }
+        } else if (Number.isFinite(args.duration_minutes) && args.duration_minutes > 0) {
+          endDate = new Date(startDate.getTime() + args.duration_minutes * 60 * 1000);
+        } else {
+          endDate = new Date(startDate.getTime() + 60 * 60 * 1000);
         }
 
         if (endDate <= startDate) {
           return `Invalid time range: end (${endDate.toISOString()}) is not after start (${startDate.toISOString()}).`;
+        }
+
+        // Optional pre-creation availability check (absorbs calendar_quick_schedule).
+        if (args.check_availability) {
+          const availability = await cal.checkAvailability(startDate, endDate);
+          if (!availability.isFree) {
+            const conflicts = (availability.conflicts || []).map(c =>
+              `- ${c.summary} (${new Date(c.start).toLocaleString()} – ${new Date(c.end).toLocaleString()})`
+            ).join('\n');
+            return `Time slot not available. Conflicts:\n${conflicts}\nNo event created. Try a different time.`;
+          }
         }
 
         const eventData = {
@@ -1867,39 +1879,6 @@ class ToolRegistry {
           msg += ` Invitations sent to: ${names}.`;
         }
         return msg;
-      }
-    });
-
-    this.register({
-      name: 'calendar_check_conflicts',
-      description: 'Check if a time slot has conflicts with existing events.',
-      parameters: {
-        type: 'object',
-        properties: {
-          start: { type: 'string', description: 'Start datetime as ISO 8601 string' },
-          end: { type: 'string', description: 'End datetime as ISO 8601 string (default: 1 hour after start)' }
-        },
-        required: ['start']
-      },
-      handler: async (args) => {
-        try {
-          const startDate = new Date(args.start);
-          const endDate = args.end
-            ? new Date(args.end)
-            : new Date(startDate.getTime() + 60 * 60 * 1000);
-
-          const result = await cal.checkAvailability(startDate, endDate);
-
-          if (result.isFree) {
-            return `No conflicts on ${startDate.toLocaleDateString()} at ${startDate.toLocaleTimeString()}.`;
-          }
-
-          return `Conflicts found:\n` +
-            result.conflicts.map(c => `  - ${c.summary} (${c.start} - ${c.end})`).join('\n');
-        } catch (err) {
-          this.logger.error(`[calendar_check_conflicts] ${err.message}`);
-          return `Failed to check conflicts: ${err.message}`;
-        }
       }
     });
 
@@ -2042,24 +2021,36 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_check_availability',
-      description: 'Check if a time slot is available. Returns whether the user is free and shows any conflicting events.',
+      description: 'Check whether a time slot is free. Returns availability and any conflicting events. If end is omitted, checks a 1-hour window from start.',
       parameters: {
         type: 'object',
         properties: {
-          date_time: {
+          start: {
             type: 'string',
-            description: 'ISO 8601 datetime to check (e.g., "2026-02-25T15:00:00"). Checks a 1-hour window starting at this time.'
+            description: 'Start datetime to check as ISO 8601 string (e.g., "2026-02-25T15:00:00").'
+          },
+          end: {
+            type: 'string',
+            description: 'End datetime as ISO 8601 string (optional; default: 1 hour after start).'
           }
         },
-        required: ['date_time']
+        required: ['start']
       },
       handler: async (args) => {
         try {
-          const start = new Date(args.date_time);
-          const end = new Date(start.getTime() + 60 * 60 * 1000);
+          const start = new Date(args.start);
+          if (isNaN(start.getTime())) {
+            return `Invalid start date: "${args.start}". Use ISO 8601 format (e.g. 2026-02-25T15:00:00).`;
+          }
+          const end = args.end
+            ? new Date(args.end)
+            : new Date(start.getTime() + 60 * 60 * 1000);
+          if (args.end && isNaN(end.getTime())) {
+            return `Invalid end date: "${args.end}". Use ISO 8601 format (e.g. 2026-02-25T16:00:00).`;
+          }
           const result = await cal.checkAvailability(start, end);
           if (result.isFree) {
-            return `You're free at ${args.date_time} (1-hour window). No conflicts.`;
+            return `You're free from ${start.toLocaleString()} to ${end.toLocaleString()}. No conflicts.`;
           }
           const conflicts = result.conflicts.map(c =>
             `- ${c.summary} (${new Date(c.start).toLocaleString()} – ${new Date(c.end).toLocaleString()})`
@@ -2072,109 +2063,9 @@ class ToolRegistry {
       }
     });
 
-    this.register({
-      name: 'calendar_quick_schedule',
-      description: 'Check availability and create a calendar event if the time slot is free. Combines availability check with event creation in one step.',
-      parameters: {
-        type: 'object',
-        properties: {
-          summary: { type: 'string', description: 'Event title/summary' },
-          date_time: { type: 'string', description: 'Start time in ISO 8601 format' },
-          duration_minutes: { type: 'number', description: 'Duration in minutes (default: 60)' },
-          attendees: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Email addresses of attendees (optional). Invitations will be sent.'
-          }
-        },
-        required: ['summary', 'date_time']
-      },
-      handler: async (args) => {
-        try {
-          const result = await cal.quickSchedule(
-            args.summary,
-            args.date_time,
-            args.duration_minutes || 60,
-            args.attendees || []
-          );
-          if (!result.success) {
-            if (result.conflicts && result.conflicts.length > 0) {
-              const conflicts = result.conflicts.map(c =>
-                `- ${c.summary} (${new Date(c.start).toLocaleString()} – ${new Date(c.end).toLocaleString()})`
-              ).join('\n');
-              return `Time slot not available. Conflicts:\n${conflicts}\nTry a different time.`;
-            }
-            return 'Failed to schedule: time slot not available or event creation failed.';
-          }
-          const attendeeNote = args.attendees?.length
-            ? ` Invitations sent to: ${args.attendees.join(', ')}.`
-            : '';
-          return `Scheduled "${args.summary}" at ${args.date_time} (${args.duration_minutes || 60} min).${attendeeNote}`;
-        } catch (err) {
-          this.logger.error(`[calendar_quick_schedule] ${err.message}`);
-          return `Failed to schedule event: ${err.message}`;
-        }
-      }
-    });
-
-    this.register({
-      name: 'calendar_schedule_meeting',
-      description: 'Schedule a meeting with full details including attendees, location, and description. Sends calendar invitations to all attendees.',
-      parameters: {
-        type: 'object',
-        properties: {
-          summary: { type: 'string', description: 'Meeting title' },
-          start: { type: 'string', description: 'Start time in ISO 8601 format' },
-          end: { type: 'string', description: 'End time in ISO 8601 format' },
-          attendees: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Email addresses of attendees'
-          },
-          location: { type: 'string', description: 'Meeting location or video call URL (optional)' },
-          description: { type: 'string', description: 'Meeting agenda or notes (optional)' }
-        },
-        required: ['summary', 'start', 'end', 'attendees']
-      },
-      handler: async (args) => {
-        try {
-          // Resolve organizer email from NC identity
-          let organizerEmail = null;
-          if (ncMgr) {
-            try {
-              organizerEmail = await ncMgr.getUserEmail(ncMgr.ncUser);
-            } catch (err) {
-              this.logger.warn(`[calendar_schedule_meeting] Could not resolve organizer email: ${err.message}`);
-            }
-          }
-          if (!organizerEmail) {
-            return 'Failed to schedule meeting: could not resolve organizer email. Check Nextcloud user configuration.';
-          }
-
-          const meeting = {
-            summary: args.summary,
-            start: new Date(args.start),
-            end: new Date(args.end),
-            attendees: args.attendees,
-            location: args.location || '',
-            description: args.description || '',
-            organizerEmail
-          };
-          const result = await cal.scheduleMeeting(meeting);
-          if (!result || !result.uid) {
-            return 'Failed to schedule meeting: no confirmation received from calendar server.';
-          }
-          return `Meeting scheduled: "${args.summary}"\n` +
-            `Time: ${args.start} – ${args.end}\n` +
-            `Attendees: ${args.attendees.join(', ')}\n` +
-            (args.location ? `Location: ${args.location}\n` : '') +
-            `Invitations sent.`;
-        } catch (err) {
-          this.logger.error(`[calendar_schedule_meeting] ${err.message}`);
-          return `Failed to schedule meeting: ${err.message}`;
-        }
-      }
-    });
+    // calendar_quick_schedule and calendar_schedule_meeting retired (#169):
+    // calendar_create_event now subsumes both via check_availability +
+    // duration_minutes + attendees. Past-date guard lives in the CalDAV substrate.
 
     this.register({
       name: 'calendar_cancel_meeting',

--- a/src/lib/integrations/caldav-client.js
+++ b/src/lib/integrations/caldav-client.js
@@ -380,6 +380,20 @@ class CalDAVClient {
    * @returns {Promise<Object>} Created event
    */
   async createEvent(event) {
+    // Past-date guard at the substrate (#169). Every creation path — createEvent,
+    // quickSchedule, scheduleMeeting — routes through here, so the guard fires once
+    // and all paths inherit it (previously it lived in only one of four tool
+    // handlers). Reject starts more than 24h in the past: a likely LLM date
+    // hallucination. The message names the current datetime so the model can
+    // self-correct. Throwing matches createEvent's existing failure contract;
+    // ToolRegistry.execute() surfaces it to the model as an actionable error.
+    const startDate = event.start instanceof Date ? event.start : new Date(event.start);
+    const now = new Date();
+    const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    if (!isNaN(startDate.getTime()) && startDate < twentyFourHoursAgo) {
+      throw new Error(`Rejected: start date ${startDate.toISOString()} is in the past. Current date/time is ${now.toISOString()}. Please use the correct date.`);
+    }
+
     const calendarId = event.calendarId || this.defaultCalendar;
     const uid = this._generateUID();
     const ics = this._buildICS({
@@ -1189,6 +1203,11 @@ class CalDAVClient {
 
   /**
    * Quick schedule: "Schedule a meeting with X tomorrow at 2pm"
+   *
+   * @deprecated (#169) No longer called by any tool handler — calendar_create_event
+   * now absorbs the availability-check + create flow via its check_availability
+   * option. Retained as a public convenience method in case external integrations
+   * rely on it; the past-date guard is inherited from createEvent.
    */
   async quickSchedule(summary, dateTime, durationMinutes = 60, attendees = []) {
     const start = new Date(dateTime);

--- a/src/security/guards/tool-guard.js
+++ b/src/security/guards/tool-guard.js
@@ -38,7 +38,7 @@ const REQUIRES_APPROVAL = [
   'modify_calendar', 'delete_calendar_event', 'calendar_delete_event', 'modify_contacts',
 
   // Calendar scheduling (sends external invitations/cancellations)
-  'calendar_quick_schedule', 'calendar_schedule_meeting', 'calendar_cancel_meeting',
+  'calendar_cancel_meeting',
 
   // System-level operations
   'execute_shell', 'run_command',

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -1911,7 +1911,7 @@ asyncTest('#133: system prompt — unknown domain (astrology) produces no ## Thi
 
 function makeParserLoop() {
   const registry = createMockToolRegistry({
-    calendar_quick_schedule: async () => ({ success: true, result: 'Scheduled.' }),
+    calendar_create_event: async () => ({ success: true, result: 'Scheduled.' }),
     deck_move_card: async () => ({ success: true, result: 'Moved.' })
   });
   return new AgentLoop({
@@ -1936,10 +1936,10 @@ test('#164: parser recognizes canonical {"name","arguments"} JSON shape', () => 
 test('#164: parser recognizes a <tool_call>-wrapped arguments-shape call', () => {
   const loop = makeParserLoop();
   const parsed = loop._parseToolCallFromText(
-    '<tool_call>\n{"name": "calendar_quick_schedule", "arguments": {"title": "Check backend"}}\n</tool_call>'
+    '<tool_call>\n{"name": "calendar_create_event", "arguments": {"title": "Check backend"}}\n</tool_call>'
   );
   assert.ok(parsed, '<tool_call>-wrapped call must parse');
-  assert.strictEqual(parsed.name, 'calendar_quick_schedule');
+  assert.strictEqual(parsed.name, 'calendar_create_event');
   assert.strictEqual(parsed.arguments.title, 'Check backend');
 });
 
@@ -1956,12 +1956,12 @@ asyncTest('#164: text-form call on a gate=action turn is invoked, reply is synth
   // Iteration 1 emits the call as TEXT (qwen3:8b shape); iteration 2 synthesizes.
   // Pre-fix: parser missed it → action guard re-prompts once → envelope shipped.
   const provider = createMockProvider([
-    { content: '<tool_call>\n{"name": "calendar_quick_schedule", "arguments": {"title": "Check backend", "start": "2026-06-17T19:00"}}\n</tool_call>', toolCalls: null },
+    { content: '<tool_call>\n{"name": "calendar_create_event", "arguments": {"title": "Check backend", "start": "2026-06-17T19:00"}}\n</tool_call>', toolCalls: null },
     { content: 'Scheduled "Check backend" for tomorrow at 19:00.', toolCalls: null }
   ]);
   let executed = false;
   const registry = createDomainMockToolRegistry({
-    calendar_quick_schedule: async () => { executed = true; return { success: true, result: 'Scheduled.' }; }
+    calendar_create_event: async () => { executed = true; return { success: true, result: 'Scheduled.' }; }
   });
 
   const loop = new AgentLoop({

--- a/test/unit/agent/orphan-tools.test.js
+++ b/test/unit/agent/orphan-tools.test.js
@@ -1,9 +1,10 @@
 /**
  * Orphan Tools Integration Tests
  *
- * Tests the 7 newly wired tools: calendar_check_availability,
- * calendar_quick_schedule, calendar_schedule_meeting, calendar_cancel_meeting,
+ * Tests the wired tools: calendar_check_availability, calendar_cancel_meeting,
  * deck_complete_task, deck_complete_review, contacts_resolve.
+ * (#169 retired calendar_quick_schedule + calendar_schedule_meeting; their
+ * capabilities are now folded into calendar_create_event.)
  *
  * Run: node --test test/unit/agent/orphan-tools.test.js
  */
@@ -63,7 +64,7 @@ test('calendar_check_availability registered when calDAVClient provided', () => 
 asyncTest('calendar_check_availability returns free when no conflicts', async () => {
   const cal = createMockCalDAVClient({ availability: { isFree: true, conflicts: [] } });
   const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
-  const result = await registry.execute('calendar_check_availability', { date_time: '2026-03-01T14:00:00' });
+  const result = await registry.execute('calendar_check_availability', { start: '2026-03-01T14:00:00' });
   assert.ok(result.success);
   assert.ok(result.result.includes('free'));
   assert.ok(result.result.includes('No conflicts'));
@@ -79,97 +80,37 @@ asyncTest('calendar_check_availability returns conflicts when busy', async () =>
     }
   });
   const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
-  const result = await registry.execute('calendar_check_availability', { date_time: '2026-03-01T14:00:00' });
+  const result = await registry.execute('calendar_check_availability', { start: '2026-03-01T14:00:00' });
   assert.ok(result.success);
   assert.ok(result.result.includes('Not available'));
   assert.ok(result.result.includes('Team standup'));
 });
 
 // ============================================================
-// Calendar: calendar_quick_schedule
+// Calendar: retired create/schedule tools (#169)
+// calendar_quick_schedule and calendar_schedule_meeting are consolidated into
+// calendar_create_event (check_availability + duration_minutes + attendees).
+// Consolidated behavior is covered in tool-registry.test.js.
 // ============================================================
 
-test('calendar_quick_schedule registered', () => {
+test('calendar_quick_schedule and calendar_schedule_meeting are retired (#169)', () => {
   const registry = new ToolRegistry({ calDAVClient: createMockCalDAVClient(), logger: silentLogger });
-  assert.ok(registry.has('calendar_quick_schedule'));
+  assert.ok(!registry.has('calendar_quick_schedule'), 'calendar_quick_schedule retired');
+  assert.ok(!registry.has('calendar_schedule_meeting'), 'calendar_schedule_meeting retired');
 });
 
-asyncTest('calendar_quick_schedule creates event when free', async () => {
-  const cal = createMockCalDAVClient({
-    quickSchedule: { success: true, event: { uid: 'qs-1', summary: 'Team sync' } }
-  });
+asyncTest('calendar_create_event absorbs availability-checked scheduling', async () => {
+  const cal = createMockCalDAVClient({ availability: { isFree: true, conflicts: [] } });
   const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
-  const result = await registry.execute('calendar_quick_schedule', {
-    summary: 'Team sync',
-    date_time: '2026-03-01T14:00:00'
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Team sync',
+    start: start.toISOString(),
+    duration_minutes: 30,
+    check_availability: true
   });
   assert.ok(result.success);
-  assert.ok(result.result.includes('Scheduled'));
   assert.ok(result.result.includes('Team sync'));
-});
-
-asyncTest('calendar_quick_schedule returns conflicts when busy', async () => {
-  const cal = createMockCalDAVClient({
-    quickSchedule: {
-      success: false,
-      reason: 'conflict',
-      conflicts: [
-        { uid: 'ev1', summary: 'Existing call', start: '2026-03-01T14:00:00Z', end: '2026-03-01T15:00:00Z' }
-      ]
-    }
-  });
-  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
-  const result = await registry.execute('calendar_quick_schedule', {
-    summary: 'Team sync',
-    date_time: '2026-03-01T14:00:00'
-  });
-  assert.ok(result.success);
-  assert.ok(result.result.includes('not available'));
-  assert.ok(result.result.includes('Existing call'));
-});
-
-// ============================================================
-// Calendar: calendar_schedule_meeting
-// ============================================================
-
-test('calendar_schedule_meeting registered', () => {
-  const registry = new ToolRegistry({ calDAVClient: createMockCalDAVClient(), logger: silentLogger });
-  assert.ok(registry.has('calendar_schedule_meeting'));
-});
-
-asyncTest('calendar_schedule_meeting creates meeting with invitations', async () => {
-  const cal = createMockCalDAVClient({
-    scheduleMeeting: { uid: 'mtg-1', summary: 'Q1 Review' }
-  });
-  const ncMgr = createMockNCRequestManager({ userEmails: { testuser: 'molti@example.com' } });
-  const registry = new ToolRegistry({ calDAVClient: cal, ncRequestManager: ncMgr, logger: silentLogger });
-  const result = await registry.execute('calendar_schedule_meeting', {
-    summary: 'Q1 Review',
-    start: '2026-03-01T10:00:00',
-    end: '2026-03-01T11:00:00',
-    attendees: ['alice@example.com', 'bob@example.com']
-  });
-  assert.ok(result.success);
-  assert.ok(result.result.includes('Meeting scheduled'));
-  assert.ok(result.result.includes('Q1 Review'));
-  assert.ok(result.result.includes('alice@example.com'));
-  assert.ok(result.result.includes('Invitations sent'));
-});
-
-asyncTest('calendar_schedule_meeting fails without organizer email', async () => {
-  const cal = createMockCalDAVClient();
-  // No ncRequestManager → no organizer email
-  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
-  const result = await registry.execute('calendar_schedule_meeting', {
-    summary: 'Q1 Review',
-    start: '2026-03-01T10:00:00',
-    end: '2026-03-01T11:00:00',
-    attendees: ['alice@example.com']
-  });
-  // #70 contract: the handler's "Failed to schedule meeting: …" guard string
-  // is re-framed by the execute() seam as a structured failure.
-  assert.strictEqual(result.success, false);
-  assert.ok(result.error.includes('could not resolve organizer email'));
 });
 
 // ============================================================
@@ -198,7 +139,7 @@ asyncTest('calendar_cancel_meeting cancels and returns confirmation', async () =
 // Calendar subset
 // ============================================================
 
-test('calendar subset includes new scheduling tools', () => {
+test('calendar subset reflects the consolidated tool set (#169)', () => {
   const cal = createMockCalDAVClient();
   const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
   const subset = registry.getToolSubset('calendar');
@@ -206,8 +147,8 @@ test('calendar subset includes new scheduling tools', () => {
   assert.ok(names.includes('calendar_list_events'), 'Should include calendar_list_events');
   assert.ok(names.includes('calendar_create_event'), 'Should include calendar_create_event');
   assert.ok(names.includes('calendar_check_availability'), 'Should include calendar_check_availability');
-  assert.ok(names.includes('calendar_quick_schedule'), 'Should include calendar_quick_schedule');
-  assert.ok(names.includes('calendar_schedule_meeting'), 'Should include calendar_schedule_meeting');
+  assert.ok(!names.includes('calendar_quick_schedule'), 'calendar_quick_schedule retired');
+  assert.ok(!names.includes('calendar_schedule_meeting'), 'calendar_schedule_meeting retired');
 });
 
 // ============================================================
@@ -331,11 +272,12 @@ asyncTest('contacts_resolve no match returns not found', async () => {
 // REQUIRES_APPROVAL tools have TOOL_APPROVAL_LABELS
 // ============================================================
 
-test('all REQUIRES_APPROVAL calendar tools have TOOL_APPROVAL_LABELS', () => {
+test('surviving calendar approval tools have TOOL_APPROVAL_LABELS (#169)', () => {
   const { TOOL_APPROVAL_LABELS } = require('../../../src/lib/agent/guardrail-enforcer');
-  assert.ok(TOOL_APPROVAL_LABELS.calendar_quick_schedule, 'calendar_quick_schedule label');
-  assert.ok(TOOL_APPROVAL_LABELS.calendar_schedule_meeting, 'calendar_schedule_meeting label');
   assert.ok(TOOL_APPROVAL_LABELS.calendar_cancel_meeting, 'calendar_cancel_meeting label');
+  // Retired tools must not linger as ghost references.
+  assert.ok(!TOOL_APPROVAL_LABELS.calendar_quick_schedule, 'calendar_quick_schedule label removed');
+  assert.ok(!TOOL_APPROVAL_LABELS.calendar_schedule_meeting, 'calendar_schedule_meeting label removed');
 });
 
 // ============================================================

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -86,7 +86,15 @@ function createMockCalDAVClient() {
       { uid: 'ev1', summary: 'Team standup', start: '2026-02-09T09:00:00Z', end: '2026-02-09T09:30:00Z', location: 'Zoom' },
       { uid: 'ev2', summary: 'Lunch', start: '2026-02-09T12:00:00Z', end: '2026-02-09T13:00:00Z' }
     ],
-    createEvent: async (event) => ({ uid: 'new-event-123', ...event }),
+    // Mirrors the real CalDAVClient.createEvent past-date guard (#169) so
+    // registry-level tests reflect production: a past start surfaces as an error.
+    createEvent: async (event) => {
+      const start = event.start instanceof Date ? event.start : new Date(event.start);
+      if (!isNaN(start.getTime()) && start < new Date(Date.now() - 24 * 60 * 60 * 1000)) {
+        throw new Error(`Rejected: start date ${start.toISOString()} is in the past. Current date/time is ${new Date().toISOString()}. Please use the correct date.`);
+      }
+      return { uid: 'new-event-123', ...event };
+    },
     checkAvailability: async (_start, _end) => ({ isFree: true, conflicts: [] })
   };
 }
@@ -138,7 +146,7 @@ test('constructor creates registry with tools from all clients', () => {
   assert.ok(registry.has('deck_create_card'), 'Should have deck_create_card');
   assert.ok(registry.has('calendar_list_events'), 'Should have calendar_list_events');
   assert.ok(registry.has('calendar_create_event'), 'Should have calendar_create_event');
-  assert.ok(registry.has('calendar_check_conflicts'), 'Should have calendar_check_conflicts');
+  assert.ok(registry.has('calendar_check_availability'), 'Should have calendar_check_availability');
   assert.ok(registry.has('tag_file'), 'Should have tag_file');
   assert.ok(registry.has('memory_recall'), 'Should have memory_recall');
 });
@@ -421,19 +429,21 @@ asyncTest('calendar_create_event rejects invalid start date', async () => {
   assert.ok(result.result.includes('Invalid start date'));
 });
 
-asyncTest('calendar_create_event rejects past date', async () => {
+asyncTest('calendar_create_event rejects past date (guard inherited from substrate)', async () => {
   const registry = new ToolRegistry({
     calDAVClient: createMockCalDAVClient(),
     logger: silentLogger
   });
 
+  // The handler no longer guards past dates (#169); CalDAVClient.createEvent does.
+  // The throw is reframed by execute() as a structured failure shown to the model.
   const result = await registry.execute('calendar_create_event', {
     title: 'Past meeting',
     start: '2020-01-01T10:00:00Z'
   });
 
-  assert.ok(result.success);
-  assert.ok(result.result.includes('in the past'));
+  assert.strictEqual(result.success, false);
+  assert.ok(result.error.includes('in the past'));
 });
 
 asyncTest('calendar_create_event rejects end before start', async () => {
@@ -454,18 +464,133 @@ asyncTest('calendar_create_event rejects end before start', async () => {
   assert.ok(result.result.includes('not after start'));
 });
 
-asyncTest('calendar_check_conflicts returns no conflicts', async () => {
+// #169: consolidated calendar tool surface
+asyncTest('calendar_check_availability reports free with a start (date_time retired)', async () => {
   const registry = new ToolRegistry({
     calDAVClient: createMockCalDAVClient(),
     logger: silentLogger
   });
 
-  const result = await registry.execute('calendar_check_conflicts', {
-    start: '2026-02-15T14:00:00Z'
+  const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  const result = await registry.execute('calendar_check_availability', { start: future });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('free'));
+  assert.ok(result.result.includes('No conflicts'));
+});
+
+asyncTest('calendar_create_event computes end from duration_minutes when end omitted', async () => {
+  let captured = null;
+  const cal = createMockCalDAVClient();
+  cal.createEvent = async (event) => { captured = event; return { uid: 'ev-dur', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Dur meeting',
+    start: start.toISOString(),
+    duration_minutes: 90
   });
 
   assert.ok(result.success);
-  assert.ok(result.result.includes('No conflicts'));
+  assert.strictEqual(captured.end.getTime() - captured.start.getTime(), 90 * 60 * 1000);
+});
+
+asyncTest('calendar_create_event: end wins when both end and duration_minutes given', async () => {
+  let captured = null;
+  const cal = createMockCalDAVClient();
+  cal.createEvent = async (event) => { captured = event; return { uid: 'ev-end', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'End wins',
+    start: start.toISOString(),
+    end: end.toISOString(),
+    duration_minutes: 240
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(captured.end.getTime() - captured.start.getTime(), 30 * 60 * 1000);
+});
+
+asyncTest('calendar_create_event defaults to 60 minutes when neither end nor duration given', async () => {
+  let captured = null;
+  const cal = createMockCalDAVClient();
+  cal.createEvent = async (event) => { captured = event; return { uid: 'ev-def', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Default',
+    start: start.toISOString()
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(captured.end.getTime() - captured.start.getTime(), 60 * 60 * 1000);
+});
+
+asyncTest('calendar_create_event with check_availability:true and a conflict creates nothing', async () => {
+  let createCalled = false;
+  const cal = createMockCalDAVClient();
+  cal.checkAvailability = async () => ({
+    isFree: false,
+    conflicts: [{ summary: 'Existing call', start: '2026-07-01T14:00:00Z', end: '2026-07-01T15:00:00Z' }]
+  });
+  cal.createEvent = async (event) => { createCalled = true; return { uid: 'x', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Conflicting',
+    start: start.toISOString(),
+    check_availability: true
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('not available'));
+  assert.ok(result.result.includes('Existing call'));
+  assert.strictEqual(createCalled, false, 'no event created on conflict');
+});
+
+asyncTest('calendar_create_event with check_availability:true and a free slot creates the event', async () => {
+  const cal = createMockCalDAVClient(); // checkAvailability defaults to free
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Free slot',
+    start: start.toISOString(),
+    check_availability: true
+  });
+
+  assert.ok(result.success);
+  assert.ok(result.result.includes('Free slot'));
+});
+
+test('retired calendar tools are not registered (#169)', () => {
+  const registry = new ToolRegistry({
+    calDAVClient: createMockCalDAVClient(),
+    ncRequestManager: createMockNCRequestManager(),
+    logger: silentLogger
+  });
+  assert.ok(!registry.has('calendar_quick_schedule'), 'calendar_quick_schedule retired');
+  assert.ok(!registry.has('calendar_schedule_meeting'), 'calendar_schedule_meeting retired');
+  assert.ok(!registry.has('calendar_check_conflicts'), 'calendar_check_conflicts retired');
+});
+
+test("getToolSubset('calendar') reflects the consolidated set (#169)", () => {
+  const registry = new ToolRegistry({
+    calDAVClient: createMockCalDAVClient(),
+    logger: silentLogger
+  });
+  const names = registry.getToolSubset('calendar').map(t => t.function.name);
+  assert.ok(names.includes('calendar_create_event'));
+  assert.ok(names.includes('calendar_check_availability'));
+  assert.ok(!names.includes('calendar_quick_schedule'));
+  assert.ok(!names.includes('calendar_schedule_meeting'));
+  assert.ok(!names.includes('calendar_check_conflicts'));
 });
 
 asyncTest('tag_file tags successfully', async () => {
@@ -1833,9 +1958,9 @@ test('all 53 tools registered with all clients', () => {
     textExtractor: createMockTextExtractor(),
     logger: silentLogger
   });
-  // 24 deck + 10 calendar + 1 tag + 1 memory + 10 file + 1 search + 6 workflow_deck = 53
-  // (workflow_deck_assign_label added as part of LLM-driven GATE architecture)
-  assert.strictEqual(registry.size, 53, `Expected 53 tools, got ${registry.size}`);
+  // 24 deck + 7 calendar + 1 tag + 1 memory + 10 file + 1 search + 6 workflow_deck = 50
+  // (#169 retired calendar_quick_schedule, calendar_schedule_meeting, calendar_check_conflicts)
+  assert.strictEqual(registry.size, 50, `Expected 50 tools, got ${registry.size}`);
 });
 
 asyncTest('file_read returns file content', async () => {

--- a/test/unit/integrations/caldav-client.test.js
+++ b/test/unit/integrations/caldav-client.test.js
@@ -681,10 +681,13 @@ asyncTest('TC-EVENT-004: Create event', async () => {
   });
   const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
 
+  // Future dates: the substrate past-date guard (#169) rejects starts >24h ago.
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
   const event = await client.createEvent({
     summary: 'New Event',
-    start: new Date('2025-02-15T10:00:00Z'),
-    end: new Date('2025-02-15T11:00:00Z'),
+    start,
+    end,
     calendarId: 'personal'
   });
 
@@ -705,14 +708,86 @@ asyncTest('TC-EVENT-005: Handle event creation error', async () => {
   const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
 
   try {
+    // Future dates so the request reaches the server and returns 403 — the
+    // substrate past-date guard (#169) would otherwise short-circuit first.
+    const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
     await client.createEvent({
       summary: 'New Event',
-      start: new Date('2025-02-15T10:00:00Z'),
-      end: new Date('2025-02-15T11:00:00Z')
+      start,
+      end: new Date(start.getTime() + 60 * 60 * 1000)
     });
     assert.fail('Should have thrown error');
   } catch (error) {
     assert.ok(error.message.includes('403'));
+  }
+});
+
+// --- #169: past-date guard at the createEvent substrate ---
+
+asyncTest('TC-EVENT-GUARD-001: createEvent rejects a start more than 24h in the past', async () => {
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const past = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  try {
+    await client.createEvent({
+      summary: 'Past Event',
+      start: past,
+      end: new Date(past.getTime() + 60 * 60 * 1000)
+    });
+    assert.fail('Should have rejected the past-dated event');
+  } catch (error) {
+    assert.ok(error.message.includes('in the past'), 'message names the past-date rejection');
+    assert.ok(error.message.includes('Current date/time is'), 'message names the current datetime for self-correction');
+  }
+});
+
+asyncTest('TC-EVENT-GUARD-002: createEvent accepts a start within the 24h grace window', async () => {
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  // 1 hour ago — inside the 24h grace window, must NOT be rejected.
+  const recent = new Date(Date.now() - 60 * 60 * 1000);
+  const event = await client.createEvent({
+    summary: 'Recent Event',
+    start: recent,
+    end: new Date(recent.getTime() + 60 * 60 * 1000)
+  });
+
+  assert.ok(event.uid, 'event created within grace window');
+});
+
+asyncTest('TC-EVENT-GUARD-003: scheduleMeeting inherits the past-date guard', async () => {
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const past = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  try {
+    await client.scheduleMeeting({
+      summary: 'Past Meeting',
+      start: past,
+      end: new Date(past.getTime() + 60 * 60 * 1000),
+      attendees: ['alice@example.com'],
+      organizerEmail: 'organizer@example.com'
+    });
+    assert.fail('Should have rejected the past-dated meeting');
+  } catch (error) {
+    assert.ok(error.message.includes('in the past'), 'scheduleMeeting inherits substrate rejection');
+  }
+});
+
+asyncTest('TC-EVENT-GUARD-004: quickSchedule inherits the past-date guard', async () => {
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+  // Force the availability check to pass so we reach createEvent.
+  client.checkAvailability = async () => ({ isFree: true, conflicts: [] });
+
+  const past = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  try {
+    await client.quickSchedule('Past Quick', past, 60);
+    assert.fail('Should have rejected the past-dated quick schedule');
+  } catch (error) {
+    assert.ok(error.message.includes('in the past'), 'quickSchedule inherits substrate rejection');
   }
 });
 
@@ -906,10 +981,13 @@ asyncTest('TC-MEET-001: Accept meeting creates event', async () => {
   });
   const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
 
+  // Future dates: respondToMeeting routes through createEvent, which now carries
+  // the substrate past-date guard (#169).
+  const start = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
   const result = await client.respondToMeeting({
     summary: 'Invited Meeting',
-    start: new Date('2025-03-01T10:00:00Z'),
-    end: new Date('2025-03-01T11:00:00Z'),
+    start,
+    end: new Date(start.getTime() + 60 * 60 * 1000),
     organizerEmail: 'organizer@example.com'
   }, 'ACCEPTED');
 
@@ -945,7 +1023,7 @@ asyncTest('TC-MEET-003: Tentative meeting creates tentative event', async () => 
 
   const result = await client.respondToMeeting({
     summary: 'Maybe Meeting',
-    start: new Date('2025-03-01T10:00:00Z'),
+    start: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     organizerEmail: 'organizer@example.com'
   }, 'TENTATIVE');
 


### PR DESCRIPTION
## #169 Calendar tool consolidation

Six calendar tools created or checked events through overlapping doors. Offered all of them, the model called two on one request — `calendar_quick_schedule` created the event, then `calendar_create_event` rejected the same date as past (the one past-date guard lived in only one of four creation handlers). With a valid future date this would have produced **duplicate events**.

This is the overlapping-capability pattern at the tool surface within Path A: capabilities accumulated beside each other without consolidating onto a shared layer. The fix is consolidation (disjoint tools so the model selects exactly one) plus moving the guard to the substrate every creation path converges on — the first stone of the shared calendar domain layer.

### Changes
- **Guard to the substrate.** Past-date rejection (24h grace) moves from the `calendar_create_event` handler to `CalDAVClient.createEvent`. Every creation path — `createEvent`, `quickSchedule`, `scheduleMeeting`, `respondToMeeting` — now inherits it. It throws (matching `createEvent`'s existing failure contract); `ToolRegistry.execute()` reframes the throw into a model-actionable error naming the current datetime.
- **Create tools consolidated.** Retire `calendar_quick_schedule` and `calendar_schedule_meeting`. `calendar_create_event` absorbs both via `check_availability` (bool, default false) and `duration_minutes` (explicit `end` wins, else `duration`, else 60m).
- **Availability tools consolidated.** Retire `calendar_check_conflicts`. `calendar_check_availability` takes `start` + optional `end` (default +1h), replacing the `date_time`-only window.
- **Every surface and guard list updated.** Cloud-workflow tool defs, the calendar tool subset, `tool-guard` `REQUIRES_APPROVAL`, and the `guardrail-enforcer` sets + HITL prompt builders. `calendar_create_event` and `calendar_cancel_meeting` retain Cockpit-governed HITL coverage, so invitation-sending creation stays gated at the single chokepoint.
- `CalDAVClient.quickSchedule` deprecated (kept — referenced indirectly); SOUL.md calendar note updated.

### Tests
- Substrate guard across all paths: reject past, accept inside grace, `scheduleMeeting`/`quickSchedule`/`respondToMeeting` inherit.
- Duration/end precedence (end-only, duration-only, both, neither); `check_availability` conflict path creates nothing.
- Retired tools unregistered and absent from subset/labels; tool count 53 → 50.
- Full unit suite **240/240 files**, lint **0 errors**.

### Reviewer follow-ups (pre-existing in `calendar_create_event`, out of this PR's consolidation scope)
1. **Organizer-resolution leniency.** The retired `calendar_schedule_meeting` hard-failed when the organizer email could not be resolved; `calendar_create_event` only warns and proceeds with no organizer, so invitations can silently fail. Now the sole invitation path. Candidate for a model-visible note when attendees are present but no organizer resolved — can file as a follow-up.
2. **`duration_minutes` as a string** falls through to the 60m default (`Number.isFinite("90")` is false). Schema declares `type: number`, so low risk.

### Verification Gate (deferred to post-merge, on Prime)
In Talk: (1) past-date schedule rejected naming the current time; (2) "tomorrow 2pm for 90 min" creates one event, one tool call, correct duration; (3) availability-checked scheduling checks the slot then creates or reports conflict; (4) journal shows no `calendar_quick_schedule`/`calendar_schedule_meeting` calls. Will close #169 on that evidence.

Closes #169 (on live verification).
