### PR TITLE
feat(llm): golden-set cold-start probe — classification model by measured per-language accuracy

### DIFF
--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -456,19 +456,24 @@ class IntentRouter {
    * @param {string} model - Ollama model name
    * @param {string} message - User message
    * @param {Array} recentContext - Recent conversation context
+   * @param {Object} [opts]
+   * @param {boolean} [opts.slow=false]
+   * @param {string} [opts.language] - Force a specific language's examples
+   *   (e.g. for the golden-set probe). Defaults to the cockpit language.
    * @returns {Promise<{intent: string, domain: string|null, needsHistory: boolean, confidence: number}>}
    * @private
    */
-  async _classifyWithModel(model, message, recentContext = [], { slow = false } = {}) {
+  async _classifyWithModel(model, message, recentContext = [], { slow = false, language } = {}) {
     const userContent = this._buildUserContent(message, recentContext);
     // The primary (smart) classifier gets 4x the timeout; the fast fallback runs
     // on the base timeout. The caller signals which via `slow`, so timeout
     // scaling no longer depends on comparing against a hardcoded model name.
     const timeout = slow ? this.timeout * 4 : this.timeout;
+    const lang = language || this.getLanguage();
 
     const result = await this.provider.chat({
       model,
-      system: buildClassificationPrompt(this.getLanguage()),
+      system: buildClassificationPrompt(lang),
       messages: [{ role: 'user', content: userContent }],
       timeout,
       format: INTENT_SCHEMA,
@@ -479,6 +484,23 @@ class IntentRouter {
     });
 
     return this._parseClassification(result.content || '', message);
+  }
+
+  /**
+   * Classify one message with a specific model + language, for the
+   * golden-set probe (measured per-language accuracy, not size, picks the
+   * classification model). Runs the SAME classification path production
+   * uses so the probe scores exactly what production consumes.
+   * @param {string} model - Ollama model name
+   * @param {string} message - Message to classify
+   * @param {string} language - Language code the fixture example is written
+   *   in (e.g. 'EN', 'DE', 'PT') — forces the matching example set rather
+   *   than reading the cockpit's current persona language.
+   * @returns {Promise<{gate: string, domain: string|null}>}
+   */
+  async probeClassify(model, message, language) {
+    const r = await this._classifyWithModel(model, message, [], { slow: true, language });
+    return { gate: r.gate, domain: r.domain ?? null };
   }
 
   /**

--- a/src/lib/llm/golden-set-probe.js
+++ b/src/lib/llm/golden-set-probe.js
@@ -1,0 +1,296 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * GoldenSetProbe — Measure classification accuracy per language instead of
+ * proxying correctness by model size.
+ *
+ * Problem:
+ *   ModelScout's classification roster picks the smallest text-generation
+ *   model on the box (latency wins, classification "needs no depth" — a size
+ *   prior). But classification is the one job with ground truth: a message
+ *   either gets the right gate/domain or it does not. A size prior is a
+ *   proxy; measured accuracy is the real signal, and it is cheap to measure
+ *   once at boot against a small labeled fixture.
+ *
+ * Pattern:
+ *   For each roster candidate (smallest first), replay the fixture's labeled
+ *   messages through the SAME classification path production uses
+ *   (`classifyFn`, injected — the probe never builds its own prompt) and
+ *   score per language. The smallest candidate that clears the accuracy bar
+ *   in every language wins; if none does, the least-bad candidate is chosen
+ *   and the gap is logged loudly rather than silently degrading. Results are
+ *   cached on disk keyed by model digest + fixture version, so a restart
+ *   does not re-run the (expensive) LLM calls unless the model or the
+ *   fixture changed.
+ *
+ * Data Flow:
+ *   webhook-server (boot, after ModelScout.discover + ModelResolver.refresh)
+ *     → new GoldenSetProbe({ classifyFn: intentRouter.probeClassify, ... })
+ *     → probe.run(modelScout.getClassificationCandidates())
+ *       → modelResolver.setGroundTruthOverride('classification', winner)
+ *
+ * Dependency Map:
+ *   src/lib/llm/golden-set-probe.js
+ *     ← (no internal imports — standalone, testable in isolation; callers
+ *        inject classifyFn and the parsed fixture)
+ *
+ * @module llm/golden-set-probe
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const DEFAULT_THRESHOLD = 0.75;
+const CACHE_FILENAME = 'golden-set-probe.json';
+
+class GoldenSetProbe {
+  /**
+   * @param {Object} opts
+   * @param {Function} [opts.classifyFn] - async (model, message, langCode) =>
+   *   ({ gate, domain }). Production injects the real classification path
+   *   (IntentRouter.probeClassify); tests inject a fake. The probe never
+   *   builds its own prompt — it scores exactly what production consumes.
+   * @param {Object} [opts.fixture] - Parsed golden-set fixture:
+   *   { version, threshold, languages: { EN:[...], DE:[...], PT:[...] } }.
+   * @param {string} [opts.cacheDir] - Directory for the results cache.
+   *   Defaults to `data/` under the process cwd.
+   * @param {Object} [opts.logger=console]
+   */
+  constructor({ classifyFn, fixture, cacheDir, logger } = {}) {
+    this.classifyFn = typeof classifyFn === 'function' ? classifyFn : null;
+    this.fixture = fixture || null;
+    this.cacheDir = cacheDir || path.resolve(process.cwd(), 'data');
+    this._cacheFile = path.join(this.cacheDir, CACHE_FILENAME);
+    this.logger = logger || console;
+
+    // In-memory scores for the candidates most recently run(), keyed the
+    // same way as the on-disk cache. select() reads only this — it makes
+    // no classifyFn calls, so it is safe to call repeatedly/synchronously
+    // after run() without re-probing.
+    this._scores = {};
+  }
+
+  /**
+   * Read and parse a golden-set fixture file. A static helper so callers
+   * (webhook-server) can load the default fixture without instantiating a
+   * probe first. Throws on a missing/corrupt file — the caller decides how
+   * to handle probe setup failure (boot must not be delayed by this).
+   * @param {string} filePath
+   * @returns {Object} parsed fixture
+   */
+  static loadFixture(filePath) {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  }
+
+  /**
+   * Run the probe over `candidates` (smallest-first) and select a winner.
+   * For each candidate, reuses cached per-language scores when the on-disk
+   * cache already has an entry for its digest+fixture-version; otherwise
+   * replays every fixture example through classifyFn and persists the
+   * result. Only the classifyFn calls are cache-gated — selection itself
+   * always re-runs against the (possibly cached) scores.
+   * @param {Array<{name: string, paramSize?: number, digest?: string}>} candidates
+   * @returns {Promise<{model: string|null, scores: Object|null, passed: boolean, reason: string}>}
+   */
+  async run(candidates) {
+    const list = Array.isArray(candidates) ? candidates.filter(c => c && typeof c.name === 'string') : [];
+    if (list.length === 0) {
+      return this.select(list);
+    }
+    if (!this.classifyFn || !this.fixture || !this.fixture.languages) {
+      this.logger.warn('[GoldenSetProbe] Missing classifyFn or fixture; skipping probe.');
+      return this.select(list);
+    }
+
+    const diskCache = this._loadCache();
+    let cacheChanged = false;
+
+    for (const candidate of list) {
+      const key = this._cacheKey(candidate);
+      const cached = diskCache[key];
+      if (cached && cached.scores) {
+        this._scores[key] = cached.scores;
+        continue;
+      }
+
+      const scores = {};
+      let complete = true;
+      for (const [lang, items] of Object.entries(this.fixture.languages)) {
+        const examples = Array.isArray(items) ? items : [];
+        let correct = 0;
+        let errored = 0;
+        for (const item of examples) {
+          try {
+            // Sequential by design: one Ollama model can't usefully serve
+            // concurrent classify calls at boot.
+            const predicted = await this.classifyFn(candidate.name, item.message, lang);
+            if (predicted && predicted.gate === item.gate &&
+                (item.domain === null || predicted.domain === item.domain)) {
+              correct++;
+            }
+          } catch (err) {
+            errored++;
+            this.logger.warn(`[GoldenSetProbe] classifyFn failed for ${candidate.name}/${lang}#${item.id}: ${err.message}`);
+          }
+        }
+        // Any classify error means this language was not fully measured — a
+        // distorted (deflated) accuracy, typically because Ollama is cold or
+        // down at boot (MEMORY #124: qwen3:8b cold-start can exceed 60s). A
+        // deflated score must NOT be cached as authoritative, or the digest+
+        // version key would hit forever and the probe would serve poisoned
+        // zeros until someone deletes the cache file by hand.
+        if (errored > 0) complete = false;
+        scores[lang] = examples.length > 0 ? correct / examples.length : 0;
+      }
+
+      if (complete) {
+        diskCache[key] = { scores, at: new Date().toISOString() };
+        this._scores[key] = scores;
+        cacheChanged = true;
+      } else {
+        // Incomplete measurement: neither persist nor trust it. Leaving it out
+        // of _scores means select() treats this model as unmeasured (not a
+        // passer, not a poisoned failer), and the next boot retries it.
+        this.logger.warn(`[GoldenSetProbe] ${candidate.name}: measurement incomplete (Ollama cold/unavailable?); not caching, will retry next boot.`);
+      }
+    }
+
+    if (cacheChanged) this._saveCache(diskCache);
+
+    const result = this.select(list);
+    if (!result.passed && result.model) {
+      const threshold = this._threshold();
+      const weak = Object.entries(result.scores || {})
+        .filter(([, v]) => (Number.isFinite(v) ? v : 0) < threshold)
+        .map(([lang]) => lang);
+      this.logger.warn(
+        `[GoldenSetProbe] No local model clears the classification bar in all languages ` +
+        `(${result.reason}). Selecting ${result.model} as least-bad — the deployer's ` +
+        `models classify ${weak.join('/') || 'one or more languages'} poorly.`
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Select a winner from already-collected/cached per-language scores
+   * (never calls classifyFn — pure w.r.t. this probe's in-memory state).
+   * Among candidates that pass every language's threshold, the first
+   * (smallest, since candidates are smallest-first) wins. If none pass,
+   * the candidate with the highest minimum-language score is chosen and
+   * marked `passed: false`.
+   * @param {Array<{name: string, digest?: string}>} candidates
+   * @returns {{model: string|null, scores: Object|null, passed: boolean, reason: string}}
+   */
+  select(candidates) {
+    const list = Array.isArray(candidates) ? candidates.filter(c => c && typeof c.name === 'string') : [];
+    if (list.length === 0) {
+      return { model: null, scores: null, passed: false, reason: 'no candidates' };
+    }
+
+    const languages = Object.keys((this.fixture && this.fixture.languages) || {});
+    const threshold = this._threshold();
+
+    const evaluated = list.map(candidate => {
+      const key = this._cacheKey(candidate);
+      const scores = this._scores[key] || {};
+      const langScores = languages.map(lang => (Number.isFinite(scores[lang]) ? scores[lang] : 0));
+      const passesAll = languages.length > 0 && langScores.every(s => s >= threshold);
+      const minScore = langScores.length > 0 ? Math.min(...langScores) : 0;
+      return { candidate, scores, passesAll, minScore };
+    });
+
+    // No candidate produced a usable measurement this cycle (e.g. Ollama was
+    // cold at boot and every classify errored). Return no pick so the caller
+    // leaves ModelScout's size-prior selection standing and retries next boot,
+    // rather than overriding with — or firing a false alarm about — nothing.
+    if (!evaluated.some(e => Object.keys(e.scores).length > 0)) {
+      return { model: null, scores: null, passed: false, reason: 'no measurements' };
+    }
+
+    const passer = evaluated.find(e => e.passesAll);
+    if (passer) {
+      return { model: passer.candidate.name, scores: passer.scores, passed: true, reason: 'smallest passer' };
+    }
+
+    // No passer: pick the highest minimum-language score (least-bad).
+    let best = evaluated[0];
+    for (const e of evaluated) {
+      if (e.minScore > best.minScore) best = e;
+    }
+    const reason = `best min-lang score ${best.minScore.toFixed(2)} from ${best.candidate.name}`;
+    return { model: best.candidate.name, scores: best.scores, passed: false, reason };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _threshold() {
+    return Number.isFinite(this.fixture?.threshold) ? this.fixture.threshold : DEFAULT_THRESHOLD;
+  }
+
+  /**
+   * @private
+   * Fixture salt for the cache key: the declared version PLUS a short content
+   * hash of the labeled examples and threshold. Deriving from content (not the
+   * hand-bumped integer alone) means editing a message or a DE/PT label
+   * invalidates stale scores even when the author forgets to bump `version`.
+   */
+  _fixtureSalt() {
+    if (this._salt) return this._salt;
+    const version = Number.isFinite(this.fixture?.version) ? this.fixture.version : 0;
+    const content = JSON.stringify({
+      languages: (this.fixture && this.fixture.languages) || null,
+      threshold: this._threshold(),
+    });
+    const hash = crypto.createHash('sha1').update(content).digest('hex').slice(0, 8);
+    this._salt = `v${version}_${hash}`;
+    return this._salt;
+  }
+
+  /**
+   * @private
+   * Cache key: digest when present (from /api/tags), else name; salted with the
+   * fixture version + content hash so any fixture change invalidates stale scores.
+   */
+  _cacheKey(candidate) {
+    const id = (candidate && (candidate.digest || candidate.name)) || 'unknown';
+    return `${id}__${this._fixtureSalt()}`;
+  }
+
+  /** @private */
+  _loadCache() {
+    try {
+      const raw = fs.readFileSync(this._cacheFile, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch (_err) {
+      // Missing file or corrupt JSON — start fresh.
+    }
+    return {};
+  }
+
+  /** @private */
+  _saveCache(cache) {
+    try {
+      if (!fs.existsSync(this.cacheDir)) {
+        fs.mkdirSync(this.cacheDir, { recursive: true });
+      }
+      const tmp = this._cacheFile + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(cache, null, 2), 'utf8');
+      fs.renameSync(tmp, this._cacheFile);
+    } catch (err) {
+      this.logger.warn(`[GoldenSetProbe] Failed to persist probe cache: ${err.message}`);
+    }
+  }
+}
+
+module.exports = GoldenSetProbe;

--- a/src/lib/llm/model-resolver.js
+++ b/src/lib/llm/model-resolver.js
@@ -101,7 +101,30 @@ class ModelResolver {
     // card changes (heartbeat). resolve() reads the cache between refreshes, so
     // no LLM call ever pays for re-reading config files or re-running ModelScout.
     this._cache = new Map();
+
+    // Ground-truth overrides (job → model name), set by the golden-set probe
+    // once it has MEASURED per-language classification accuracy rather than
+    // proxying correctness by model size. Deliberately NOT cleared by
+    // refresh() — refresh() re-snapshots ModelScout/Cockpit, which have no
+    // opinion on measured accuracy; the probe's finding survives until the
+    // probe itself revises or clears it.
+    this._groundTruthOverrides = {};
+
     this.refresh();
+  }
+
+  /**
+   * Set (or clear) the ground-truth override for a job, sourced from a
+   * measured probe (e.g. GoldenSetProbe) rather than size or config.
+   * Invalidates the job's cache entry so the next resolve() picks it up.
+   * @param {string} job
+   * @param {string|null} model - Pass null/falsy to clear the override.
+   */
+  setGroundTruthOverride(job, model) {
+    if (!job) return;
+    if (model) this._groundTruthOverrides[job] = model;
+    else delete this._groundTruthOverrides[job];
+    this._cache.delete(job);
   }
 
   /**
@@ -201,12 +224,17 @@ class ModelResolver {
   _resolveUncached(job) {
     const scout = this._scoutRoster ? (this._scoutRoster[job] || null) : null;
     const cockpit = this._cockpitModel || null; // explicit local model from the card, if any
+    // Measured per-language classification accuracy (GoldenSetProbe), when the
+    // probe has run for this job. Ground truth beats a size prior, but the
+    // human's deliberate Cockpit override still wins over a measurement.
+    const probePick = this._groundTruthOverrides[job] || null;
 
     const derivation = {
       deployerConfig: this.deployerModel,
       envOverride: this.envModel,
       modelScout: scout,
       cockpitCard: cockpit,
+      probePick,
       resolved: null,
     };
 
@@ -216,10 +244,14 @@ class ModelResolver {
       ? LOCAL_ONLY
       : (this._cockpitTrust || DEFAULT_TRUST);
 
-    // Model precedence (later wins): cockpit > model-scout > env > deployer > fallback.
+    // Model precedence (later wins): cockpit > golden-set-probe > model-scout
+    // > env > deployer > fallback. The probe sits above model-scout because it
+    // measured accuracy for the exact roster scout produced; it sits below
+    // cockpit because an explicit human override is always deliberate intent.
     let model = null;
     let source = 'fallback';
     if (cockpit) { model = cockpit; source = 'cockpit-card'; }
+    else if (probePick) { model = probePick; source = 'golden-set-probe'; }
     else if (scout) { model = scout; source = 'model-scout'; }
     else if (this.envModel) { model = this.envModel; source = 'env-override'; }
     else if (this.deployerModel) { model = this.deployerModel; source = 'deployer-config'; }

--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -52,7 +52,8 @@ class ModelScout {
         family: this._extractFamily(m),
         paramSize: this._extractParamSize(m),
         sizeBytes: m.size || 0,
-        modifiedAt: m.modified_at || null
+        modifiedAt: m.modified_at || null,
+        digest: m.digest || null
       }));
 
       // Layer 0 (Declared): ask each model what it can do rather than inferring
@@ -136,6 +137,20 @@ class ModelScout {
 
     this._roster = roster;
     return roster;
+  }
+
+  /**
+   * Capability-eligible text-generation models, sorted smallest-first, for
+   * the golden-set probe (which measures classification accuracy per
+   * language rather than assuming smallest-is-best from a size prior).
+   * @returns {Array<{name: string, paramSize: number|null, digest: string|null}>}
+   */
+  getClassificationCandidates() {
+    if (!this._discovered || this._discovered.length === 0) return [];
+    return this._discovered
+      .filter(m => this._isTextGen(m))
+      .sort((a, b) => this._compareSize(a, b))
+      .map(m => ({ name: m.name, paramSize: m.paramSize, digest: m.digest || null }));
   }
 
   /**

--- a/test/fixtures/golden-set/classification-golden-set.json
+++ b/test/fixtures/golden-set/classification-golden-set.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Golden-set classification fixture (#golden-set-probe). Ground truth for the install-time probe that selects the classification model by measured per-language accuracy, not by size. The 12 messages are PARALLEL across EN/DE/PT (same intents, translated) so a per-language accuracy gap reflects a model's language handling, not different difficulty. Scoring: a prediction is correct when predicted.gate === expected.gate AND (expected.domain === null OR predicted.domain === expected.domain). Gates: knowledge|action|compound|thinking|greeting. Domains: deck|calendar|email|wiki|file|null. Calendar/deck READS classify as action (#134). HUMAN DEPENDENCY: the DE and PT labels are the operational definition of correctness per language — a mislabeled example silently selects the wrong model for that language. These need a native-speaker read (Fu) before merge.",
+  "version": 1,
+  "threshold": 0.75,
+  "languages": {
+    "EN": [
+      { "id": 1,  "message": "What is a sovereign AI agent?",                                  "gate": "knowledge", "domain": null },
+      { "id": 2,  "message": "How does the trust boundary work?",                              "gate": "knowledge", "domain": null },
+      { "id": 3,  "message": "Who leads the marketing project?",                               "gate": "knowledge", "domain": null },
+      { "id": 4,  "message": "Summarize the notes from yesterday's meeting.",                  "gate": "knowledge", "domain": null },
+      { "id": 5,  "message": "Create a card for the website redesign.",                        "gate": "action",    "domain": "deck" },
+      { "id": 6,  "message": "Send an email to Alex about the budget.",                        "gate": "action",    "domain": "email" },
+      { "id": 7,  "message": "Schedule a meeting with the design team on Friday.",            "gate": "action",    "domain": "calendar" },
+      { "id": 8,  "message": "Write a wiki page about the onboarding process.",               "gate": "action",    "domain": "wiki" },
+      { "id": 9,  "message": "List the files in the Projects folder.",                         "gate": "action",    "domain": "file" },
+      { "id": 10, "message": "Should we focus on the mobile app or the web platform this quarter?", "gate": "thinking", "domain": null },
+      { "id": 11, "message": "Create a task for the report and email Alex about it.",          "gate": "compound",  "domain": null },
+      { "id": 12, "message": "Good morning!",                                                  "gate": "greeting",  "domain": null }
+    ],
+    "DE": [
+      { "id": 1,  "message": "Was ist ein souveräner KI-Agent?",                               "gate": "knowledge", "domain": null },
+      { "id": 2,  "message": "Wie funktioniert die Vertrauensgrenze?",                         "gate": "knowledge", "domain": null },
+      { "id": 3,  "message": "Wer leitet das Marketing-Projekt?",                              "gate": "knowledge", "domain": null },
+      { "id": 4,  "message": "Fasse die Notizen vom gestrigen Meeting zusammen.",             "gate": "knowledge", "domain": null },
+      { "id": 5,  "message": "Erstelle eine Karte für das Website-Redesign.",                 "gate": "action",    "domain": "deck" },
+      { "id": 6,  "message": "Schick eine E-Mail an Alex wegen des Budgets.",                 "gate": "action",    "domain": "email" },
+      { "id": 7,  "message": "Plane am Freitag ein Meeting mit dem Design-Team.",             "gate": "action",    "domain": "calendar" },
+      { "id": 8,  "message": "Schreib eine Wiki-Seite über den Onboarding-Prozess.",          "gate": "action",    "domain": "wiki" },
+      { "id": 9,  "message": "Liste die Dateien im Projekte-Ordner auf.",                      "gate": "action",    "domain": "file" },
+      { "id": 10, "message": "Sollten wir uns dieses Quartal auf die mobile App oder die Web-Plattform konzentrieren?", "gate": "thinking", "domain": null },
+      { "id": 11, "message": "Erstelle eine Aufgabe für den Bericht und schick Alex eine E-Mail dazu.", "gate": "compound", "domain": null },
+      { "id": 12, "message": "Guten Morgen!",                                                  "gate": "greeting",  "domain": null }
+    ],
+    "PT": [
+      { "id": 1,  "message": "O que é um agente de IA soberano?",                              "gate": "knowledge", "domain": null },
+      { "id": 2,  "message": "Como funciona a fronteira de confiança?",                        "gate": "knowledge", "domain": null },
+      { "id": 3,  "message": "Quem lidera o projeto de marketing?",                            "gate": "knowledge", "domain": null },
+      { "id": 4,  "message": "Resume as notas da reunião de ontem.",                           "gate": "knowledge", "domain": null },
+      { "id": 5,  "message": "Cria um cartão para o redesign do site.",                        "gate": "action",    "domain": "deck" },
+      { "id": 6,  "message": "Envia um e-mail ao Alex sobre o orçamento.",                     "gate": "action",    "domain": "email" },
+      { "id": 7,  "message": "Agenda uma reunião com a equipa de design na sexta-feira.",     "gate": "action",    "domain": "calendar" },
+      { "id": 8,  "message": "Escreve uma página wiki sobre o processo de integração.",        "gate": "action",    "domain": "wiki" },
+      { "id": 9,  "message": "Lista os ficheiros na pasta Projetos.",                          "gate": "action",    "domain": "file" },
+      { "id": 10, "message": "Devemos focar-nos na app móvel ou na plataforma web este trimestre?", "gate": "thinking", "domain": null },
+      { "id": 11, "message": "Cria uma tarefa para o relatório e envia um e-mail ao Alex sobre isso.", "gate": "compound", "domain": null },
+      { "id": 12, "message": "Bom dia!",                                                       "gate": "greeting",  "domain": null }
+    ]
+  }
+}

--- a/test/unit/llm/golden-set-probe.test.js
+++ b/test/unit/llm/golden-set-probe.test.js
@@ -1,0 +1,388 @@
+/**
+ * GoldenSetProbe Unit Tests
+ *
+ * Measures classification accuracy per language against a labeled fixture
+ * and selects the smallest local model that clears the bar in every
+ * language — ground truth beats a size prior. Also covers the ModelResolver
+ * probe tier the probe's winner feeds into.
+ *
+ * Run: node test/unit/llm/golden-set-probe.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const GoldenSetProbe = require('../../../src/lib/llm/golden-set-probe');
+const { ModelResolver } = require('../../../src/lib/llm/model-resolver');
+
+// ============================================================
+// Fixtures / helpers
+// ============================================================
+
+// Small parallel EN/DE/PT fixture, 4 items per language, mirroring the real
+// fixture's shape (gate/domain ground truth). Message text is unique per
+// item so a fake classifyFn can look up the correct answer without needing
+// the fixture item's id.
+function makeFixture() {
+  return {
+    version: 1,
+    threshold: 0.75,
+    languages: {
+      EN: [
+        { id: 1, message: 'en-msg-1', gate: 'knowledge', domain: null },
+        { id: 2, message: 'en-msg-2', gate: 'action', domain: 'deck' },
+        { id: 3, message: 'en-msg-3', gate: 'action', domain: 'email' },
+        { id: 4, message: 'en-msg-4', gate: 'thinking', domain: null }
+      ],
+      DE: [
+        { id: 1, message: 'de-msg-1', gate: 'knowledge', domain: null },
+        { id: 2, message: 'de-msg-2', gate: 'action', domain: 'deck' },
+        { id: 3, message: 'de-msg-3', gate: 'action', domain: 'email' },
+        { id: 4, message: 'de-msg-4', gate: 'thinking', domain: null }
+      ],
+      PT: [
+        { id: 1, message: 'pt-msg-1', gate: 'knowledge', domain: null },
+        { id: 2, message: 'pt-msg-2', gate: 'action', domain: 'deck' },
+        { id: 3, message: 'pt-msg-3', gate: 'action', domain: 'email' },
+        { id: 4, message: 'pt-msg-4', gate: 'thinking', domain: null }
+      ]
+    }
+  };
+}
+
+// message -> ground-truth { gate, domain }, flattened across languages.
+function truthMap(fixture) {
+  const map = {};
+  for (const items of Object.values(fixture.languages)) {
+    for (const item of items) {
+      map[item.message] = { gate: item.gate, domain: item.domain };
+    }
+  }
+  return map;
+}
+
+function perfectClassifyFn(fixture) {
+  const truth = truthMap(fixture);
+  return async (_model, message) => truth[message] || { gate: 'knowledge', domain: null };
+}
+
+const silentLogger = { warn: () => {}, log: () => {}, info: () => {} };
+
+function capturingLogger() {
+  const warnings = [];
+  return { warnings, warn: (msg) => warnings.push(msg), log: () => {}, info: () => {} };
+}
+
+function uniqueTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'golden-set-probe-test-'));
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+console.log('\n=== GoldenSetProbe Tests ===\n');
+
+asyncTest('TC-PROBE-001: perfect model passes every language and is selected', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: perfectClassifyFn(fixture),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const result = await probe.run([{ name: 'perfect-model', paramSize: 3, digest: 'd1' }]);
+    assert.strictEqual(result.model, 'perfect-model');
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.reason, 'smallest passer');
+    assert.strictEqual(result.scores.EN, 1);
+    assert.strictEqual(result.scores.DE, 1);
+    assert.strictEqual(result.scores.PT, 1);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-002: smallest-first candidates both pass -> smallest wins', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: perfectClassifyFn(fixture),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const candidates = [
+      { name: 'small', paramSize: 2, digest: 'd-small' },
+      { name: 'big', paramSize: 8, digest: 'd-big' }
+    ];
+    await probe.run(candidates);
+    const result = probe.select(candidates);
+    assert.strictEqual(result.model, 'small');
+    assert.strictEqual(result.passed, true);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-003: no candidate clears DE -> least-bad picked, loud warning logged', async () => {
+  const fixture = makeFixture();
+  const truth = truthMap(fixture);
+  const cacheDir = uniqueTmpDir();
+  try {
+    // modelA: DE always wrong (0/4). modelB: DE half wrong (2/4 = 0.5). Both
+    // fail the 0.75 DE threshold, but modelB has the higher minimum-language
+    // score (0.5 vs 0) and must be the least-bad pick.
+    const classifyFn = async (model, message, lang) => {
+      if (lang === 'DE') {
+        const id = parseInt(message.split('-').pop(), 10);
+        if (model === 'modelA') return { gate: 'greeting', domain: null };
+        if (model === 'modelB' && id > 2) return { gate: 'greeting', domain: null };
+      }
+      return truth[message];
+    };
+
+    const logger = capturingLogger();
+    const probe = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger });
+    const candidates = [
+      { name: 'modelA', paramSize: 2, digest: 'd-a' },
+      { name: 'modelB', paramSize: 4, digest: 'd-b' }
+    ];
+    const result = await probe.run(candidates);
+
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.model, 'modelB');
+    assert.ok(result.scores.DE < 0.75, 'DE score must be below threshold');
+    assert.ok(logger.warnings.length > 0, 'a loud warning must be logged when nothing passes');
+    assert.ok(
+      logger.warnings.some(w => w.includes('GoldenSetProbe') && w.includes('modelB')),
+      'warning should name the selected least-bad model'
+    );
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-004: second run with same candidates+digests reuses the cache (no re-probe)', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    let callCount = 0;
+    const classifyFn = async (...args) => {
+      callCount++;
+      return perfectClassifyFn(fixture)(...args);
+    };
+    const candidates = [{ name: 'cache-model', paramSize: 3, digest: 'digest-cache-1' }];
+
+    const probe1 = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger: silentLogger });
+    await probe1.run(candidates);
+    const firstCallCount = callCount;
+    assert.ok(firstCallCount > 0, 'first run must call classifyFn');
+
+    // Simulate a restart: a brand-new probe instance pointed at the same
+    // on-disk cache directory must not re-probe an already-scored digest.
+    const probe2 = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger: silentLogger });
+    const result2 = await probe2.run(candidates);
+
+    assert.strictEqual(callCount, firstCallCount, 'classifyFn must not be called again on cache hit');
+    assert.strictEqual(result2.model, 'cache-model');
+    assert.strictEqual(result2.passed, true);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-005: empty candidates returns null model without throwing', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: perfectClassifyFn(fixture),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const result = await probe.run([]);
+    assert.strictEqual(result.model, null);
+    assert.strictEqual(result.passed, false);
+
+    // Also guard select() and run() directly against null/undefined input.
+    assert.strictEqual(probe.select(null).model, null);
+    const resultUndefined = await probe.run(undefined);
+    assert.strictEqual(resultUndefined.model, null);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('TC-PROBE-006: loadFixture parses the real golden-set fixture', () => {
+  const fixturePath = path.join(__dirname, '../../fixtures/golden-set/classification-golden-set.json');
+  const fixture = GoldenSetProbe.loadFixture(fixturePath);
+  assert.strictEqual(fixture.version, 1);
+  assert.strictEqual(fixture.threshold, 0.75);
+  assert.ok(Array.isArray(fixture.languages.EN));
+  assert.ok(Array.isArray(fixture.languages.DE));
+  assert.ok(Array.isArray(fixture.languages.PT));
+});
+
+asyncTest('TC-PROBE-007: a transient all-error measurement is NOT cached and yields no pick (cold-Ollama poisoning guard)', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    // Simulate Ollama cold/down at boot: every classify throws.
+    let throwing = true;
+    let callCount = 0;
+    const classifyFn = async (...args) => {
+      callCount++;
+      if (throwing) throw new Error('ECONNREFUSED');
+      return perfectClassifyFn(fixture)(...args);
+    };
+    const candidates = [{ name: 'cold-model', paramSize: 3, digest: 'd-cold' }];
+    const logger = capturingLogger();
+    const probe = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger });
+
+    const r1 = await probe.run(candidates);
+    // No usable measurement → no pick to apply (scout's size prior stands), and
+    // no false "classifies poorly" alarm.
+    assert.strictEqual(r1.model, null, 'a fully-failed probe must not select a model');
+    assert.strictEqual(r1.reason, 'no measurements');
+    // Nothing poisoned to disk: the cache file must not hold the zero-scores.
+    const cacheFile = path.join(cacheDir, 'golden-set-probe.json');
+    assert.ok(!fs.existsSync(cacheFile), 'a failed measurement must not be persisted');
+
+    // Ollama warms up; the next boot must RE-PROBE (not serve poisoned zeros).
+    throwing = false;
+    const callsBeforeRetry = callCount;
+    const probe2 = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger });
+    const r2 = await probe2.run(candidates);
+    assert.ok(callCount > callsBeforeRetry, 'a previously-failed model must be re-probed, not cached');
+    assert.strictEqual(r2.model, 'cold-model');
+    assert.strictEqual(r2.passed, true);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-008: editing a label without bumping version invalidates the cache (content-hash salt)', async () => {
+  const cacheDir = uniqueTmpDir();
+  try {
+    const fixtureA = makeFixture();
+    let callCount = 0;
+    const classifyFn = async (...args) => { callCount++; return perfectClassifyFn(fixtureA)(...args); };
+    const candidates = [{ name: 'm', paramSize: 3, digest: 'd-fixed' }];
+
+    const probeA = new GoldenSetProbe({ classifyFn, fixture: fixtureA, cacheDir, logger: silentLogger });
+    await probeA.run(candidates);
+    const afterA = callCount;
+
+    // Same version (1), but a label changed. The content-hash salt must differ,
+    // so the prior entry does NOT hit and the model is re-probed.
+    const fixtureB = makeFixture();
+    fixtureB.languages.DE[1].gate = 'knowledge'; // was 'action'
+    const classifyFnB = async (...args) => { callCount++; return perfectClassifyFn(fixtureB)(...args); };
+    const probeB = new GoldenSetProbe({ classifyFn: classifyFnB, fixture: fixtureB, cacheDir, logger: silentLogger });
+    await probeB.run(candidates);
+
+    assert.ok(callCount > afterA, 'a fixture content change must invalidate the cache even without a version bump');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-PROBE-009: a candidate with digest null keys the cache by name (still caches)', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    let callCount = 0;
+    const classifyFn = async (...args) => { callCount++; return perfectClassifyFn(fixture)(...args); };
+    const candidates = [{ name: 'no-digest-model', paramSize: 3, digest: null }];
+
+    const probe1 = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger: silentLogger });
+    const r1 = await probe1.run(candidates);
+    assert.strictEqual(r1.model, 'no-digest-model');
+    const afterFirst = callCount;
+
+    // Restart: keyed by name (digest null) → cache still hits, no re-probe.
+    const probe2 = new GoldenSetProbe({ classifyFn, fixture, cacheDir, logger: silentLogger });
+    await probe2.run(candidates);
+    assert.strictEqual(callCount, afterFirst, 'digest-null candidate must still be cache-keyed by name');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+// ============================================================
+// ModelResolver probe tier
+// ============================================================
+
+console.log('\n--- ModelResolver golden-set-probe tier ---\n');
+
+function createMockScout(roster, installed) {
+  const installedSet = new Set(installed || Object.values(roster || {}).flat());
+  return {
+    generateLocalRoster: () => roster,
+    hasModel: (name) => installedSet.has(name)
+  };
+}
+
+function createMockCockpit(modelsConfig) {
+  return { cachedConfig: { system: { modelsConfig } } };
+}
+
+test('TC-PROBE-010: setGroundTruthOverride wins over model-scout, below cockpit', () => {
+  const resolver = new ModelResolver({
+    modelScout: createMockScout({ classification: ['small'] }, ['small', 'operator-choice']),
+    logger: silentLogger
+  });
+
+  // Before the probe runs, ModelScout's size-prior pick serves the job.
+  assert.strictEqual(resolver.resolve('classification').model, 'small');
+  assert.strictEqual(resolver.resolve('classification').source, 'model-scout');
+
+  resolver.setGroundTruthOverride('classification', 'measured');
+  const r = resolver.resolve('classification');
+  assert.strictEqual(r.model, 'measured');
+  assert.strictEqual(r.source, 'golden-set-probe');
+
+  // An explicit Cockpit card override is deliberate human intent and still
+  // wins over a measurement.
+  resolver.cockpitManager = createMockCockpit({ trust: 'local-only', localDefault: 'operator-choice' });
+  resolver.refresh(); // refresh must NOT clear the ground-truth override map
+  const r2 = resolver.resolve('classification');
+  assert.strictEqual(r2.model, 'operator-choice');
+  assert.strictEqual(r2.source, 'cockpit-card');
+});
+
+test('TC-PROBE-011: clearing the override (null model) falls back to model-scout', () => {
+  const resolver = new ModelResolver({
+    modelScout: createMockScout({ classification: ['small'] }),
+    logger: silentLogger
+  });
+  resolver.setGroundTruthOverride('classification', 'measured');
+  assert.strictEqual(resolver.resolve('classification').model, 'measured');
+
+  resolver.setGroundTruthOverride('classification', null);
+  const r = resolver.resolve('classification');
+  assert.strictEqual(r.model, 'small');
+  assert.strictEqual(r.source, 'model-scout');
+});
+
+test('TC-PROBE-012: setGroundTruthOverride guards against a falsy job', () => {
+  const resolver = new ModelResolver({ logger: silentLogger });
+  assert.doesNotThrow(() => resolver.setGroundTruthOverride(null, 'x'));
+  assert.doesNotThrow(() => resolver.setGroundTruthOverride('', 'x'));
+});
+
+// Summary
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -421,18 +421,20 @@ try {
 const CostTracker = require('./src/lib/llm/cost-tracker');
 
 // Local Intelligence: ModelScout + MicroPipeline + DeferralQueue
-let ModelScout, MicroPipeline, MemoryContextEnricher, DeferralQueue;
+let ModelScout, MicroPipeline, MemoryContextEnricher, DeferralQueue, GoldenSetProbe;
 try {
   ({ ModelScout } = require('./src/lib/providers/model-scout'));
   MicroPipeline = require('./src/lib/agent/micro-pipeline');
   MemoryContextEnricher = require('./src/lib/agent/memory-context-enricher');
   DeferralQueue = require('./src/lib/agent/deferral-queue');
+  GoldenSetProbe = require('./src/lib/llm/golden-set-probe');
 } catch (err) {
   console.warn(`[WARN] Local Intelligence modules not available: ${err.message}`);
   ModelScout = null;
   MicroPipeline = null;
   MemoryContextEnricher = null;
   DeferralQueue = null;
+  GoldenSetProbe = null;
 }
 
 // Configuration (NO secrets - only non-sensitive config)
@@ -2036,6 +2038,32 @@ async function initialize() {
           console.log(`[INIT] Model resolver: ${summary}`);
           for (const d of divergences) {
             console.warn(`[WARN] ${d}`);
+          }
+        }
+
+        // Golden-set probe: measure classification accuracy per language and select
+        // the smallest local model that clears the bar (ground truth beats size).
+        // Non-blocking — boot and first requests proceed on ModelScout's size-prior
+        // pick; the probe's finding (if any) overrides it once it lands.
+        if (GoldenSetProbe && modelResolver && intentRouter) {
+          try {
+            const fixture = GoldenSetProbe.loadFixture(path.join(__dirname, 'test/fixtures/golden-set/classification-golden-set.json'));
+            const probe = new GoldenSetProbe({
+              classifyFn: (m, msg, lang) => intentRouter.probeClassify(m, msg, lang),
+              fixture,
+              cacheDir: path.join(__dirname, 'data'),
+              logger: console,
+            });
+            probe.run(modelScout.getClassificationCandidates())
+              .then(sel => {
+                if (sel && sel.model) {
+                  modelResolver.setGroundTruthOverride('classification', sel.model);
+                  console.log(`[INIT] Golden-set probe: classification -> ${sel.model} (EN ${sel.scores?.EN} DE ${sel.scores?.DE} PT ${sel.scores?.PT}, ${sel.passed ? 'passed' : sel.reason})`);
+                }
+              })
+              .catch(err => console.warn(`[INIT] Golden-set probe failed: ${err.message}`));
+          } catch (err) {
+            console.warn(`[INIT] Golden-set probe setup failed: ${err.message}`);
           }
         }
       }).catch(err => {


### PR DESCRIPTION
## What

Implements the golden-set cold-start probe (briefing 03b), after the three cleanups. The classification roster picked the **smallest** local text-gen model (a size prior — "classification needs no depth"). But classification has ground truth, and **multilingual coverage is orthogonal to parameter count**. This replaces the proxy with a measurement.

At boot / roster change, `GoldenSetProbe` replays a labeled EN/DE/PT fixture through the **same** classification path production uses (`IntentRouter.probeClassify` — the probe never builds its own prompt) against each capability-eligible local model, scores per language, and selects the **smallest model that clears the bar in all three languages**. The winner feeds a new `ModelResolver` tier: `cockpit > golden-set-probe > model-scout > env > deployer` — above the size pick, below an explicit human override. If none clears the bar, the least-bad is chosen and the gap is logged loudly.

## Live evidence (real Ollama, this box) — this is the fix, demonstrated

108 real classify calls per run, twice (independent runs, identical result):

| model | params | EN | DE | PT | verdict |
|---|---|---|---|---|---|
| **gemma2:2b** (current size-prior pick) | 2.6B | 0.67 | 0.67 | 0.67 | **fails bar in all 3 langs** |
| qwen2.5:3b | 3.1B | 0.67 | 0.75 | 0.83 | fails EN |
| **qwen3:8b** (probe selection) | 8.2B | 0.92 | 1.00 | 0.83 | **passes — smallest passer** |

`resolve('classification')` → `qwen3:8b`, `source: golden-set-probe`. Run 2 = **0 re-probe calls** (digest+content-hash cache hit). The size prior would have shipped a 67%-accurate classifier; the measurement corrects it.

## Reviewer-driven hardening

A reviewer pass (PASS-with-notes) caught a real failure mode I fixed before commit:
- **Cache-poisoning on transient failure**: a cold Ollama at boot (project memory #124: qwen3:8b cold-start can exceed 60s) would make every classify throw, and the deflated `0/0/0` would cache under the digest key **forever**. Fixed: incomplete measurements are **not** persisted and `select()` returns no pick (scout's size pick stands, retry next boot) — no poison, no false alarm.
- **Content-hash cache key**: keyed on fixture **content hash** + version, not a hand-bumped integer, so editing a DE/PT label invalidates stale scores even if `version` isn't bumped.

## Verification

- `npm run test:unit` → **220/220** files (new `test/unit/llm/golden-set-probe.test.js`, 12/12 — includes the poisoning-guard, content-hash-invalidation, and digest-null cases). eslint **0 errors**.
- Live: two independent real-Ollama runs, results above; cache-hit and resolver override confirmed.

`[VERIFIED: golden-set probe live on real Ollama — probed 3 eligible models (108 classify calls/run x2), per-language scores gemma2:2b EN0.67/DE0.67/PT0.67 (fails bar), qwen2.5:3b EN0.67/DE0.75/PT0.83, qwen3:8b EN0.92/DE1.0/PT0.83; resolve('classification') -> qwen3:8b source=golden-set-probe; run2 cache-hit 0 re-probes; cold-Ollama poisoning guard verified (incomplete measurement not cached, re-probes on retry). test:unit 220/220, probe 12/12, lint 0.]`

## Human dependency (merge gate)

The **DE/PT fixture labels are the operational definition of correctness per language** — a mislabeled example silently selects the wrong model for that language. They need a native-speaker read (Fu) before merge. PT is European Portuguese (`equipa`, `ficheiros`, `integração`); two EN/DE calls are debatable (id 4 "Summarize…" as `knowledge`; id 3 "Who leads…" as `knowledge`).

## Notes for Fu

- **Fixture home**: lives under `test/fixtures/` but is loaded at **runtime** by the probe. Works because the service runs from the full checkout; if a packaged deploy ever prunes `test/`, move the fixture to `config/`.
- **Design-doc amendments** (briefing handoff — flagging rather than editing your spec): *Session 2*'s per-job prior for ground-truth jobs should defer to this probe's selection, not size; *Session 3*'s maturation loop should seed each classification pairing from this probe's per-language result instead of cold.
- Low-priority reviewer suggestions deferred: `describe()` doesn't surface the probe tier as a divergence (harmless — runs pre-probe); `fellBack` log can read misleadingly when the probe wins (cosmetic); cache file isn't pruned of retired digests (low impact).

Part of the adaptive-model-selection pack (design doc §5/§6/§8). Branch off `next`.