### PR TITLE
fix(f1): expose ported deck tools to the model + wire entityExtractor

### DIFF
--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -82,8 +82,8 @@ class ToolRegistry {
    * @param {import('../integrations/news-client').NewsClient} [options.newsClient]
    * @param {Object} [options.logger]
    */
-  constructor({ deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, logger }) {
-    this.clients = { deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient };
+  constructor({ deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor, logger }) {
+    this.clients = { deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor };
     this.logger = logger || console;
 
     /** @type {Map<string, {name: string, description: string, parameters: Object, handler: Function}>} */
@@ -239,6 +239,13 @@ class ToolRegistry {
         'deck_get_card',
         'deck_list_stacks',
         'deck_create_stack',
+        'deck_rename_stack',
+        'deck_delete_stack',
+        'deck_rename_board',
+        'deck_archive_board',
+        'deck_delete_board',
+        'deck_setup_workflow',
+        'deck_troubleshoot',
         'deck_create_label',
         'deck_remove_label',
         'deck_move_card',

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -593,6 +593,32 @@ test("getToolSubset('calendar') reflects the consolidated set (#169)", () => {
   assert.ok(!names.includes('calendar_check_conflicts'));
 });
 
+test("getToolSubset('deck') exposes the F1-ported lifecycle + compound tools", () => {
+  // Regression: the 7 ports were registered but absent from the deck subset,
+  // so AgentLoop's domain-scoped tool list (#133) never showed them to the model
+  // ("I don't have a function to rename a stack"). The subset is the model-visible gate.
+  const registry = new ToolRegistry({
+    deckClient: createMockDeckClient(),
+    logger: silentLogger
+  });
+  const names = registry.getToolSubset('deck').map(t => t.function.name);
+  for (const t of [
+    'deck_rename_board', 'deck_archive_board', 'deck_delete_board',
+    'deck_rename_stack', 'deck_delete_stack', 'deck_setup_workflow', 'deck_troubleshoot'
+  ]) {
+    assert.ok(names.includes(t), `deck subset must expose ${t}`);
+  }
+});
+
+test('constructor keeps entityExtractor in clients (wiki_write graph population)', () => {
+  // Regression: entityExtractor was passed at the construction site but dropped
+  // by the constructor destructure, so this.clients.entityExtractor was undefined
+  // and wiki_write's populateGraph silently no-opped (no graph population on Path A).
+  const fakeExtractor = { extractFromPage: () => {} };
+  const registry = new ToolRegistry({ entityExtractor: fakeExtractor, logger: silentLogger });
+  assert.strictEqual(registry.clients.entityExtractor, fakeExtractor);
+});
+
 asyncTest('tag_file tags successfully', async () => {
   const registry = new ToolRegistry({
     systemTagsClient: createMockSystemTagsClient(),


### PR DESCRIPTION
Follow-up to #219. Live production smoke-testing surfaced two wiring gaps that unit tests and static review both missed — the ported tools were registered but unreachable on the live path.

## Caught in production
- **Deck rename test** → model replied *"I don't have a function to rename a stack"*. The 7 ported deck tools were absent from `getToolSubset('deck')`, the hardcoded per-domain allow-list AgentLoop scopes deck actions through (#133 domain custody). Registered ≠ reachable.
- **Wiki write test** → `wiki_write` fired and created the page, but no `extractFromPage`/`[KnowledgeGraph]` — `entityExtractor` was passed at the construction site but dropped by the `ToolRegistry` constructor destructure, so `this.clients.entityExtractor` was `undefined` and `populateGraph` silently no-opped.

## Fix
1. Add all 7 ports (rename/archive/delete board, rename/delete stack, setup_workflow, troubleshoot) to the `deck` subset.
2. Add `entityExtractor` to the constructor params + `this.clients`.
3. Regression tests for both (subset exposure; constructor keeps entityExtractor).

## Verification
- `npm run test:unit` → 218/218 files pass (2 new regression tests).
- `npx eslint` → 0 errors.
- Pre-fix, live: calendar/deck-list/file/wiki-knowledge all confirmed on Path A (zero executor).
- Post-fix live re-test (deck_rename_stack fires; wiki_write→[KnowledgeGraph]) pending redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)