### PR TITLE
feat(llm): capability-class abstraction spans local + cloud (Declared tier)

### DIFF
--- a/src/lib/llm/router.js
+++ b/src/lib/llm/router.js
@@ -16,6 +16,8 @@
  */
 
 const { createProvider } = require('./providers');
+const { cloudCapabilities } = require('../providers/cloud-model-descriptor');
+const { isToolCapable, classesOf } = require('../providers/capability-classes');
 const RateLimitTracker = require('./rate-limit-tracker');
 const BudgetEnforcer = require('./budget-enforcer');
 const BackoffStrategy = require('./backoff-strategy');
@@ -121,6 +123,10 @@ class LLMRouter {
     this._roster = null;
     this._activePreset = null;
 
+    // Cloud providers whose capabilities are not in the descriptor — logged once
+    // each (a maintainer adds them) rather than re-warned on every roster rebuild.
+    this._loggedUnknownCloudCaps = new Set();
+
     // Stats
     this.stats = {
       totalCalls: 0,
@@ -152,6 +158,11 @@ class LLMRouter {
           ...providerConfig,
           getCredential
         });
+
+        // Record the adapter the deployer configured so the cloud capability
+        // gate can look this player up in the descriptor (a datasheet keyed on
+        // the API contract, not a guess from the model name).
+        provider.adapter = adapter;
 
         this.providers.set(id, provider);
       } catch (error) {
@@ -643,8 +654,12 @@ class LLMRouter {
 
       // Tools: cheapest cloud first (Haiku — reliable structured output, 2-3s),
       // local fallback for sovereign mode. Local models (qwen3:8b) take 60-70s
-      // and produce unreliable structured JSON.
-      roster[JOBS.TOOLS] = [...new Set([cheapest, ...local].filter(Boolean))];
+      // and produce unreliable structured JSON. Capability gate (Declared, cloud):
+      // the tools job draws only from tool-capable cloud models, so a non-tool
+      // cloud model (an embedding endpoint) never lands in the tools roster.
+      const toolCloud = this._classifyCloudProviders(this._toolCapableCloudIds(cloudIds));
+      const toolCheapest = [...toolCloud.rest].reverse()[0] || toolCloud.workhorse || toolCloud.heavy;
+      roster[JOBS.TOOLS] = [...new Set([toolCheapest, ...local].filter(Boolean))];
 
       // Research: cheapest cloud (Haiku — sufficient quality, ~10x cheaper than Sonnet)
       roster[JOBS.RESEARCH] = [...new Set([cheapest, ...local].filter(Boolean))];
@@ -686,6 +701,66 @@ class LLMRouter {
   }
 
   /**
+   * Declared capabilities of a cloud provider, read from the descriptor keyed on
+   * the adapter the deployer configured (and any per-model override). Returns
+   * null for a local provider; `source: 'unknown'` when the model is not in the
+   * datasheet.
+   * @private
+   * @param {string} id - Provider ID
+   * @returns {{ capabilities: string[]|null, source: string }|null}
+   */
+  _cloudCapabilitiesOf(id) {
+    const provider = this.providers.get(id);
+    if (!provider || provider.type === 'local') return null;
+    return cloudCapabilities({ adapter: provider.adapter, model: provider.model });
+  }
+
+  /**
+   * Filter cloud provider IDs to those a datasheet declares tool-capable. A
+   * model the descriptor does not know is kept (never drop a working provider on
+   * a gap in the datasheet) but logged once so a maintainer adds it. A model the
+   * descriptor declares non-tool (e.g. an embedding endpoint) is excluded.
+   * @private
+   * @param {string[]} cloudIds
+   * @returns {string[]}
+   */
+  _toolCapableCloudIds(cloudIds) {
+    return cloudIds.filter((id) => {
+      const caps = this._cloudCapabilitiesOf(id);
+      if (!caps || caps.source === 'unknown' || caps.capabilities === null) {
+        if (!this._loggedUnknownCloudCaps.has(id)) {
+          this._loggedUnknownCloudCaps.add(id);
+          const model = this.providers.get(id)?.model || '(unknown model)';
+          console.log(`[LLMRouter] Cloud model not in capability descriptor: ${id} (${model}); assuming tool-capable and keeping it in the tools roster. Add it to cloud-model-descriptor.js.`);
+        }
+        return true;
+      }
+      return isToolCapable(caps.capabilities);
+    });
+  }
+
+  /**
+   * Report each cloud provider's capability classes, for the startup log and the
+   * verification gate. Uses the same shared classifier as the local roster, so a
+   * local and a cloud model are classed by one function.
+   * @returns {Array<{ id: string, model: string, classes: string[], source: string }>}
+   */
+  describeCloudCapabilityClasses() {
+    const out = [];
+    for (const [id, provider] of this.providers) {
+      if (provider.type === 'local') continue;
+      const caps = cloudCapabilities({ adapter: provider.adapter, model: provider.model });
+      out.push({
+        id,
+        model: provider.model || '(unknown)',
+        classes: caps.capabilities ? classesOf(caps.capabilities) : ['unknown'],
+        source: caps.source,
+      });
+    }
+    return out;
+  }
+
+  /**
    * Build a flat cloud-fast roster: cheapest + mid-tier cloud, no heavy (Opus).
    * Every job gets the same chain — no escalation.
    * @private
@@ -710,6 +785,14 @@ class LLMRouter {
     for (const job of VALID_JOBS) {
       roster[job] = [...chain];
     }
+
+    // Capability gate (Declared, cloud): the tools job draws only from
+    // tool-capable cloud models. Same policy as smart-mix/cloud-first.
+    const toolCloud = this._classifyCloudProviders(this._toolCapableCloudIds(cloudIds));
+    const toolCheapest = [...toolCloud.rest].reverse()[0] || toolCloud.workhorse || toolCloud.heavy;
+    const toolMid = toolCloud.rest.length > 0 ? toolCloud.workhorse : (toolCloud.workhorse !== toolCloud.heavy ? toolCloud.workhorse : null);
+    roster[JOBS.TOOLS] = [...new Set([toolCheapest, toolMid, ...localIds].filter(Boolean))];
+
     return roster;
   }
 
@@ -994,6 +1077,16 @@ class LLMRouter {
     this._roster = this._resolvePreset(presetName);
     this._activePreset = presetName;
     console.log(`[LLMRouter] Preset activated: ${presetName}`);
+
+    // Presets that route to cloud pass through the capability gate: log the
+    // classed cloud roster so the gate's decision is observable in production.
+    if (presetName === 'smart-mix' || presetName === 'cloud-first') {
+      const classed = this.describeCloudCapabilityClasses();
+      if (classed.length > 0) {
+        const summary = classed.map(c => `${c.id}[${c.classes.join('/')}]`).join(', ');
+        console.log(`[LLMRouter] Cloud capability classes (${presetName}): ${summary}`);
+      }
+    }
   }
 
   /**

--- a/src/lib/providers/capability-classes.js
+++ b/src/lib/providers/capability-classes.js
@@ -1,0 +1,157 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * capability-classes — The shared vocabulary for "what can this model do",
+ * answered the same way for a local Ollama model and a cloud API model.
+ *
+ * Problem:
+ *   Cleanup A senses local capability from Ollama's `/api/show` `capabilities`
+ *   array and partitions the pool inside ModelScout. Cloud players have no
+ *   `/api/show`, so their capability comes from a per-provider descriptor. Left
+ *   apart, "is this model tool-capable" would be answered by two different code
+ *   paths with two different notions of a capability class — the seam where the
+ *   local and cloud rosters would drift.
+ *
+ * Pattern:
+ *   Both sources converge on one shape: a `capabilities` array in Ollama's
+ *   vocabulary (`completion`, `tools`, `vision`, `embedding`, `thinking`). Local
+ *   models carry it from the probe; cloud models get it from the descriptor
+ *   (see cloud-model-descriptor.js). This module is the single set of predicates
+ *   over that array, so the same question — text-generation? tool-capable? — has
+ *   one answer for any player, local or cloud. Capability is read from what a
+ *   model declares, never inferred from its family name (NO REGEX FOR
+ *   INTELLIGENCE); the declared array is the input, this module only classifies.
+ *
+ *   Two text-generation predicates exist on purpose. `isTextGeneration` is the
+ *   honest class membership (a multimodal generalist that also does vision is
+ *   still a text generator). `isDedicatedTextGenerator` is a *selection policy*
+ *   the local roster applies — it excludes vision/embedding specialists, because
+ *   a local vision model (llava) is a poor general chat model. Cloud multimodal
+ *   generalists (Claude) are text-generators and tool-capable regardless of also
+ *   declaring vision, so the cloud tools gate keys on `isToolCapable`.
+ *
+ * Dependency Map:
+ *   src/lib/providers/capability-classes.js
+ *     ← src/lib/providers/model-scout.js       (local capability partition)
+ *     ← src/lib/providers/cloud-model-descriptor.js (cloud capability lookup)
+ *     ← src/lib/llm/router.js                   (cloud tools capability gate)
+ *     ← (no internal imports — pure, leaf module)
+ *
+ * @module providers/capability-classes
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+/**
+ * Declared-capability tokens. These mirror Ollama's `/api/show` `capabilities`
+ * vocabulary; the cloud descriptor declares the same tokens so one predicate
+ * set spans local and cloud.
+ */
+const CAPABILITY = Object.freeze({
+  COMPLETION: 'completion',
+  TOOLS: 'tools',
+  VISION: 'vision',
+  EMBEDDING: 'embedding',
+  THINKING: 'thinking',
+});
+
+/**
+ * Capability classes — the partitions a model may belong to. A model can belong
+ * to several (a multimodal tool-caller is text-generation + tool-capable +
+ * vision); embedding is disjoint from text-generation.
+ */
+const CLASS = Object.freeze({
+  TEXT_GENERATION: 'text-generation',
+  TOOL_CAPABLE: 'tool-capable',
+  VISION: 'vision',
+  EMBEDDING: 'embedding',
+});
+
+/**
+ * Normalize a declared-capabilities array: coerce to lowercase strings and,
+ * when nothing is declared, default to text-generation so a model with an
+ * unreadable capability line is treated as chat-capable rather than dark. This
+ * matches ModelScout's never-go-dark default for a failed `/api/show`.
+ * @param {string[]|null|undefined} capabilities
+ * @returns {string[]}
+ */
+function normalizeCapabilities(capabilities) {
+  if (!Array.isArray(capabilities) || capabilities.length === 0) {
+    return [CAPABILITY.COMPLETION];
+  }
+  return capabilities.map(c => String(c).toLowerCase());
+}
+
+/** @param {string[]} caps @param {string} cap */
+function hasCapability(caps, cap) {
+  return normalizeCapabilities(caps).includes(cap);
+}
+
+/** Whether the model produces embeddings (disjoint from text-generation). */
+function isEmbedding(capabilities) {
+  return hasCapability(capabilities, CAPABILITY.EMBEDDING);
+}
+
+/** Whether the model declares vision (additive — may also be a text generator). */
+function hasVision(capabilities) {
+  return hasCapability(capabilities, CAPABILITY.VISION);
+}
+
+/**
+ * Honest text-generation membership: declares completion and is not an
+ * embedding model. A multimodal generalist counts (vision is additive).
+ */
+function isTextGeneration(capabilities) {
+  const caps = normalizeCapabilities(capabilities);
+  return caps.includes(CAPABILITY.COMPLETION) && !caps.includes(CAPABILITY.EMBEDDING);
+}
+
+/**
+ * The local roster's stricter text-job policy: a dedicated text generator that
+ * is neither a vision nor an embedding specialist. Equivalent to ModelScout's
+ * original `_isTextGen` — kept here so the policy has one home.
+ */
+function isDedicatedTextGenerator(capabilities) {
+  return isTextGeneration(capabilities) && !hasVision(capabilities);
+}
+
+/**
+ * Whether the model can call tools: a text generator that declares `tools`.
+ * Vision-additive generalists (Claude) qualify; embedding models do not. This
+ * is the predicate the cloud tools gate keys on.
+ */
+function isToolCapable(capabilities) {
+  return isTextGeneration(capabilities) && hasCapability(capabilities, CAPABILITY.TOOLS);
+}
+
+/**
+ * The set of capability classes a declared-capabilities array belongs to.
+ * Consistent for a local model (probe-derived caps) and a cloud model
+ * (descriptor-derived caps): the same array yields the same classes.
+ * @param {string[]} capabilities
+ * @returns {string[]} subset of CLASS values, stable order
+ */
+function classesOf(capabilities) {
+  const caps = normalizeCapabilities(capabilities);
+  const classes = [];
+  if (isTextGeneration(caps)) classes.push(CLASS.TEXT_GENERATION);
+  if (isToolCapable(caps)) classes.push(CLASS.TOOL_CAPABLE);
+  if (hasVision(caps)) classes.push(CLASS.VISION);
+  if (isEmbedding(caps)) classes.push(CLASS.EMBEDDING);
+  return classes;
+}
+
+module.exports = {
+  CAPABILITY,
+  CLASS,
+  normalizeCapabilities,
+  hasCapability,
+  isEmbedding,
+  hasVision,
+  isTextGeneration,
+  isDedicatedTextGenerator,
+  isToolCapable,
+  classesOf,
+};

--- a/src/lib/providers/cloud-model-descriptor.js
+++ b/src/lib/providers/cloud-model-descriptor.js
@@ -1,0 +1,126 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * cloud-model-descriptor — The Declared tier for cloud players: a datasheet of
+ * published capability facts, so the capability gate spans cloud the same way
+ * Cleanup A's `/api/show` probe spans local.
+ *
+ * Problem:
+ *   A cloud model has no `/api/show` to ask. Its capabilities (does it call
+ *   tools, does it see images, how large is its context) are published facts,
+ *   not runtime-sensible ones. Without them, the router treats every cloud
+ *   provider as tool-capable and a non-tool cloud model (an embedding endpoint)
+ *   would sit in the tools roster it has no business serving — the cloud twin of
+ *   the local roster contamination Cleanup A fixed.
+ *
+ * Pattern:
+ *   Two tiers, both honest datasheets — recorded truth about a small, fixed,
+ *   publicly-specified roster the deployer chose, NOT a hunch inferred from a
+ *   model name (that is the affinity-map anti-pattern this pack retired).
+ *
+ *   - ADAPTER_PROFILES: keyed on the adapter the deployer explicitly configured
+ *     (`anthropic`, `openai`, ...). This is the API contract — "the Anthropic
+ *     Messages API supports tool use and vision" is a fact about the endpoint,
+ *     stable across model versions, so it survives a model bump without edits.
+ *   - MODEL_OVERRIDES: keyed on an exact model name, for facts that vary within
+ *     a provider (an embedding-only model; a precise context window). Layered on
+ *     top of the adapter profile.
+ *
+ *   An adapter/model with no entry is reported as `source: 'unknown'` (caller
+ *   logs the gap and adds it to the datasheet) rather than guessed from its
+ *   name. Capabilities are emitted in the shared vocabulary so the same
+ *   predicates in capability-classes.js classify local and cloud alike.
+ *
+ * Dependency Map:
+ *   src/lib/providers/cloud-model-descriptor.js
+ *     → src/lib/providers/capability-classes.js (normalizeCapabilities)
+ *     ← src/lib/llm/router.js                    (cloud tools capability gate)
+ *
+ * @module providers/cloud-model-descriptor
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+const { normalizeCapabilities } = require('./capability-classes');
+
+/**
+ * Adapter-level capability profiles. Keyed by the `adapter` id from the
+ * provider config (config/moltagent-providers.yaml → provider.adapter, mirrored
+ * by the ADAPTERS registry in src/lib/llm/providers/index.js). Each entry is a
+ * published fact about that provider's chat API. `capabilities` uses the shared
+ * vocabulary; `contextWindow`/`structuredOutput` are declared for downstream
+ * consumers (Session 2+) and are not read by the tools gate.
+ *
+ * A maintainer adds a row here when they wire up a new cloud provider.
+ */
+const ADAPTER_PROFILES = Object.freeze({
+  anthropic: { capabilities: ['completion', 'tools', 'vision'], contextWindow: 200000, structuredOutput: true },
+  openai: { capabilities: ['completion', 'tools', 'vision'], contextWindow: 128000, structuredOutput: true },
+  google: { capabilities: ['completion', 'tools', 'vision'], contextWindow: 1000000, structuredOutput: true },
+  // OpenAI-compatible chat APIs that implement function/tool calling. Vision
+  // varies by the specific model behind the endpoint, so it is not claimed at
+  // the adapter level; a MODEL_OVERRIDES row adds it where true.
+  deepseek: { capabilities: ['completion', 'tools'], contextWindow: 64000, structuredOutput: true },
+  mistral: { capabilities: ['completion', 'tools'], contextWindow: 128000, structuredOutput: true },
+  groq: { capabilities: ['completion', 'tools'], contextWindow: 128000, structuredOutput: true },
+  together: { capabilities: ['completion', 'tools'], contextWindow: 32000, structuredOutput: false },
+  fireworks: { capabilities: ['completion', 'tools'], contextWindow: 32000, structuredOutput: false },
+  openrouter: { capabilities: ['completion', 'tools'], contextWindow: 200000, structuredOutput: true },
+  xai: { capabilities: ['completion', 'tools'], contextWindow: 131072, structuredOutput: true },
+});
+
+/**
+ * Per-model overrides layered on the adapter profile. Keyed by exact model name.
+ * Present here only where a model deviates from its adapter's profile — an
+ * embedding endpoint that cannot chat or call tools, a differing context window.
+ * These are recorded published facts, not name-pattern guesses.
+ */
+const MODEL_OVERRIDES = Object.freeze({
+  // OpenAI embedding endpoints: served through the `openai` adapter but neither
+  // chat nor tool-capable — the exact cloud contamination the gate excludes.
+  'text-embedding-3-small': { capabilities: ['embedding'], contextWindow: 8191, structuredOutput: false },
+  'text-embedding-3-large': { capabilities: ['embedding'], contextWindow: 8191, structuredOutput: false },
+});
+
+/**
+ * Look up the declared capabilities of a cloud model from the datasheet.
+ *
+ * A model-name override wins over the adapter profile. When neither is known,
+ * `source` is `'unknown'` and `capabilities` is null — the caller decides how to
+ * treat an unrecognized cloud model (the router keeps it in the roster but logs
+ * the gap) rather than this module inventing a capability from the name.
+ *
+ * @param {Object} [player]
+ * @param {string} [player.adapter] - Adapter id (e.g. 'anthropic').
+ * @param {string} [player.model] - Model name (e.g. 'claude-opus-4-6').
+ * @returns {{
+ *   capabilities: string[]|null,
+ *   contextWindow: number|null,
+ *   structuredOutput: boolean|null,
+ *   source: 'model-override'|'adapter'|'unknown'
+ * }}
+ */
+function cloudCapabilities({ adapter, model } = {}) {
+  const override = (typeof model === 'string' && MODEL_OVERRIDES[model]) || null;
+  const profile = (typeof adapter === 'string' && ADAPTER_PROFILES[adapter]) || null;
+
+  if (!override && !profile) {
+    return { capabilities: null, contextWindow: null, structuredOutput: null, source: 'unknown' };
+  }
+
+  const merged = { ...(profile || {}), ...(override || {}) };
+  return {
+    capabilities: normalizeCapabilities(merged.capabilities),
+    contextWindow: Number.isFinite(merged.contextWindow) ? merged.contextWindow : null,
+    structuredOutput: typeof merged.structuredOutput === 'boolean' ? merged.structuredOutput : null,
+    source: override ? 'model-override' : 'adapter',
+  };
+}
+
+module.exports = {
+  ADAPTER_PROFILES,
+  MODEL_OVERRIDES,
+  cloudCapabilities,
+};

--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+const { normalizeCapabilities, isDedicatedTextGenerator } = require('./capability-classes');
+
 class ModelScout {
   /**
    * @param {Object} config
@@ -240,15 +242,16 @@ class ModelScout {
 
   /** Declared capabilities of a model, defaulting to text-generation. */
   _capsOf(model) {
-    return Array.isArray(model.capabilities) && model.capabilities.length > 0
-      ? model.capabilities
-      : ['completion'];
+    return normalizeCapabilities(model.capabilities);
   }
 
-  /** Whether a model may serve text jobs (embedding-only and vision excluded). */
+  /**
+   * Whether a model may serve local text jobs. Delegates to the shared
+   * capability-class policy (a dedicated text generator — embedding-only and
+   * vision specialists excluded), so local and cloud speak one vocabulary.
+   */
   _isTextGen(model) {
-    const caps = this._capsOf(model);
-    return caps.includes('completion') && !caps.includes('embedding') && !caps.includes('vision');
+    return isDedicatedTextGenerator(model.capabilities);
   }
 
   /** Compare by capacity ascending (param size, then file size). (b,a) => largest-first. */

--- a/test/unit/llm/router-cloud-capability-gate.test.js
+++ b/test/unit/llm/router-cloud-capability-gate.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * LLMRouter Cloud Capability Gate Tests (Session 1: Declared tier, cloud)
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: Verify the capability gate spans cloud — the tools job draws only
+ * from tool-capable cloud models, a non-tool cloud model (an embedding
+ * endpoint the descriptor declares) is excluded, and an unrecognized cloud
+ * model is kept (never dark) rather than dropped.
+ *
+ * Pattern: Build a router through the real _initializeProviders path (so each
+ * provider carries its adapter), then read the resolved preset roster.
+ *
+ * Run: node test/unit/llm/router-cloud-capability-gate.test.js
+ *
+ * @module test/unit/llm/router-cloud-capability-gate
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const LLMRouter = require('../../../src/lib/llm/router');
+
+console.log('\n=== LLMRouter Cloud Capability Gate Tests ===\n');
+
+/**
+ * Router with a local model, a tool-capable cloud model (Haiku, more
+ * expensive), and a CHEAPER cloud embedding endpoint. Without the gate the
+ * embedding model — being cheapest — would win the tools job.
+ */
+function routerWithEmbeddingTrap() {
+  const router = new LLMRouter({
+    providers: {
+      'ollama-local': { adapter: 'ollama', type: 'local', model: 'qwen3:8b', endpoint: 'http://localhost:11434' },
+      'claude-haiku': { adapter: 'anthropic', type: 'api', model: 'claude-haiku-4-5-20251001', costModel: { type: 'per_token', inputPer1M: 0.8, outputPer1M: 4.0 } },
+      'openai-embed': { adapter: 'openai', type: 'api', model: 'text-embedding-3-small', endpoint: 'https://api.openai.com/v1', costModel: { type: 'per_token', inputPer1M: 0.02, outputPer1M: 0.02 } },
+    },
+  });
+  return router;
+}
+
+test('smart-mix tools job draws only from tool-capable cloud models', () => {
+  const router = routerWithEmbeddingTrap();
+  const roster = router._resolvePreset('smart-mix');
+
+  // The tool-capable cloud model wins tools even though the embedding endpoint
+  // is cheaper; the embedding endpoint is excluded from the tools roster.
+  assert.strictEqual(roster.tools[0], 'claude-haiku', 'tool-capable cloud leads the tools job');
+  assert.ok(!roster.tools.includes('openai-embed'), 'declared non-tool cloud model excluded from tools');
+  assert.ok(roster.tools.includes('ollama-local'), 'local fallback retained');
+});
+
+test('cloud-first tools job excludes the non-tool cloud model', () => {
+  const router = routerWithEmbeddingTrap();
+  const roster = router._resolvePreset('cloud-first');
+  assert.strictEqual(roster.tools[0], 'claude-haiku');
+  assert.ok(!roster.tools.includes('openai-embed'));
+});
+
+test('non-tools cloud jobs are untouched this session (scope: tools gate only)', () => {
+  // Session 1 gates only the tools job. Other jobs keep cost-tier selection
+  // unchanged (broader per-job capability gating is Session 2). The cheapest
+  // cloud provider still leads a non-tool job.
+  const router = routerWithEmbeddingTrap();
+  const roster = router._resolvePreset('smart-mix');
+  assert.strictEqual(roster.thinking[0], 'claude-haiku', 'depth job unchanged (Haiku is the priciest → heavy tier here)');
+});
+
+test('unrecognized cloud model is kept in the tools roster (never dark) + logged once', () => {
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...a) => logs.push(a.join(' '));
+  let roster;
+  try {
+    const router = new LLMRouter({
+      providers: {
+        'ollama-local': { adapter: 'ollama', type: 'local', model: 'qwen3:8b', endpoint: 'http://localhost:11434' },
+        'mystery-cloud': { adapter: 'openai-compatible', type: 'api', model: 'some-llama-70b', endpoint: 'https://example.test/v1', costModel: { type: 'per_token', inputPer1M: 1, outputPer1M: 1 } },
+      },
+    });
+    roster = router._resolvePreset('smart-mix');
+    // Rebuild once more to prove the unknown warning fires only once.
+    router._resolvePreset('smart-mix');
+  } finally {
+    console.log = origLog;
+  }
+
+  assert.strictEqual(roster.tools[0], 'mystery-cloud', 'unknown cloud model kept in tools (fail-open)');
+  const unknownWarns = logs.filter(l => l.includes('not in capability descriptor') && l.includes('mystery-cloud'));
+  assert.strictEqual(unknownWarns.length, 1, 'unknown cloud capability warned exactly once');
+});
+
+test('describeCloudCapabilityClasses classes cloud providers by the shared classifier', () => {
+  const router = routerWithEmbeddingTrap();
+  const classed = router.describeCloudCapabilityClasses();
+  const byId = Object.fromEntries(classed.map(c => [c.id, c]));
+
+  assert.ok(byId['claude-haiku'].classes.includes('tool-capable'), 'Haiku classed tool-capable');
+  assert.ok(byId['claude-haiku'].classes.includes('text-generation'));
+  assert.deepStrictEqual(byId['openai-embed'].classes, ['embedding'], 'embedding endpoint classed embedding-only');
+  // Local provider is not part of the cloud descriptor report.
+  assert.ok(!byId['ollama-local']);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/providers/capability-classes.test.js
+++ b/test/unit/providers/capability-classes.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * capability-classes Unit Tests
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: Verify the shared capability vocabulary classifies a declared
+ * capabilities array consistently for local (Ollama probe) and cloud
+ * (descriptor) models — one predicate set, one answer for any player.
+ *
+ * Pattern: Direct unit testing of pure predicates. No mocks — leaf module.
+ *
+ * Run: node test/unit/providers/capability-classes.test.js
+ *
+ * @module test/unit/providers/capability-classes
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const {
+  CLASS,
+  normalizeCapabilities,
+  isEmbedding,
+  hasVision,
+  isTextGeneration,
+  isDedicatedTextGenerator,
+  isToolCapable,
+  classesOf,
+} = require('../../../src/lib/providers/capability-classes');
+
+console.log('\n=== capability-classes Tests ===\n');
+
+// --- normalizeCapabilities: default + lowercase ---
+test('normalizeCapabilities defaults empty/undefined to completion', () => {
+  assert.deepStrictEqual(normalizeCapabilities(undefined), ['completion']);
+  assert.deepStrictEqual(normalizeCapabilities([]), ['completion']);
+  assert.deepStrictEqual(normalizeCapabilities(null), ['completion']);
+});
+
+test('normalizeCapabilities lowercases declared tokens', () => {
+  assert.deepStrictEqual(normalizeCapabilities(['Completion', 'TOOLS']), ['completion', 'tools']);
+});
+
+// --- text-generation membership (honest, additive vision) ---
+test('isTextGeneration: completion-bearing model is text-gen, embedding is not', () => {
+  assert.strictEqual(isTextGeneration(['completion', 'tools']), true);
+  assert.strictEqual(isTextGeneration(['completion', 'vision']), true, 'vision is additive');
+  assert.strictEqual(isTextGeneration(['embedding']), false);
+});
+
+// --- dedicated (local roster policy) excludes vision/embedding specialists ---
+test('isDedicatedTextGenerator excludes vision and embedding specialists', () => {
+  assert.strictEqual(isDedicatedTextGenerator(['completion', 'tools']), true);
+  assert.strictEqual(isDedicatedTextGenerator(['completion', 'vision']), false, 'llava excluded from local text jobs');
+  assert.strictEqual(isDedicatedTextGenerator(['embedding']), false);
+});
+
+// --- tool-capable: text-gen + tools, vision-additive generalist still qualifies ---
+test('isToolCapable: multimodal generalist qualifies, embedding does not', () => {
+  assert.strictEqual(isToolCapable(['completion', 'tools', 'vision']), true, 'Claude-shape qualifies');
+  assert.strictEqual(isToolCapable(['completion', 'tools']), true);
+  assert.strictEqual(isToolCapable(['completion']), false, 'no tools declared');
+  assert.strictEqual(isToolCapable(['embedding']), false);
+});
+
+test('hasVision / isEmbedding read declared tokens', () => {
+  assert.strictEqual(hasVision(['completion', 'vision']), true);
+  assert.strictEqual(hasVision(['completion']), false);
+  assert.strictEqual(isEmbedding(['embedding']), true);
+  assert.strictEqual(isEmbedding(['completion']), false);
+});
+
+// --- classesOf: consistent classes for a LOCAL and a CLOUD model ---
+test('classesOf returns consistent classes for a local and a cloud tool-caller', () => {
+  // qwen3:8b (local, /api/show) and claude (cloud, descriptor) both declare
+  // completion+tools → both are text-generation AND tool-capable.
+  const localCaps = ['completion', 'tools', 'thinking'];
+  const cloudCaps = ['completion', 'tools', 'vision'];
+  const localClasses = classesOf(localCaps);
+  const cloudClasses = classesOf(cloudCaps);
+
+  assert.ok(localClasses.includes(CLASS.TEXT_GENERATION));
+  assert.ok(localClasses.includes(CLASS.TOOL_CAPABLE));
+  assert.ok(cloudClasses.includes(CLASS.TEXT_GENERATION));
+  assert.ok(cloudClasses.includes(CLASS.TOOL_CAPABLE));
+  // Cloud model additionally sees images; both agree on the shared classes.
+  assert.ok(cloudClasses.includes(CLASS.VISION));
+  assert.ok(!localClasses.includes(CLASS.VISION));
+});
+
+test('classesOf: embedding model is embedding-only, not text-generation', () => {
+  const classes = classesOf(['embedding']);
+  assert.deepStrictEqual(classes, [CLASS.EMBEDDING]);
+});
+
+test('classesOf: vision specialist is text-generation + vision (membership, not policy)', () => {
+  // Membership is honest even though the local roster POLICY excludes it.
+  const classes = classesOf(['completion', 'vision']);
+  assert.ok(classes.includes(CLASS.TEXT_GENERATION));
+  assert.ok(classes.includes(CLASS.VISION));
+  assert.ok(!classes.includes(CLASS.TOOL_CAPABLE));
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/providers/cloud-model-descriptor.test.js
+++ b/test/unit/providers/cloud-model-descriptor.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * cloud-model-descriptor Unit Tests
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: Verify the cloud datasheet reports declared capabilities from the
+ * adapter profile and per-model overrides, in the shared vocabulary, and flags
+ * unrecognized models as unknown rather than guessing from the name.
+ *
+ * Pattern: Direct unit testing of the lookup function against known and
+ * unknown adapters/models.
+ *
+ * Run: node test/unit/providers/cloud-model-descriptor.test.js
+ *
+ * @module test/unit/providers/cloud-model-descriptor
+ */
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { cloudCapabilities } = require('../../../src/lib/providers/cloud-model-descriptor');
+const { isToolCapable } = require('../../../src/lib/providers/capability-classes');
+
+console.log('\n=== cloud-model-descriptor Tests ===\n');
+
+// --- adapter profile: tool-capable chat provider ---
+test('anthropic adapter is tool-capable with a context window', () => {
+  const caps = cloudCapabilities({ adapter: 'anthropic', model: 'claude-opus-4-6' });
+  assert.strictEqual(caps.source, 'adapter');
+  assert.ok(caps.capabilities.includes('tools'));
+  assert.ok(caps.capabilities.includes('vision'));
+  assert.strictEqual(isToolCapable(caps.capabilities), true);
+  assert.strictEqual(typeof caps.contextWindow, 'number');
+});
+
+test('adapter profile answers even for an unlisted model of a known adapter', () => {
+  // A newer Claude version not individually enumerated still resolves via the
+  // adapter contract — the datasheet survives model-version bumps.
+  const caps = cloudCapabilities({ adapter: 'anthropic', model: 'claude-opus-9-future' });
+  assert.strictEqual(caps.source, 'adapter');
+  assert.strictEqual(isToolCapable(caps.capabilities), true);
+});
+
+// --- per-model override: a real non-tool cloud model ---
+test('embedding model override is not tool-capable (excluded from tools job)', () => {
+  const caps = cloudCapabilities({ adapter: 'openai', model: 'text-embedding-3-small' });
+  assert.strictEqual(caps.source, 'model-override');
+  assert.deepStrictEqual(caps.capabilities, ['embedding']);
+  assert.strictEqual(isToolCapable(caps.capabilities), false);
+});
+
+test('override wins over the adapter profile', () => {
+  // openai adapter alone is tool-capable; the embedding model override overrides it.
+  const adapterOnly = cloudCapabilities({ adapter: 'openai', model: 'gpt-4o' });
+  assert.strictEqual(isToolCapable(adapterOnly.capabilities), true);
+  const overridden = cloudCapabilities({ adapter: 'openai', model: 'text-embedding-3-large' });
+  assert.strictEqual(isToolCapable(overridden.capabilities), false);
+});
+
+// --- unknown: not guessed from the name ---
+test('unrecognized adapter is reported unknown, not guessed', () => {
+  const caps = cloudCapabilities({ adapter: 'some-new-provider', model: 'mystery-model-claude-ish' });
+  assert.strictEqual(caps.source, 'unknown');
+  assert.strictEqual(caps.capabilities, null, 'capability is null, not inferred from the name');
+});
+
+test('missing adapter and model yields unknown', () => {
+  const caps = cloudCapabilities({});
+  assert.strictEqual(caps.source, 'unknown');
+  assert.strictEqual(caps.capabilities, null);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
## Session 1 — Capability Classes + Cloud Descriptors (Declared tier)

Implements Session 1 of the Adaptive Model Selection pack. Cleanup A gave the local roster a capability gate from Ollama's `/api/show`. Cloud players have no `/api/show`, so the tools job treated **every** cloud provider as tool-capable — a non-tool cloud model (an embedding endpoint) would sit in the tools roster it has no business serving, the cloud twin of the local contamination Cleanup A fixed.

### What this builds
- **One shared capability vocabulary** (`capability-classes.js`) — both local (probe) and cloud (descriptor) converge on a `capabilities` array in Ollama's tokens; one predicate set (`isToolCapable`, `classesOf`, …) classifies either. `describeCloudCapabilityClasses()` prints the classed cloud roster.
- **A cloud descriptor as a datasheet** (`cloud-model-descriptor.js`) — keyed on the **adapter** the deployer configured (the published API contract, stable across model-version bumps), with per-model overrides for facts that vary within a provider. An adapter/model with no entry is reported `unknown` and logged, **never guessed from its name** (NO REGEX FOR INTELLIGENCE).
- **The capability gate spans cloud** — the `tools` job draws only from tool-capable cloud models. A declared-non-tool model is excluded; an unknown model is kept (never dark) and logged once.

### Scope discipline
Declared tier for cloud only. The cost prior, smart-mix rewrite, maturation loop, judge, and niche assignment are later sessions. Non-tools jobs are unchanged this session.

### Honesty seam
Two text-generation predicates on purpose: `isTextGeneration` is honest class membership (a multimodal generalist that also sees images is still a text generator), `isDedicatedTextGenerator` is the local roster's stricter policy (exclude vision/embedding specialists like llava). The cloud tools gate keys on `isToolCapable`, so vision-additive generalists (Claude) qualify. ModelScout's local behavior is unchanged (delegates to the shared module).

### Verification
- `npm run test:unit`: **223/223 test files pass** (20 new unit tests across the three files; all pre-existing router/scout tests green → gate is a no-op for the reference cloud-ok roster, no regression).
- Live on the box, real provider config + one synthetic embedding cloud endpoint injected to prove the gate bites:

```
[LLMRouter] Cloud capability classes (smart-mix): anthropic-claude[text-generation/tool-capable/vision], claude-sonnet[text-generation/tool-capable/vision], claude-haiku[text-generation/tool-capable/vision], openai-embed[embedding]

tools = ["claude-haiku","ollama-local"]      # openai-embed ($0.02, cheapest) EXCLUDED — declared embedding-only
thinking = [...,"openai-embed",...]          # ungated this session (Session 2), confirming tools-only scope
```

`[VERIFIED: session-1: shared capability-class abstraction covers local (Ollama capabilities) and cloud (per-provider adapter datasheet + model overrides); cloud tool-job gated to tool-capable cloud models (embedding endpoint excluded, cheapest but non-tool); classed roster log shows anthropic-claude/claude-sonnet/claude-haiku = text-generation/tool-capable/vision, openai-embed = embedding; tests 223/223 files.]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)