### PR TITLE
refactor(llm): IntentRouter reads ModelResolver (Cleanup B)

### DIFF
--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -332,19 +332,33 @@ class IntentRouter {
    * @param {Function} [opts.getTrust] - Returns the trust verdict for classification
    *   ('local-only' | 'cloud-ok'), sourced from the ModelResolver (the single
    *   control). Null/undefined return → fall back to the provider census. See #132.
+   * @param {Function} [opts.getFastModel] - Returns the fast/fallback classifier
+   *   model name from ModelResolver (resolve('quick')). Lazy thunk: the resolver
+   *   is built after this router in the bootstrap. Null return → config seam.
+   * @param {Function} [opts.getSmartModel] - Returns the primary classifier model
+   *   name from ModelResolver (resolve('classification')). Same lazy-thunk reason.
    * @param {Object} [opts.config]
    * @param {number} [opts.config.classifyTimeout=10000]
-   * @param {string} [opts.config.fastModel='qwen2.5:3b'] - Fast model for explicit intents
-   * @param {string} [opts.config.smartModel='qwen3:8b'] - Smart model for ambiguous intents
+   * @param {string} [opts.config.fastModel] - Direct-injection seam for tests /
+   *   last resort when no resolver is wired. No model name is hardcoded here.
+   * @param {string} [opts.config.smartModel] - As above, for the primary model.
    */
-  constructor({ provider, config = {}, getLanguage, getTrust, llmRouter } = {}) {
+  constructor({ provider, config = {}, getLanguage, getTrust, getFastModel, getSmartModel, llmRouter } = {}) {
     this.provider = provider;
     this.llmRouter = llmRouter || null;
     this.timeout = config.classifyTimeout || 10000;
-    this.fastModel = config.fastModel || 'qwen2.5:3b';
-    this.smartModel = config.smartModel || 'qwen3:8b';
     this.getLanguage = getLanguage || (() => 'EN');
     this.getTrust = getTrust || (() => null);
+    // Classification model selection lives in ModelResolver, the single source of
+    // truth for "which model serves job X" (design doc §8). These accessors are
+    // lazy thunks because the resolver is constructed after the router in the
+    // bootstrap — the same reason getTrust is a thunk. resolve('classification')
+    // is the primary classifier; resolve('quick') is the fast fallback. The
+    // config.fastModel/smartModel values remain only as a direct-injection seam
+    // for tests and a last resort when no resolver is wired; no model name is
+    // hardcoded in this class.
+    this.getFastModel = getFastModel || (() => config.fastModel || null);
+    this.getSmartModel = getSmartModel || (() => config.smartModel || null);
   }
 
   /**
@@ -362,36 +376,49 @@ class IntentRouter {
   async classify(message, recentContext = [], _context = {}) {
     message = message || '';
 
+    // The model the primary attempt ran on the local provider (null when the
+    // primary went through the cloud router). The fast fallback below reads this
+    // so it never re-runs the identical model on a shorter timeout — a doomed
+    // retry once the resolver maps 'quick' and 'classification' to the same local
+    // model. After a cloud-router failure this stays null, so the local fallback
+    // still fires (the router is not a local model that was already tried).
+    let primaryLocalModel = null;
+
     try {
       // The trust boundary is the single control (#132): the classification path
       // follows the trust verdict, not the registered-provider census. Under
-      // trust:local-only the classifier is the local smart model (qwen3:8b)
+      // trust:local-only the classifier is the local primary (smart) model
       // directly; a credential-less cloud entry in providers.json can no longer
-      // make hasCloudPlayers() true and degrade classification to qwen2.5:3b.
+      // make hasCloudPlayers() true and degrade classification to the fast model.
       //   cloud-ok: Haiku via the router, classifies correctly every time.
-      //   local-only: qwen3:8b first, qwen2.5:3b fallback, regex last resort.
+      //   local-only: primary model first, fast fallback, regex last resort.
       // The resolver is the trust authority; when it is absent (early boot or a
       // direct test caller) fall back to the legacy provider census.
       const trust = this.getTrust();
       const cloudOk = trust
         ? trust !== 'local-only'
         : this.llmRouter?.hasCloudPlayers?.();
-      console.log(`[IntentRouter] Trust=${trust || 'census'} → classification path: ${cloudOk ? 'cloud/router (Haiku)' : 'local smart (qwen3:8b)'}`);
+      console.log(`[IntentRouter] Trust=${trust || 'census'} → classification path: ${cloudOk ? 'cloud/router (Haiku)' : `local smart (${this.getSmartModel() || this.provider?.model || 'unset'})`}`);
 
       if (cloudOk && this.llmRouter) {
         return await this._classifyViaRouter(message, recentContext);
       }
 
-      // Local-only path: fast model → smart model → regex
-      const result = this.provider
-        ? await this._classifyWithModel(this.smartModel, message, recentContext)
-        : await this._classifyViaRouter(message, recentContext);
-      return result;
+      // Local-only path: primary (smart) model → fast fallback → regex
+      if (this.provider) {
+        primaryLocalModel = this.getSmartModel();
+        return await this._classifyWithModel(primaryLocalModel, message, recentContext, { slow: true });
+      }
+      return await this._classifyViaRouter(message, recentContext);
     } catch (err) {
-      // Primary failed — try fast model, then regex
+      // Primary failed. Fall back to the fast model, but only when it is a
+      // genuinely different model from the one the primary already ran — a
+      // same-model retry on a shorter timeout cannot do better and only delays
+      // the regex last resort.
       try {
-        if (this.provider) {
-          return await this._classifyWithModel(this.fastModel, message, recentContext);
+        const fastModel = this.getFastModel();
+        if (this.provider && fastModel && fastModel !== primaryLocalModel) {
+          return await this._classifyWithModel(fastModel, message, recentContext, { slow: false });
         }
       } catch (_fallbackErr) {
         // intentional fall-through
@@ -432,9 +459,12 @@ class IntentRouter {
    * @returns {Promise<{intent: string, domain: string|null, needsHistory: boolean, confidence: number}>}
    * @private
    */
-  async _classifyWithModel(model, message, recentContext = []) {
+  async _classifyWithModel(model, message, recentContext = [], { slow = false } = {}) {
     const userContent = this._buildUserContent(message, recentContext);
-    const timeout = model === this.smartModel ? this.timeout * 4 : this.timeout;
+    // The primary (smart) classifier gets 4x the timeout; the fast fallback runs
+    // on the base timeout. The caller signals which via `slow`, so timeout
+    // scaling no longer depends on comparing against a hardcoded model name.
+    const timeout = slow ? this.timeout * 4 : this.timeout;
 
     const result = await this.provider.chat({
       model,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -275,7 +275,10 @@ const config = {
     domainToolTimeout: envInt('OLLAMA_DOMAIN_TOOL_TIMEOUT', 90000),
     classifyTimeout: envInt('OLLAMA_CLASSIFY_TIMEOUT', 30000),
     classifyModel: envStr('OLLAMA_CLASSIFY_MODEL', 'qwen2.5:3b'),
-    smartModel: envStr('OLLAMA_SMART_MODEL', 'qwen3:8b'),
+    // OLLAMA_SMART_MODEL retired: classification model selection now lives in
+    // ModelResolver (resolve('classification')), the single source of truth, so
+    // this key had become a silent no-op. Pin the classification model via the
+    // Cockpit Models card or the resolver's config instead.
     synthesisProvider: envStr('SYNTHESIS_PROVIDER', 'local')
   },
 

--- a/test/unit/agent/dual-model-classifier.test.js
+++ b/test/unit/agent/dual-model-classifier.test.js
@@ -223,4 +223,77 @@ asyncTest('fast model gets base timeout when used as fallback', async () => {
   assert.strictEqual(timeouts[1].timeout, 5000, 'Fast model uses base timeout');
 });
 
+// -- Test 13: resolver accessors drive model selection (Cleanup B) --
+asyncTest('resolver-provided models drive classification (getSmartModel/getFastModel)', async () => {
+  const calls = [];
+  const provider = {
+    chat: async ({ model }) => {
+      calls.push(model);
+      if (calls.length === 1) throw new Error('primary down'); // force fallback
+      return { content: JSON.stringify({ intent: 'deck_move' }) };
+    }
+  };
+  const router = new IntentRouter({
+    provider,
+    config: { classifyTimeout: 1000 },
+    getSmartModel: () => 'resolved-smart',
+    getFastModel: () => 'resolved-fast'
+  });
+  const result = await router.classify('Move the onboarding task to done');
+  assert.strictEqual(calls[0], 'resolved-smart', 'primary classify uses resolver classification model');
+  assert.strictEqual(calls[1], 'resolved-fast', 'fallback uses resolver quick model');
+  assert.strictEqual(result.domain, 'deck');
+});
+
+// -- Test 14: identical primary/fallback model skips the doomed retry (Cleanup B) --
+// When the resolver maps 'classification' and 'quick' to the same local model,
+// re-running it on a shorter timeout after it just failed cannot help. The
+// fallback is skipped and classification drops straight to the regex last resort.
+asyncTest('identical primary/fallback model skips the doomed retry', async () => {
+  const calls = [];
+  const provider = {
+    chat: async ({ model }) => { calls.push(model); throw new Error('model down'); }
+  };
+  const router = new IntentRouter({
+    provider,
+    getTrust: () => 'local-only',
+    getSmartModel: () => 'gemma2:2b',
+    getFastModel: () => 'gemma2:2b', // same model — a second attempt would be doomed
+    config: { classifyTimeout: 1000 }
+  });
+  const result = await router.classify('send an email to the team about the update');
+  assert.strictEqual(calls.length, 1, 'Only the primary call fires; the identical fallback is skipped');
+  assert.strictEqual(calls[0], 'gemma2:2b');
+  // regex last resort catches "send" (action verb) + "email" (domain)
+  assert.strictEqual(result.gate, 'action');
+  assert.strictEqual(result.domain, 'email');
+});
+
+// -- Test 15: cloud-router failure still falls back to the local model --
+// The primary ran through the router (not a local model), so primaryLocalModel is
+// null and the local fallback must still fire — the same-model skip must NOT eat
+// the cloud→local safety net.
+asyncTest('cloud-router failure falls back to the local model', async () => {
+  const calls = [];
+  const provider = {
+    chat: async ({ model }) => { calls.push(model); return { content: JSON.stringify({ intent: 'deck_move' }) }; }
+  };
+  const llmRouter = {
+    hasCloudPlayers: () => true,
+    route: async () => { throw new Error('cloud down'); }
+  };
+  const router = new IntentRouter({
+    provider,
+    llmRouter,
+    getTrust: () => 'cloud-ok',
+    getSmartModel: () => 'gemma2:2b',
+    getFastModel: () => 'gemma2:2b',
+    config: { classifyTimeout: 1000 }
+  });
+  const result = await router.classify('Move the onboarding task to done');
+  assert.strictEqual(calls.length, 1, 'Local fallback fires after cloud failure (router is not a tried local model)');
+  assert.strictEqual(calls[0], 'gemma2:2b');
+  assert.strictEqual(result.domain, 'deck');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/agent/intent-router.test.js
+++ b/test/unit/agent/intent-router.test.js
@@ -162,7 +162,9 @@ asyncTest('classify() retries on timeout then falls back to regex', async () => 
   let callCount = 0;
   const router = new IntentRouter({
     provider: { chat: async () => { callCount++; throw new Error('Request timed out'); } },
-    config: { classifyTimeout: 100 }
+    // Distinct primary/fallback models exercise the two-call ladder (the fast
+    // fallback only fires when it differs from the model the primary just ran).
+    config: { classifyTimeout: 100, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   const result = await router.classify('what is on my schedule today');
   assert.strictEqual(callCount, 2, 'Should have tried twice (initial + retry)');
@@ -182,7 +184,9 @@ asyncTest('classify() succeeds on retry after first timeout', async () => {
         return { content: '{"intent":"greeting"}' };
       }
     },
-    config: { classifyTimeout: 100 }
+    // Distinct primary/fallback models exercise the two-call ladder (the fast
+    // fallback only fires when it differs from the model the primary just ran).
+    config: { classifyTimeout: 100, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   const result = await router.classify('hey there');
   assert.strictEqual(callCount, 2, 'Should have tried twice');
@@ -195,7 +199,9 @@ asyncTest('classify() tries other model on error, then regex fallback', async ()
   let callCount = 0;
   const router = new IntentRouter({
     provider: { chat: async () => { callCount++; throw new Error('Connection refused'); } },
-    config: { classifyTimeout: 100 }
+    // Distinct primary/fallback models exercise the two-call ladder (the fast
+    // fallback only fires when it differs from the model the primary just ran).
+    config: { classifyTimeout: 100, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   const result = await router.classify('check my email');
   assert.strictEqual(callCount, 2, 'Should try both models before regex fallback');
@@ -215,7 +221,9 @@ asyncTest('classify() fallback model uses appropriate timeout', async () => {
         return { content: '{"intent":"deck"}' };
       }
     },
-    config: { classifyTimeout: 5000 }
+    // Models injected via the direct-injection seam (post Cleanup B: the router
+    // holds no hardcoded model defaults — selection comes from ModelResolver).
+    config: { classifyTimeout: 5000, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   await router.classify('create a card');
   assert.strictEqual(calls.length, 2);
@@ -504,7 +512,9 @@ asyncTest('classify() uses smart model first', async () => {
         return { content: '{"intent":"file_query"}' };
       }
     },
-    config: { classifyTimeout: 5000 }
+    // Models injected via the direct-injection seam (post Cleanup B: the router
+    // holds no hardcoded model defaults — selection comes from ModelResolver).
+    config: { classifyTimeout: 5000, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
 
   await router.classify('read the most recent one and tell me what you learned', [

--- a/test/unit/agent/regex-prerouter.test.js
+++ b/test/unit/agent/regex-prerouter.test.js
@@ -110,7 +110,9 @@ asyncTest('messages with memory verbs use smart model first', async () => {
         return { content: '{"gate":"action","domain":"wiki","confidence":0.9}' };
       }
     },
-    config: { classifyTimeout: 5000 }
+    // Models injected via the direct-injection seam (post Cleanup B: the router
+    // holds no hardcoded model defaults — selection comes from ModelResolver).
+    config: { classifyTimeout: 5000, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   await router.classify('Remember that Sarah prefers video calls');
   assert.strictEqual(models[0], 'qwen3:8b', 'Smart model used first');
@@ -126,7 +128,9 @@ asyncTest('contextual references use smart model first', async () => {
         return { content: '{"gate":"action","domain":"deck","confidence":0.9}' };
       }
     },
-    config: { classifyTimeout: 5000 }
+    // Models injected via the direct-injection seam (post Cleanup B: the router
+    // holds no hardcoded model defaults — selection comes from ModelResolver).
+    config: { classifyTimeout: 5000, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   await router.classify('move the most recent one to done', [
     { role: 'assistant', content: 'Here are your tasks: Fix bug, Update docs' }
@@ -144,7 +148,9 @@ asyncTest('explicit action messages use smart model', async () => {
         return { content: '{"gate":"action","domain":"calendar","confidence":0.95}' };
       }
     },
-    config: { classifyTimeout: 5000 }
+    // Models injected via the direct-injection seam (post Cleanup B: the router
+    // holds no hardcoded model defaults — selection comes from ModelResolver).
+    config: { classifyTimeout: 5000, smartModel: 'qwen3:8b', fastModel: 'qwen2.5:3b' }
   });
   await router.classify('Delete the Team Sync meeting');
   assert.strictEqual(models[0], 'qwen3:8b');

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1596,13 +1596,18 @@ async function initialize() {
         // thunk: modelResolver is constructed later in this bootstrap, so read it
         // at classify time, not now. Returns 'local-only' | 'cloud-ok' | null.
         getTrust: () => modelResolver?.resolveTrust?.('classification') || null,
+        // Classification models come from ModelResolver, the single source of
+        // truth for per-job model selection (design doc §8). Same lazy-thunk
+        // reason as getTrust: the resolver is built further down this bootstrap.
+        // resolve('classification') is the primary classifier; resolve('quick')
+        // the fast fallback. No model name is hardcoded at the call site.
+        getSmartModel: () => modelResolver?.resolveModel?.('classification') || null,
+        getFastModel: () => modelResolver?.resolveModel?.('quick') || null,
         config: {
-          classifyTimeout: appConfig.ollama.classifyTimeout,
-          fastModel: appConfig.ollama.classifyModel || 'qwen2.5:3b',
-          smartModel: appConfig.ollama.smartModel || 'qwen3:8b'
+          classifyTimeout: appConfig.ollama.classifyTimeout
         }
       }) : null;
-      if (intentRouter) console.log(`[INIT] IntentRouter ready (fast: ${appConfig.ollama.classifyModel || 'qwen2.5:3b'}, smart: ${appConfig.ollama.smartModel || 'qwen3:8b'}, timeout: ${appConfig.ollama.classifyTimeout}ms)`);
+      if (intentRouter) console.log(`[INIT] IntentRouter ready (classification models via ModelResolver, timeout: ${appConfig.ollama.classifyTimeout}ms)`);
 
       // claudeProvider: first anthropic provider, kept for ProviderChain fallback path below
       const claudeProvider = claudeConfig.adapter === 'anthropic' && claudeConfig.credentialName
@@ -2027,7 +2032,7 @@ async function initialize() {
         if (modelResolver) {
           modelResolver.modelScout = modelScout;
           modelResolver.refresh();
-          const { summary, divergences } = modelResolver.describe(['tools', 'thinking', 'quick']);
+          const { summary, divergences } = modelResolver.describe(['tools', 'thinking', 'quick', 'classification']);
           console.log(`[INIT] Model resolver: ${summary}`);
           for (const d of divergences) {
             console.warn(`[WARN] ${d}`);


### PR DESCRIPTION
## Cleanup B — IntentRouter reads ModelResolver

Second of the model-selection-pack consolidations. `IntentRouter` held its classification model names as constructor literals (a fast and a smart model) — one of several scattered homes for model config. This moves classification model selection into `ModelResolver`, the single source of truth for "which model serves job X" (design doc §8).

### What changed
- `getFastModel` (→ `resolve('quick')`) and `getSmartModel` (→ `resolve('classification')`) lazy accessor thunks replace the constructor literals, matching the existing `getTrust`/`getLanguage` accessor pattern. Lazy because the resolver is built after the router in bootstrap.
- **No model-name string literals remain in `intent-router.js`** (verified by grep).
- Timeout scaling (4× for the primary classifier) now uses an explicit `{ slow }` flag instead of comparing `model === this.smartModel`.
- Boot `describe()` line now includes `classification`, so the startup log names the resolved classification model + its source.
- Retire the now-inert `OLLAMA_SMART_MODEL` config key (nothing reads it once selection moved to the resolver).

### Behavioral note (not pure parity — called out deliberately)
With Cleanup A's roster, `quick` and `classification` both resolve to the **smallest capable text model**, so the local classifier moves from the large model to the resolver's small pick. This is the intended design (spec §5, "park classification on the small model"), not a regression.

Because primary and fast fallback now resolve to the **same** local model, the fallback skips a doomed same-model retry (a shorter-timeout re-run of a model that just failed) and drops straight to regex. A **cloud-router failure still falls back to the local model** — the router is not a tried local model — so the cloud→local safety net is preserved. New unit tests lock in both behaviours.

### Verification
- `npm run test:unit` → **218/218** files pass (new tests: resolver accessors drive selection; same-model retry skipped; cloud→local fallback preserved).
- `eslint` changed files → **0 errors**.
- `grep -nE "qwen|phi4|3:8b|2.5:3b" intent-router.js` → **empty**.
- **Live, real Ollama, `trust:local-only`:** resolver `classification`/`quick` → smallest capable (source `model-scout`); IntentRouter log names the resolver's pick; EN/DE/PT **6/6** classified correctly (action/calendar + knowledge).

Follow-ups in the pack: Cleanup C (`getToolSubset` from registration metadata, #221), then Session 2's smart-mix rewrite.