### PR TITLE
fix(security): gate file_write through the guardrail chokepoint

### DIFF
--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -20,6 +20,7 @@ const SENSITIVE_TOOLS = new Set([
   'mail_send',
   'file_delete',
   'file_move',
+  'file_write',
   'calendar_create_event',
   'calendar_update_event',
   'calendar_delete_event',
@@ -35,6 +36,7 @@ const EDITABLE_TOOLS = new Set([
   'calendar_create_event',
   'calendar_update_event',
   'wiki_write',
+  'file_write',
 ]);
 
 // Explicit tool categories — fed to the LLM so it reasons about category membership,
@@ -43,6 +45,7 @@ const TOOL_CATEGORIES = {
   mail_send:              'EMAIL — sends a message to an external recipient',
   file_delete:            'FILE DELETION — permanently removes a file from storage',
   file_move:              'FILE MOVE — relocates a file to a different path',
+  file_write:             'FILE WRITE — creates a new file or overwrites an existing one in storage',
   calendar_create_event:  'CALENDAR — creates a new calendar event',
   calendar_update_event:  'CALENDAR — modifies an existing calendar event',
   calendar_delete_event:  'CALENDAR — deletes a calendar event',
@@ -56,6 +59,7 @@ const KEYWORD_FALLBACK_MAP = {
   mail_send:              ['external communication', 'email', 'outbound mail'],
   file_delete:            ['delete file', 'file deletion', 'destructive'],
   file_move:              ['move file', 'file move'],
+  file_write:             ['write file', 'file write', 'save file', 'create file', 'overwrite file'],
   calendar_create_event:  ['calendar event', 'schedule meeting'],
   calendar_update_event:  ['calendar event', 'modify calendar'],
   calendar_delete_event:  ['delete event', 'cancel event'],

--- a/test/unit/agent/guardrail-enforcer.test.js
+++ b/test/unit/agent/guardrail-enforcer.test.js
@@ -1023,6 +1023,29 @@ async function runTests() {
     assert.ok(userMsg.includes('Does this guardrail govern the FILE DELETION category?'));
   });
 
+  // F1 discovery: file_write was ungated on the live (Path A) tool-calling path —
+  // present in neither ToolGuard REQUIRES_APPROVAL nor GuardrailEnforcer SENSITIVE_TOOLS,
+  // while file_delete/file_move/file_share and wiki_write all were. Mirror wiki_write
+  // (the write precedent): file_write is now guardrail-evaluable (Cockpit-GATE-governed),
+  // not short-circuited. This asserts the gap is closed.
+  await asyncTest('file_write is evaluated as sensitive (F1 gap closed)', async () => {
+    const ollama = createMockOllama('NO');
+    const enforcer = makeEnforcer({
+      cockpitManager: createMockCockpit([gateGuardrail('Confirm before writing files')]),
+      ollamaProvider: ollama,
+      talkSendQueue: createMockTalkQueue(),
+      conversationContext: createMockConversationContext([])
+    });
+
+    await enforcer.check('file_write', { path: '/Outbox/report.md', content: 'x' }, 'room1');
+    // If file_write were still non-sensitive, check() would short-circuit before any
+    // LLM call and _getLastCall() would be empty — so reaching the semantic prompt
+    // proves it is now in SENSITIVE_TOOLS.
+    const userMsg = ollama._getLastCall().messages[0].content;
+    assert.ok(userMsg.includes('Tool category: FILE WRITE'));
+    assert.ok(userMsg.includes('Does this guardrail govern the FILE WRITE category?'));
+  });
+
   // ============================================================
   // checkApproval() — ToolGuard APPROVAL_REQUIRED routing
   // ============================================================


### PR DESCRIPTION
## Problem

F1 discovery surfaced a **live security gap**: `file_write` was ungated on the Path A (LLM tool-calling) execution path — present in **neither** `ToolGuard.REQUIRES_APPROVAL` nor `GuardrailEnforcer.SENSITIVE_TOOLS`, while `file_delete`, `file_move`, `file_share`, and `wiki_write` all were. Path A is the path that actually runs under `cloud-ok`, so the agent could create/overwrite files with **no guardrail evaluation**.

## Fix

Mirrors **`wiki_write`** — the write precedent, which is deliberately handled via the Cockpit-governed `SENSITIVE_TOOLS` rather than unconditional `REQUIRES_APPROVAL`, so automated/workflow writes (Outbox, reports) are not forced through HITL on every call. Registers `file_write` into the **existing** GuardrailEnforcer chokepoint — no new guard site (rule 5: the pipe already narrows here):

- `SENSITIVE_TOOLS` (makes it guardrail-evaluable)
- `TOOL_CATEGORIES` (`FILE WRITE — creates a new file or overwrites an existing one`)
- `KEYWORD_FALLBACK_MAP` (fallback safety net, matching the existing pattern)
- `EDITABLE_TOOLS` (a write is revisable, like `wiki_write`)

Effect: a Cockpit ⛔ GATE guardrail that governs file writes now triggers HITL confirmation on the live path.

## Why `SENSITIVE_TOOLS`, not `REQUIRES_APPROVAL`

`REQUIRES_APPROVAL` is *unconditional* HITL (for destructive/external ops). `wiki_write` and `file_move` were deliberately placed in the Cockpit-governed `SENSITIVE_TOOLS` instead (see `tool-guard.js` comment). A write is not a deletion; forcing unconditional HITL on every file write would block legitimate automation. This change brings `file_write` to parity with the other sensitive-but-non-destructive operations. If unconditional approval is wanted instead, that is a one-line follow-up to `REQUIRES_APPROVAL` — flagged for the reviewer.

## Verification

- `npm run test:unit` → **234/234** files pass (added: `file_write is evaluated as sensitive (F1 gap closed)` — proves it reaches semantic evaluation, not the non-sensitive short-circuit).
- `npx eslint` on changed files → **0 errors**.

Lands on `next` independently of the F1 discovery doc (#213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #215.