### PR TITLE
refactor(llm): capability gate + size prior (retire JOB_AFFINITY_MAP) — Cleanup A

### DIFF
--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -1,82 +1,17 @@
 /**
- * ModelScout — Auto-discover installed Ollama models and map capabilities.
+ * ModelScout — Sense installed Ollama models and rank them per job.
  *
- * Queries the Ollama `/api/tags` endpoint, parses model metadata,
- * and generates a local roster mapping jobs to model names.
+ * Queries `/api/tags` for the installed models, then `/api/show` per model for
+ * its declared `capabilities` (Layer 0). Partitions the pool by capability
+ * class and ranks within class by a per-job size prior (Layer 1) to produce a
+ * local roster. Capability is read from what each model declares, never guessed
+ * from its family name — see docs/briefings adaptive-model-selection §2, §4, §5.
  *
  * @module providers/model-scout
- * @version 1.0.0
+ * @version 2.0.0
  */
 
 'use strict';
-
-/**
- * Job affinity map: which model families/sizes are suited to which jobs.
- * Each entry lists families in preference order with optional min param size.
- * Fallback: the largest discovered model fills any unmapped job.
- */
-const JOB_AFFINITY_MAP = Object.freeze({
-  quick: {
-    description: 'Fast, low-latency responses — smallest viable model wins',
-    preferred: [
-      { family: 'qwen2', maxParams: 4 },
-      { family: 'gemma', maxParams: 3 },
-      { family: 'phi', maxParams: 4 },
-      { family: 'qwen3', maxParams: 4 },
-      { family: 'qwen2', maxParams: 14 },
-      { family: 'llama', maxParams: 8 },
-      { family: 'qwen3', maxParams: 14 }
-    ]
-  },
-  tools: {
-    description: 'Tool calling and structured output',
-    preferred: [
-      { family: 'phi', maxParams: 14 },
-      { family: 'qwen3' },
-      { family: 'qwen2.5' },
-      { family: 'mistral' },
-      { family: 'llama', minParams: 8 }
-    ]
-  },
-  thinking: {
-    description: 'Multi-step reasoning',
-    preferred: [
-      { family: 'qwen3', minParams: 14 },
-      { family: 'deepseek', minParams: 14 },
-      { family: 'llama', minParams: 14 },
-      { family: 'qwen3' },
-      { family: 'mistral' }
-    ]
-  },
-  writing: {
-    description: 'Long-form text generation',
-    preferred: [
-      { family: 'qwen3', minParams: 14 },
-      { family: 'llama', minParams: 14 },
-      { family: 'mistral', minParams: 7 },
-      { family: 'qwen3' }
-    ]
-  },
-  research: {
-    description: 'Information synthesis and analysis',
-    preferred: [
-      { family: 'qwen3', minParams: 14 },
-      { family: 'deepseek' },
-      { family: 'llama', minParams: 14 },
-      { family: 'qwen3' }
-    ]
-  },
-  coding: {
-    description: 'Code generation and analysis',
-    preferred: [
-      { family: 'deepseek-coder' },
-      { family: 'codellama' },
-      { family: 'qwen2.5-coder' },
-      { family: 'qwen3' },
-      { family: 'deepseek' }
-    ]
-  }
-});
 
 class ModelScout {
   /**
@@ -92,8 +27,8 @@ class ModelScout {
   }
 
   /**
-   * Discover installed Ollama models via /api/tags.
-   * Caches the result in _discovered.
+   * Discover installed Ollama models via /api/tags, then sense each model's
+   * declared capabilities via /api/show. Caches the result in _discovered.
    * @returns {Promise<Array>} Array of parsed model descriptors
    */
   async discover() {
@@ -112,7 +47,7 @@ class ModelScout {
       const data = await response.json();
       const models = data.models || [];
 
-      this._discovered = models.map(m => ({
+      const base = models.map(m => ({
         name: m.name || m.model,
         family: this._extractFamily(m),
         paramSize: this._extractParamSize(m),
@@ -120,7 +55,14 @@ class ModelScout {
         modifiedAt: m.modified_at || null
       }));
 
-      this.logger.log(`[ModelScout] Discovered ${this._discovered.length} model(s): ${this._discovered.map(m => m.name).join(', ')}`);
+      // Layer 0 (Declared): ask each model what it can do rather than inferring
+      // from its name. One /api/show per model, at boot, in parallel.
+      this._discovered = await Promise.all(base.map(async (m) => {
+        const { capabilities, contextLength } = await this._probeCapabilities(m.name);
+        return { ...m, capabilities, contextLength };
+      }));
+
+      this.logger.log(`[ModelScout] Discovered ${this._discovered.length} model(s): ${this._discovered.map(m => `${m.name}[${m.capabilities.join('/')}]`).join(', ')}`);
       return this._discovered;
     } catch (err) {
       this.logger.warn(`[ModelScout] Discovery failed: ${err.message}`);
@@ -130,9 +72,10 @@ class ModelScout {
   }
 
   /**
-   * Generate a local roster mapping job names to model name arrays.
-   * Compatible with LLMRouter.setLocalRoster().
-   * @returns {Object|null} { quick: ['model1'], thinking: ['model2'], ... } or null if no models
+   * Generate a local roster mapping job names to model-name arrays, ranked
+   * best-first. Compatible with LLMRouter.setLocalRoster() and
+   * ModelResolver._readScoutRoster() (which takes the first element per job).
+   * @returns {Object|null} { quick: ['model1', ...], ... } or null if no models
    */
   generateLocalRoster() {
     if (!this._discovered || this._discovered.length === 0) {
@@ -140,22 +83,55 @@ class ModelScout {
       return null;
     }
 
-    const roster = {};
-    const largest = this._getLargestModel();
+    // Layer 0 — capability gate (Declared): each job draws only from models that
+    // declare the capability it needs. Embedding and vision models are excluded
+    // from text-generation jobs, which they have no business serving.
+    const textGen = this._discovered.filter(m => this._isTextGen(m));
+    const toolCapable = textGen.filter(m => this._capsOf(m).includes('tools'));
 
-    for (const [job, affinity] of Object.entries(JOB_AFFINITY_MAP)) {
-      const matched = this._getModelAffinity(job, affinity);
-      if (matched.length > 0) {
-        roster[job] = matched.map(m => m.name);
-      } else if (largest) {
-        // Fallback: use the largest model for unmapped jobs
-        roster[job] = [largest.name];
-      }
+    // Layer 1 — capacity prior (Described): rank by size. Strength varies per job.
+    const smallestFirst = [...textGen].sort((a, b) => this._compareSize(a, b));
+    const largestFirst = [...textGen].sort((a, b) => this._compareSize(b, a));
+    const toolsLargestFirst = [...toolCapable].sort((a, b) => this._compareSize(b, a));
+    const names = list => list.map(m => m.name);
+
+    const roster = {};
+
+    // quick / classification: latency wins and classification needs no depth,
+    // so the smallest capable model leads. (context_length is carried per model
+    // for future long-context gating; no current job declares a minimum.)
+    if (smallestFirst.length > 0) {
+      roster.quick = names(smallestFirst);
+      roster.classification = names(smallestFirst);
     }
 
-    // credentials job always gets the largest model (most capable for sensitive ops)
-    if (largest) {
-      roster.credentials = [largest.name];
+    // thinking / writing / research: size is a STRONG prior — bigger models
+    // reason and write better on average — so the largest capable model leads.
+    // credentials stays local (enforced in ModelResolver) and wants the most
+    // capable model on the box.
+    if (largestFirst.length > 0) {
+      roster.thinking = names(largestFirst);
+      roster.writing = names(largestFirst);
+      roster.research = names(largestFirst);
+      roster.credentials = names(largestFirst);
+    }
+
+    // tools / coding: size is a WEAK prior — a fine-tuned mid-size model
+    // routinely beats a larger generalist, and that specialization is invisible
+    // in size or a capability flag. Largest tool-capable is a placeholder only;
+    // Session 3 replaces it with measured performance. If no model declares
+    // `tools`, fall back to the general text roster so the box never goes dark.
+    const toolRoster = toolsLargestFirst.length > 0 ? names(toolsLargestFirst) : names(largestFirst);
+    if (toolRoster.length > 0) {
+      roster.tools = toolRoster;
+      roster.coding = toolRoster;
+    }
+
+    // A box with only embedding/vision models can serve no job here: keep the
+    // return contract single-valued (null, never an empty object).
+    if (Object.keys(roster).length === 0) {
+      this._roster = null;
+      return null;
     }
 
     this._roster = roster;
@@ -173,7 +149,8 @@ class ModelScout {
 
     const lines = this._discovered.map(m => {
       const size = m.paramSize ? `${m.paramSize}B` : '?B';
-      return `${m.name} (${m.family}, ${size})`;
+      const caps = this._capsOf(m).join('/');
+      return `${m.name} (${m.family}, ${size}, ${caps})`;
     });
 
     const rosterInfo = this._roster
@@ -203,6 +180,71 @@ class ModelScout {
   // ---------------------------------------------------------------------------
 
   /**
+   * Sense a model's declared capabilities via /api/show. On any failure, treat
+   * the model as text-generation-capable so the box never goes dark, and log
+   * the gap rather than inferring capability from the model's name.
+   * @param {string} name - Model name (e.g. 'qwen3:8b')
+   * @returns {Promise<{capabilities: string[], contextLength: number|null}>}
+   */
+  async _probeCapabilities(name) {
+    try {
+      const response = await fetch(`${this.ollamaEndpoint}/api/show`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({ model: name }),
+        signal: AbortSignal.timeout(10000)
+      });
+      if (!response.ok) {
+        throw new Error(`/api/show returned ${response.status}`);
+      }
+      const data = await response.json();
+      const capabilities = (Array.isArray(data.capabilities) && data.capabilities.length > 0)
+        ? data.capabilities.map(c => String(c).toLowerCase())
+        : ['completion'];
+      return { capabilities, contextLength: this._extractContextLength(data) };
+    } catch (err) {
+      this.logger.warn(`[ModelScout] /api/show unavailable for ${name} (${err.message}); treating as text-generation-capable`);
+      return { capabilities: ['completion'], contextLength: null };
+    }
+  }
+
+  /**
+   * Extract the context window length from an /api/show response. Ollama nests
+   * it under model_info as `<family>.context_length`.
+   * @param {Object} showData - Parsed /api/show response
+   * @returns {number|null}
+   */
+  _extractContextLength(showData) {
+    const info = showData.model_info || {};
+    for (const [key, value] of Object.entries(info)) {
+      if (key.endsWith('context_length') && Number.isFinite(value)) return value;
+    }
+    if (Number.isFinite(showData.context_length)) return showData.context_length;
+    return null;
+  }
+
+  /** Declared capabilities of a model, defaulting to text-generation. */
+  _capsOf(model) {
+    return Array.isArray(model.capabilities) && model.capabilities.length > 0
+      ? model.capabilities
+      : ['completion'];
+  }
+
+  /** Whether a model may serve text jobs (embedding-only and vision excluded). */
+  _isTextGen(model) {
+    const caps = this._capsOf(model);
+    return caps.includes('completion') && !caps.includes('embedding') && !caps.includes('vision');
+  }
+
+  /** Compare by capacity ascending (param size, then file size). (b,a) => largest-first. */
+  _compareSize(a, b) {
+    const sa = a.paramSize || 0;
+    const sb = b.paramSize || 0;
+    if (sa !== sb) return sa - sb;
+    return (a.sizeBytes || 0) - (b.sizeBytes || 0);
+  }
+
+  /**
    * Extract model family from Ollama model metadata.
    * @param {Object} model - Raw Ollama model object
    * @returns {string}
@@ -215,8 +257,6 @@ class ModelScout {
     // Fallback: parse from model name (e.g. 'qwen3:8b' → 'qwen3')
     const name = model.name || model.model || '';
     const base = name.split(':')[0];
-    // Remove trailing numbers that represent size (e.g. 'llama3.1' → 'llama')
-    // But keep version numbers like 'qwen2.5' or 'qwen3'
     return base.toLowerCase();
   }
 
@@ -242,62 +282,6 @@ class ModelScout {
 
     return null;
   }
-
-  /**
-   * Check if a model matches a preferred entry from JOB_AFFINITY_MAP.
-   * @param {Object} model - Parsed model descriptor
-   * @param {Object} pref - { family, minParams?, maxParams? }
-   * @returns {boolean}
-   */
-  _modelMatches(model, pref) {
-    if (model.family !== pref.family && !model.family.startsWith(pref.family)) {
-      return false;
-    }
-    if (pref.minParams && model.paramSize && model.paramSize < pref.minParams) {
-      return false;
-    }
-    if (pref.maxParams && model.paramSize && model.paramSize > pref.maxParams) {
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Get the largest discovered model (by param size, then file size).
-   * @returns {Object|null}
-   */
-  _getLargestModel() {
-    if (!this._discovered || this._discovered.length === 0) return null;
-    return this._discovered.reduce((best, m) => {
-      const bestSize = best.paramSize || 0;
-      const mSize = m.paramSize || 0;
-      if (mSize > bestSize) return m;
-      if (mSize === bestSize && m.sizeBytes > best.sizeBytes) return m;
-      return best;
-    }, this._discovered[0]);
-  }
-
-  /**
-   * Find models matching an affinity spec, ordered by preference.
-   * @param {string} job - Job name
-   * @param {Object} affinity - Affinity entry from JOB_AFFINITY_MAP
-   * @returns {Array} Matching model descriptors (may be empty)
-   */
-  _getModelAffinity(job, affinity) {
-    const matched = [];
-    const seen = new Set();
-
-    for (const pref of affinity.preferred) {
-      for (const model of this._discovered) {
-        if (!seen.has(model.name) && this._modelMatches(model, pref)) {
-          matched.push(model);
-          seen.add(model.name);
-        }
-      }
-    }
-
-    return matched;
-  }
 }
 
-module.exports = { ModelScout, JOB_AFFINITY_MAP };
+module.exports = { ModelScout };

--- a/test/unit/providers/model-scout.test.js
+++ b/test/unit/providers/model-scout.test.js
@@ -2,223 +2,227 @@
 
 const assert = require('assert');
 const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
-const { ModelScout, JOB_AFFINITY_MAP } = require('../../../src/lib/providers/model-scout');
+const { ModelScout } = require('../../../src/lib/providers/model-scout');
 
-const MOCK_TAGS_RESPONSE = {
-  models: [
-    {
-      name: 'phi4-mini',
-      model: 'phi4-mini',
-      size: 4915200000,
-      modified_at: '2025-01-15T10:00:00Z',
-      details: { family: 'phi3', parameter_size: '4B', format: 'gguf' }
-    },
-    {
-      name: 'deepseek-coder:6.7b',
-      model: 'deepseek-coder:6.7b',
-      size: 3800000000,
-      modified_at: '2025-01-10T10:00:00Z',
-      details: { family: 'deepseek-coder', parameter_size: '6.7B', format: 'gguf' }
-    },
-    {
-      name: 'llama3.1:70b',
-      model: 'llama3.1:70b',
-      size: 40000000000,
-      modified_at: '2025-01-20T10:00:00Z',
-      details: { family: 'llama', parameter_size: '70B', format: 'gguf' }
-    }
-  ]
+// A realistic mixed pool: two tool-capable chat models of different sizes, a
+// small text-only chat model, an embedding model, and a vision model.
+const TAGS_MODELS = [
+  { name: 'qwen3:8b', model: 'qwen3:8b', size: 5200000000, modified_at: '2025-01-20T10:00:00Z', details: { family: 'qwen3', parameter_size: '8.2B', format: 'gguf' } },
+  { name: 'qwen2.5:3b', model: 'qwen2.5:3b', size: 2000000000, modified_at: '2025-01-15T10:00:00Z', details: { family: 'qwen2', parameter_size: '3.1B', format: 'gguf' } },
+  { name: 'gemma2:2b', model: 'gemma2:2b', size: 1600000000, modified_at: '2025-01-10T10:00:00Z', details: { family: 'gemma2', parameter_size: '2.6B', format: 'gguf' } },
+  { name: 'nomic-embed-text:latest', model: 'nomic-embed-text:latest', size: 270000000, modified_at: '2025-01-05T10:00:00Z', details: { family: 'nomic-bert', parameter_size: '137M', format: 'gguf' } },
+  { name: 'llava:7b', model: 'llava:7b', size: 4700000000, modified_at: '2025-01-12T10:00:00Z', details: { family: 'llama', parameter_size: '7B', format: 'gguf' } }
+];
+
+const SHOW_BY_MODEL = {
+  'qwen3:8b': { capabilities: ['completion', 'tools', 'thinking'], model_info: { 'qwen3.context_length': 40960 } },
+  'qwen2.5:3b': { capabilities: ['completion', 'tools'], model_info: { 'qwen2.context_length': 32768 } },
+  'gemma2:2b': { capabilities: ['completion'], model_info: { 'gemma2.context_length': 8192 } },
+  'nomic-embed-text:latest': { capabilities: ['embedding'], model_info: { 'nomic-bert.context_length': 2048 } },
+  'llava:7b': { capabilities: ['completion', 'vision'], model_info: { 'llama.context_length': 8192 } }
 };
 
 const silentLogger = { log() {}, warn() {}, error() {} };
 
-// -- Test 1: discover() parses Ollama /api/tags response --
-asyncTest('discover() parses Ollama /api/tags response', async () => {
-  // Mock global fetch
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({
-    ok: true,
-    json: async () => MOCK_TAGS_RESPONSE
-  });
+// These tests swap globalThis.fetch, so they must run sequentially — the async
+// discover() now probes /api/show per model, widening the window in which a
+// concurrent test could clobber the shared fetch mock. main() awaits each in order.
+const suite = [];
+function scenario(name, fn) { suite.push({ name, fn }); }
 
+/**
+ * Build a fetch mock that routes /api/tags and /api/show by URL.
+ * @param {Array} tags - models for /api/tags
+ * @param {Object} showByModel - model name → /api/show payload
+ * @param {Object} [opts] - { showFails: true } to make /api/show error
+ */
+function mockFetch(tags, showByModel, opts = {}) {
+  return async (url, options) => {
+    if (String(url).includes('/api/tags')) {
+      return { ok: true, json: async () => ({ models: tags }) };
+    }
+    if (String(url).includes('/api/show')) {
+      if (opts.showFails) return { ok: false, status: 500, json: async () => ({}) };
+      const body = JSON.parse(options.body);
+      return { ok: true, json: async () => (showByModel[body.model] || {}) };
+    }
+    throw new Error(`unexpected url ${url}`);
+  };
+}
+
+async function withMock(fetchImpl, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
   try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+// -- discover() parses /api/tags and senses capabilities via /api/show --
+scenario('discover() parses tags and attaches declared capabilities', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     const result = await scout.discover();
 
-    assert.strictEqual(result.length, 3);
-    assert.strictEqual(result[0].name, 'phi4-mini');
-    assert.strictEqual(result[0].family, 'phi3');
-    assert.strictEqual(result[0].paramSize, 4);
-    assert.strictEqual(result[1].name, 'deepseek-coder:6.7b');
-    assert.strictEqual(result[1].paramSize, 6.7);
-    assert.strictEqual(result[2].paramSize, 70);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    assert.strictEqual(result.length, 5);
+    const qwen3 = result.find(m => m.name === 'qwen3:8b');
+    assert.strictEqual(qwen3.paramSize, 8.2);
+    assert.strictEqual(qwen3.family, 'qwen3');
+    assert.deepStrictEqual(qwen3.capabilities, ['completion', 'tools', 'thinking']);
+    assert.strictEqual(qwen3.contextLength, 40960);
+
+    const nomic = result.find(m => m.name === 'nomic-embed-text:latest');
+    assert.deepStrictEqual(nomic.capabilities, ['embedding']);
+  });
 });
 
-// -- Test 2: discover() handles Ollama offline gracefully --
-asyncTest('discover() handles Ollama offline gracefully', async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => { throw new Error('Connection refused'); };
-
-  try {
+// -- discover() handles Ollama offline gracefully --
+scenario('discover() handles Ollama offline gracefully', async () => {
+  await withMock(async () => { throw new Error('Connection refused'); }, async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     const result = await scout.discover();
-
     assert.ok(Array.isArray(result));
     assert.strictEqual(result.length, 0);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  });
 });
 
-// -- Test 3: _extractFamily() parses model name variants --
+// -- discover() falls back to text-capable when /api/show is unreachable --
+scenario('discover() defaults to text-generation when /api/show fails', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL, { showFails: true }), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    const result = await scout.discover();
+    // Every model should be treated as text-generation-capable, never dark.
+    assert.ok(result.every(m => m.capabilities.includes('completion')));
+    assert.ok(result.every(m => m.contextLength === null));
+  });
+});
+
+// -- _extractFamily() parses model name variants --
 test('_extractFamily() parses model name variants', () => {
   const scout = new ModelScout({ logger: silentLogger });
-
-  // With details.family
   assert.strictEqual(scout._extractFamily({ details: { family: 'Qwen3' } }), 'qwen3');
-
-  // Without details, parse from name
   assert.strictEqual(scout._extractFamily({ name: 'mistral:7b' }), 'mistral');
   assert.strictEqual(scout._extractFamily({ name: 'llama3.1:70b' }), 'llama3.1');
   assert.strictEqual(scout._extractFamily({ name: 'deepseek-coder:6.7b' }), 'deepseek-coder');
 });
 
-// -- Test 4: _extractParamSize() extracts parameter sizes --
+// -- _extractParamSize() extracts parameter sizes --
 test('_extractParamSize() extracts parameter sizes', () => {
   const scout = new ModelScout({ logger: silentLogger });
-
-  // From details.parameter_size
   assert.strictEqual(scout._extractParamSize({ details: { parameter_size: '8B' } }), 8);
   assert.strictEqual(scout._extractParamSize({ details: { parameter_size: '70B' } }), 70);
   assert.strictEqual(scout._extractParamSize({ details: { parameter_size: '6.7B' } }), 6.7);
-
-  // From name tag
   assert.strictEqual(scout._extractParamSize({ name: 'qwen3:8b' }), 8);
-  assert.strictEqual(scout._extractParamSize({ name: 'llama:70b' }), 70);
-
-  // No size info
   assert.strictEqual(scout._extractParamSize({ name: 'custom-model' }), null);
 });
 
-// -- Test 5: generateLocalRoster() assigns models to jobs --
-asyncTest('generateLocalRoster() assigns models to jobs based on affinity', async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({
-    ok: true,
-    json: async () => MOCK_TAGS_RESPONSE
-  });
+// -- _extractContextLength() reads model_info --
+test('_extractContextLength() reads the family context_length key', () => {
+  const scout = new ModelScout({ logger: silentLogger });
+  assert.strictEqual(scout._extractContextLength({ model_info: { 'qwen3.context_length': 40960 } }), 40960);
+  assert.strictEqual(scout._extractContextLength({ context_length: 8192 }), 8192);
+  assert.strictEqual(scout._extractContextLength({}), null);
+});
 
-  try {
+// -- capability gate: embedding and vision models excluded from text jobs --
+scenario('generateLocalRoster() excludes embedding and vision from text jobs', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     await scout.discover();
     const roster = scout.generateLocalRoster();
 
-    assert.ok(roster !== null);
-    // quick should include phi4-mini (preferred for quick via phi family)
-    assert.ok(roster.quick.includes('phi4-mini'), `quick roster should include phi4-mini, got: ${roster.quick}`);
-    // coding should include deepseek-coder
-    assert.ok(roster.coding.includes('deepseek-coder:6.7b'), `coding roster should include deepseek-coder:6.7b, got: ${roster.coding}`);
-    // thinking should include the large model
-    assert.ok(roster.thinking.includes('llama3.1:70b'), `thinking roster should include llama3.1:70b, got: ${roster.thinking}`);
-    // credentials always gets the largest model
-    assert.ok(roster.credentials.includes('llama3.1:70b'));
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    const everyModel = Object.values(roster).flat();
+    assert.ok(!everyModel.includes('nomic-embed-text:latest'), 'embedding model must not appear in any job');
+    assert.ok(!everyModel.includes('llava:7b'), 'vision model must not appear in any job');
+  });
 });
 
-// -- Test 6: generateLocalRoster() uses largest model as fallback --
-asyncTest('generateLocalRoster() uses largest model as fallback for unmapped jobs', async () => {
-  const originalFetch = globalThis.fetch;
-  // Only one model with unusual family that doesn't match any affinity
-  globalThis.fetch = async () => ({
-    ok: true,
-    json: async () => ({
-      models: [{
-        name: 'unusual-model:7b',
-        model: 'unusual-model:7b',
-        size: 5000000000,
-        details: { family: 'unusual', parameter_size: '7B' }
-      }]
-    })
-  });
-
-  try {
+// -- per-job prior: smallest for quick/classification, largest for depth jobs --
+scenario('generateLocalRoster() applies the per-job size prior', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     await scout.discover();
     const roster = scout.generateLocalRoster();
 
-    assert.ok(roster !== null);
-    // All jobs should fall back to the only available model
-    assert.deepStrictEqual(roster.quick, ['unusual-model:7b']);
-    assert.deepStrictEqual(roster.thinking, ['unusual-model:7b']);
-    assert.deepStrictEqual(roster.coding, ['unusual-model:7b']);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    // Smallest text-gen model leads latency jobs (gemma2:2b at 2.6B).
+    assert.strictEqual(roster.quick[0], 'gemma2:2b');
+    assert.strictEqual(roster.classification[0], 'gemma2:2b');
+
+    // Largest text-gen model leads depth jobs (qwen3:8b at 8.2B).
+    assert.strictEqual(roster.thinking[0], 'qwen3:8b');
+    assert.strictEqual(roster.writing[0], 'qwen3:8b');
+    assert.strictEqual(roster.research[0], 'qwen3:8b');
+    assert.strictEqual(roster.credentials[0], 'qwen3:8b');
+  });
 });
 
-// -- Test 7: generateLocalRoster() handles single-model scenario --
-asyncTest('generateLocalRoster() handles single-model scenario', async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({
-    ok: true,
-    json: async () => ({
-      models: [{
-        name: 'phi4-mini',
-        model: 'phi4-mini',
-        size: 4915200000,
-        details: { family: 'phi3', parameter_size: '4B' }
-      }]
-    })
-  });
-
-  try {
+// -- tools/coding draw only from tool-capable models, largest first --
+scenario('generateLocalRoster() routes tools/coding to tool-capable models only', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     await scout.discover();
     const roster = scout.generateLocalRoster();
 
-    assert.ok(roster !== null);
-    // phi3/phi4-mini matches quick and tools affinities
-    assert.ok(roster.quick.includes('phi4-mini'));
-    assert.ok(roster.tools.includes('phi4-mini'));
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    // Only qwen3:8b and qwen2.5:3b declare `tools`; gemma2:2b (text-only) excluded.
+    assert.deepStrictEqual(roster.tools, ['qwen3:8b', 'qwen2.5:3b']);
+    assert.deepStrictEqual(roster.coding, ['qwen3:8b', 'qwen2.5:3b']);
+    assert.ok(!roster.tools.includes('gemma2:2b'), 'non-tool model must not serve tools');
+  });
 });
 
-// -- Test 8: hasModel() matches by name and family --
-asyncTest('hasModel() matches by name and family', async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({
-    ok: true,
-    json: async () => MOCK_TAGS_RESPONSE
-  });
-
-  try {
+// -- fallback: no tool-capable model → tools reuses the text roster (never dark) --
+scenario('generateLocalRoster() falls back to text roster when no tool-capable model', async () => {
+  const tags = [TAGS_MODELS[2], TAGS_MODELS[3]]; // gemma2:2b (text-only) + nomic (embedding)
+  await withMock(mockFetch(tags, SHOW_BY_MODEL), async () => {
     const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
     await scout.discover();
+    const roster = scout.generateLocalRoster();
 
-    // Exact name match
-    assert.strictEqual(scout.hasModel('phi4-mini'), true);
-    // Family match
-    assert.strictEqual(scout.hasModel('phi3'), true);
-    // Non-existent model
+    assert.deepStrictEqual(roster.tools, ['gemma2:2b']);
+    assert.deepStrictEqual(roster.coding, ['gemma2:2b']);
+    assert.strictEqual(roster.quick[0], 'gemma2:2b');
+  });
+});
+
+// -- returns null when nothing is discovered --
+scenario('generateLocalRoster() returns null with no models', async () => {
+  await withMock(async () => { throw new Error('offline'); }, async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    assert.strictEqual(scout.generateLocalRoster(), null);
+  });
+});
+
+// -- returns null (not {}) when models exist but none can serve a text job --
+scenario('generateLocalRoster() returns null when only non-text models exist', async () => {
+  const tags = [TAGS_MODELS[3], TAGS_MODELS[4]]; // nomic (embedding) + llava (vision)
+  await withMock(mockFetch(tags, SHOW_BY_MODEL), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    assert.strictEqual(scout.generateLocalRoster(), null);
+  });
+});
+
+// -- hasModel() matches by name and family --
+scenario('hasModel() matches by name and family', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    assert.strictEqual(scout.hasModel('qwen3:8b'), true);
+    assert.strictEqual(scout.hasModel('qwen3'), true);
     assert.strictEqual(scout.hasModel('gpt-4'), false);
-    // Before discover
     const scout2 = new ModelScout({ logger: silentLogger });
-    assert.strictEqual(scout2.hasModel('phi4-mini'), false);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+    assert.strictEqual(scout2.hasModel('qwen3:8b'), false);
+  });
 });
 
-// Use setTimeout to allow all asyncTest promises to resolve before exiting.
-// This matches the pattern used in audio-converter.test.js and whisper-client.test.js.
-setTimeout(() => {
+// Run the fetch-mocking scenarios sequentially, then report.
+(async () => {
+  for (const { name, fn } of suite) {
+    await asyncTest(name, fn);
+  }
   summary();
   exitWithCode();
-}, 100);
+})();


### PR DESCRIPTION
## Cleanup A of the adaptive model-selection pack

Replaces `ModelScout`'s `JOB_AFFINITY_MAP` (a hand-written family-name + size table) with a **sense-don't-guess** local roster: a capability gate over declared capabilities, plus a per-job size prior.

### What changed
- **Layer 0 (Declared):** at boot, after `/api/tags` discovery, `ModelScout` probes `/api/show` once per model and reads the `capabilities` array. Each model now carries `capabilities` and `contextLength`. If `/api/show` is unreachable, the model defaults to text-generation-capable and the gap is logged — capability is never inferred from the name.
- **Capability gate:** models are partitioned by class; embedding and vision models are excluded from text-generation jobs.
- **Layer 1 (Described) per-job size prior:**
  - `quick` / `classification` → smallest capable (latency)
  - `thinking` / `writing` / `research` / `credentials` → largest capable
  - `tools` / `coding` → largest **tool-capable** (flagged in-code as a *weak* prior; a later session replaces it with measured performance). Falls back to the text roster when no model declares `tools`, so the box never goes dark.
- **Deleted** `JOB_AFFINITY_MAP` and its family-match helpers (`grep -rn JOB_AFFINITY_MAP src/` → 0 hits). Net **−16 lines** in the selection module.

### Compatibility
`generateLocalRoster()` still returns `{ job: [modelName, ...] }` ranked best-first (`null` when no model can serve a text job). Consumers unchanged: `ModelResolver._readScoutRoster()` (takes `models[0]`), `LLMRouter.setLocalRoster()`, and `hasModel()`.

### Verification (live, against the configured Ollama endpoint `[OLLAMA_HOST]`, 4 installed models)
Real `/api/show` capability probe drives the roster. Before → after per job:

| job | before (affinity map) | after (capability gate) |
|---|---|---|
| credentials | **embedding model** (won on a buggy size parse) | largest tool+text model |
| quick / classification | mid model / (absent) | genuinely smallest capable |
| tools / coding | single model | tool-capable chain, largest first |

The headline fix: the old size-only path assigned the **embedding model to `credentials`** because its parameter size parsed incorrectly as larger than the real chat models. The capability gate excludes it on its declared class regardless of size.

- `npm run test:unit` → 218/218 test files pass
- `node test/unit/providers/model-scout.test.js` → 13/13 (deterministic; sequential fetch-mock harness removes a race the per-model probe would otherwise widen)
- `npm run lint` → 0 errors
- `git diff --shortstat` → net-negative

Reviewer agent pass: **APPROVE** (one contract-cleanliness fix folded in: `null` instead of `{}` when only non-text models exist).

Full-service restart prod-verify deferred to post-merge.