### PR TITLE
feat(llm): per-job prior strength + resolver-driven smart-mix boundary (Layer 1)

### DIFF
--- a/src/lib/llm/router.js
+++ b/src/lib/llm/router.js
@@ -17,7 +17,7 @@
 
 const { createProvider } = require('./providers');
 const { cloudCapabilities } = require('../providers/cloud-model-descriptor');
-const { isToolCapable, classesOf } = require('../providers/capability-classes');
+const { isToolCapable, isTextGeneration, classesOf } = require('../providers/capability-classes');
 const RateLimitTracker = require('./rate-limit-tracker');
 const BudgetEnforcer = require('./budget-enforcer');
 const BackoffStrategy = require('./backoff-strategy');
@@ -40,6 +40,21 @@ const JOBS = Object.freeze({
 });
 const VALID_JOBS = new Set(Object.values(JOBS));
 const PRESET_NAMES = Object.freeze(['all-local', 'smart-mix', 'cloud-first']);
+
+/**
+ * Per-job cloud DEPTH policy over the cost-ranked eligible list.
+ *   'cheapest'  — single cheapest capable cloud, then local (RouteLLM: most
+ *                 work needs no depth).
+ *   'mid-first' — mid-tier then cheapest (coding: WEAK prior placeholder, same
+ *                 shape as today; Session 3 corrects with measurement).
+ *   'depth'     — costliest → mid → cheapest (thinking/writing need depth).
+ * Jobs absent default to 'cheapest'. credentials is never here (local-only).
+ */
+const CLOUD_DEPTH = Object.freeze({
+  quick: 'cheapest', classification: 'cheapest', synthesis: 'cheapest',
+  decomposition: 'cheapest', research: 'cheapest', tools: 'cheapest',
+  coding: 'mid-first', thinking: 'depth', writing: 'depth',
+});
 
 class LLMRouter {
   /**
@@ -617,21 +632,10 @@ class LLMRouter {
         roster[job] = job === JOBS.QUICK ? [...fastFirstLocal] : [...localIds];
       }
     } else if (presetName === 'smart-mix' || presetName === 'cloud-first') {
-      // Job→model tier mapping (same for both modes):
-      //   synthesis/decomposition/classification → cheapest (Haiku)
-      //   tools                                 → cheapest (Haiku) → local
-      //   research/coding                       → mid-tier (Sonnet) → cheapest
-      //   thinking/writing                      → top-tier (Opus) → mid → cheapest
-      //
-      // smart-mix: local fallbacks after cloud
-      // cloud-first: cloud only, no local fallbacks
-      const { heavy, workhorse, rest } = this._classifyCloudProviders(cloudIds);
-      // Cost tiers: heavy=most expensive, workhorse=second, rest=remaining (desc)
-      // With 1 provider: heavy === workhorse, rest empty → all tiers collapse
-      // With 2 providers: heavy=expensive, workhorse=cheap → midTier=heavy, cheapest=workhorse
-      // With 3+: heavy=top, workhorse=mid, rest has cheapest at end
-      const cheapest = [...rest].reverse()[0] || workhorse || heavy;
-      const midTier = rest.length > 0 ? workhorse : heavy || workhorse;
+      // cloud-first zeroes local fallbacks; smart-mix keeps them (last-local rule
+      // still applies in _buildRosterChain). Per-job cloud chain comes from the ONE
+      // generating function: capability-eligible-per-job × cost rank × depth policy.
+      const cloudFirst = presetName === 'cloud-first';
 
       // Sort local providers: ollama-fast first for QUICK chain speed
       const fastFirst = [...localIds].sort((a, b) => {
@@ -640,34 +644,15 @@ class LLMRouter {
         return 0;
       });
 
-      const local = presetName === 'cloud-first' ? [] : localIds;
-      const localFast = presetName === 'cloud-first' ? [] : fastFirst;
+      const local = cloudFirst ? [] : localIds;
+      const localFast = cloudFirst ? [] : fastFirst;
 
-      // Quick tasks: cheapest cloud first (Haiku — 2s, reliable), local fallback
-      roster[JOBS.QUICK] = [...new Set([cheapest, ...localFast].filter(Boolean))];
-      // Classification: Haiku first (reliable compound detection), local fallback
-      roster[JOBS.CLASSIFICATION] = [...new Set([cheapest, ...local].filter(Boolean))];
-
-      // Comprehension: cheapest cloud (Haiku — $0.002, 2s, any language), local fallback
-      roster[JOBS.SYNTHESIS] = [...new Set([cheapest, ...local].filter(Boolean))];
-      roster[JOBS.DECOMPOSITION] = [...new Set([cheapest, ...local].filter(Boolean))];
-
-      // Tools: cheapest cloud first (Haiku — reliable structured output, 2-3s),
-      // local fallback for sovereign mode. Local models (qwen3:8b) take 60-70s
-      // and produce unreliable structured JSON. Capability gate (Declared, cloud):
-      // the tools job draws only from tool-capable cloud models, so a non-tool
-      // cloud model (an embedding endpoint) never lands in the tools roster.
-      const toolCloud = this._classifyCloudProviders(this._toolCapableCloudIds(cloudIds));
-      const toolCheapest = [...toolCloud.rest].reverse()[0] || toolCloud.workhorse || toolCloud.heavy;
-      roster[JOBS.TOOLS] = [...new Set([toolCheapest, ...local].filter(Boolean))];
-
-      // Research: cheapest cloud (Haiku — sufficient quality, ~10x cheaper than Sonnet)
-      roster[JOBS.RESEARCH] = [...new Set([cheapest, ...local].filter(Boolean))];
-      roster[JOBS.CODING] = [...new Set([midTier, cheapest, ...local].filter(Boolean))];
-
-      // Deep/complex: top-tier cloud (Opus), mid fallback, local last
-      roster[JOBS.THINKING] = [...new Set([heavy, midTier, cheapest, ...local].filter(Boolean))];
-      roster[JOBS.WRITING] = [...new Set([heavy, midTier, cheapest, ...local].filter(Boolean))];
+      const cloudChains = this._buildCloudJobChains(cloudIds);
+      for (const job of VALID_JOBS) {
+        if (job === JOBS.CREDENTIALS) continue;
+        const localPart = job === JOBS.QUICK ? localFast : local;
+        roster[job] = [...new Set([...(cloudChains[job] || []), ...localPart].filter(Boolean))];
+      }
     }
 
     // credentials: prefer credential-specific local provider, then all other local
@@ -716,27 +701,94 @@ class LLMRouter {
   }
 
   /**
-   * Filter cloud provider IDs to those a datasheet declares tool-capable. A
-   * model the descriptor does not know is kept (never drop a working provider on
-   * a gap in the datasheet) but logged once so a maintainer adds it. A model the
-   * descriptor declares non-tool (e.g. an embedding endpoint) is excluded.
+   * Filter cloud provider IDs to those a datasheet declares eligible for a
+   * capability predicate (isTextGeneration for text jobs, isToolCapable for
+   * tools/coding). A model the descriptor does not know is KEPT (never drop a
+   * working provider on a datasheet gap — fail-open) and logged ONCE. A model
+   * the descriptor declares out-of-class (an embedding endpoint vs a text job)
+   * is excluded.
    * @private
    * @param {string[]} cloudIds
+   * @param {(caps:string[])=>boolean} predicate
    * @returns {string[]}
    */
-  _toolCapableCloudIds(cloudIds) {
+  _eligibleCloudIds(cloudIds, predicate) {
     return cloudIds.filter((id) => {
       const caps = this._cloudCapabilitiesOf(id);
       if (!caps || caps.source === 'unknown' || caps.capabilities === null) {
         if (!this._loggedUnknownCloudCaps.has(id)) {
           this._loggedUnknownCloudCaps.add(id);
           const model = this.providers.get(id)?.model || '(unknown model)';
-          console.log(`[LLMRouter] Cloud model not in capability descriptor: ${id} (${model}); assuming tool-capable and keeping it in the tools roster. Add it to cloud-model-descriptor.js.`);
+          console.log(`[LLMRouter] Cloud model not in capability descriptor: ${id} (${model}); keeping it in chains (fail-open). Add it to cloud-model-descriptor.js.`);
         }
         return true;
       }
-      return isToolCapable(caps.capabilities);
+      return predicate(caps.capabilities);
     });
+  }
+
+  /**
+   * Cost tiers over a cost-ranked eligible cloud list. Reuses
+   * _classifyCloudProviders (output-cost DESC → heavy/workhorse/rest) — the
+   * single custody basis is provider.costModel.outputPer1M (NOT
+   * CostTracker.PRICING; see issues-to-file). Budget is NOT consulted here: it is
+   * a LIVE input applied per-candidate at chain execution
+   * (BudgetEnforcer.canSpend, router.js execution path) and must not be
+   * duplicated into the static prior.
+   * @private
+   * @param {string[]} eligibleIds
+   * @returns {{ heavy: string|null, workhorse: string|null, rest: string[], cheapest: string|null }}
+   */
+  _costTiers(eligibleIds) {
+    const c = this._classifyCloudProviders(eligibleIds);
+    const cheapest = [...c.rest].reverse()[0] || c.workhorse || c.heavy;
+    return { ...c, cheapest };
+  }
+
+  /**
+   * Select the cloud tier chain for a job from its cost tiers and depth policy.
+   * excludeHeavy=true reproduces _buildCloudFastRoster's flat, no-Opus semantics.
+   * @private
+   */
+  _cloudDepthChain(job, tiers, { excludeHeavy = false } = {}) {
+    const { heavy, workhorse, rest, cheapest } = tiers;
+    if (excludeHeavy) {
+      // cloud-fast: flat [cheapest, mid], NO heavy tier. mid is null when it
+      // would collapse onto heavy (1-cloud case) — matches current lines 780/793.
+      const mid = rest.length > 0 ? workhorse : (workhorse !== heavy ? workhorse : null);
+      return [cheapest, mid].filter(Boolean);
+    }
+    // midTier: with 3+ clouds = 2nd most expensive (workhorse); with 2 clouds =
+    // the most expensive (heavy); with 1 = the sole cloud. Faithful to line 634.
+    const midTier = rest.length > 0 ? workhorse : (heavy || workhorse);
+    const depth = CLOUD_DEPTH[job] || 'cheapest';
+    if (depth === 'depth') return [heavy, midTier, cheapest].filter(Boolean);
+    if (depth === 'mid-first') return [midTier, cheapest].filter(Boolean);
+    return [cheapest].filter(Boolean);
+  }
+
+  /**
+   * THE generating function. Build every job's cloud chain from (1) per-job
+   * capability eligibility (text-generation for all text jobs — extends Session
+   * 1's tools-only gate so a known embedding endpoint appears in NO text chain,
+   * e.g. quick; tool-capable for tools AND coding) and (2) cost rank + per-job
+   * depth. Computes the two eligible sets ONCE (so unknowns log at most once) and
+   * loops the jobs, replacing the hand-rolled per-job tier assignments.
+   * @private
+   * @param {string[]} cloudIds
+   * @param {{excludeHeavy?: boolean}} [opts]
+   * @returns {Object} job → cloud-only provider-ID chain (local appended by caller)
+   */
+  _buildCloudJobChains(cloudIds, opts = {}) {
+    const textTiers = this._costTiers(this._eligibleCloudIds(cloudIds, isTextGeneration));
+    const toolTiers = this._costTiers(this._eligibleCloudIds(cloudIds, isToolCapable));
+    const out = {};
+    for (const job of VALID_JOBS) {
+      if (job === JOBS.CREDENTIALS) continue; // local-only, handled by caller
+      const tiers = (job === JOBS.TOOLS || job === JOBS.CODING) ? toolTiers : textTiers;
+      out[job] = this._cloudDepthChain(job, tiers, opts);
+    }
+    return out;
   }
 
   /**
@@ -770,29 +822,20 @@ class LLMRouter {
     const localIds = [];
     const cloudIds = [];
     for (const [id, p] of this.providers) {
-      if (p.type === 'local') localIds.push(id);
-      else cloudIds.push(id);
+      if (p.type === 'local') localIds.push(id); else cloudIds.push(id);
     }
-
-    const { heavy, workhorse, rest } = this._classifyCloudProviders(cloudIds);
-    // Exclude heavy (Opus) — use only workhorse (Sonnet) and cheapest (Haiku)
-    const cheapest = [...rest].reverse()[0] || workhorse || heavy;
-    const midTier = rest.length > 0 ? workhorse : (workhorse !== heavy ? workhorse : null);
-    // Build flat chain: cheapest first, mid-tier fallback, local last
-    const chain = [...new Set([cheapest, midTier, ...localIds].filter(Boolean))];
-
+    // Same generating function, excludeHeavy: flat [cheapest, mid] per job, no
+    // Opus. Text jobs are now text-gen-gated too (embedding endpoints excluded);
+    // tools/coding tool-gated. Preserves "no heavy tier".
+    const cloudChains = this._buildCloudJobChains(cloudIds, { excludeHeavy: true });
     const roster = {};
     for (const job of VALID_JOBS) {
-      roster[job] = [...chain];
+      if (job === JOBS.CREDENTIALS) continue;
+      roster[job] = [...new Set([...(cloudChains[job] || []), ...localIds].filter(Boolean))];
     }
-
-    // Capability gate (Declared, cloud): the tools job draws only from
-    // tool-capable cloud models. Same policy as smart-mix/cloud-first.
-    const toolCloud = this._classifyCloudProviders(this._toolCapableCloudIds(cloudIds));
-    const toolCheapest = [...toolCloud.rest].reverse()[0] || toolCloud.workhorse || toolCloud.heavy;
-    const toolMid = toolCloud.rest.length > 0 ? toolCloud.workhorse : (toolCloud.workhorse !== toolCloud.heavy ? toolCloud.workhorse : null);
-    roster[JOBS.TOOLS] = [...new Set([toolCheapest, toolMid, ...localIds].filter(Boolean))];
-
+    const credLocalIds = localIds.filter(id => id.includes('-credential'));
+    const otherLocalIds = localIds.filter(id => !id.includes('-credential'));
+    roster[JOBS.CREDENTIALS] = [...credLocalIds, ...otherLocalIds];
     return roster;
   }
 

--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -15,6 +15,54 @@
 
 const { normalizeCapabilities, isDedicatedTextGenerator } = require('./capability-classes');
 
+/**
+ * Per-job prior STRENGTH — a machine-readable declaration of how much the
+ * size prior is trusted for each job, so tests and Session 3 can read which
+ * priors are placeholders.
+ *   'latency'      — smallest-capable wins; size predicts speed, not quality
+ *                    (quick: pure-latency, no answer key).
+ *   'ground-truth' — NOT a size prior at all. classification defers to the
+ *                    golden-set probe's per-language fixture accuracy via
+ *                    ModelResolver precedence (cockpit > golden-set-probe >
+ *                    model-scout > …). The size ordering ModelScout emits for
+ *                    classification is a fallback only when the probe has no
+ *                    measurement; the probe's ground-truth pick overrides it.
+ *   'strong'       — bigger reasons/writes better on average (thinking/writing/
+ *                    research/credentials).
+ *   'weak'         — PLACEHOLDER. A fine-tuned mid-size model routinely beats a
+ *                    larger generalist; size is a poor proxy. Session 3 replaces
+ *                    this with measured performance (tools/coding).
+ * @type {Readonly<Record<string,'latency'|'ground-truth'|'strong'|'weak'>>}
+ */
+const PRIOR_STRENGTH = Object.freeze({
+  quick: 'latency',
+  classification: 'ground-truth',
+  thinking: 'strong',
+  writing: 'strong',
+  research: 'strong',
+  credentials: 'strong',
+  tools: 'weak',
+  coding: 'weak',
+});
+
+/**
+ * Minimum sensed context_length (tokens) a model must clear to serve a
+ * long-context job. These jobs assemble long prompts — SOUL.md + memory
+ * enrichment + living context + a multi-paragraph answer — so a model whose
+ * window is below the floor would truncate silently. 8192 is deliberately
+ * conservative: it is the smallest window among the reference box's text
+ * models (gemma2:2b = 8192) and roughly the floor at which a full SOUL +
+ * enrichment prompt still leaves room for an answer. Jobs NOT listed have no
+ * floor: quick/classification are short, tools/coding are structured-output
+ * (short context), credentials wants the most capable local model regardless.
+ * @type {Readonly<Record<string, number>>}
+ */
+const CONTEXT_FLOOR = Object.freeze({
+  thinking: 8192,
+  writing: 8192,
+  research: 8192,
+});
+
 class ModelScout {
   /**
    * @param {Object} config
@@ -109,13 +157,16 @@ class ModelScout {
     }
 
     // thinking / writing / research: size is a STRONG prior — bigger models
-    // reason and write better on average — so the largest capable model leads.
-    // credentials stays local (enforced in ModelResolver) and wants the most
-    // capable model on the box.
+    // reason and write better on average — so the largest capable model leads,
+    // subject to the context-length floor (a large model with a short window
+    // would truncate these long prompts). Never-go-dark: if the floor empties
+    // the list, fall back to the ungated largest-first list. credentials stays
+    // local (enforced in ModelResolver) and wants the most capable model on the
+    // box regardless of window (short, sensitive prompts) so it is UNGATED.
     if (largestFirst.length > 0) {
-      roster.thinking = names(largestFirst);
-      roster.writing = names(largestFirst);
-      roster.research = names(largestFirst);
+      roster.thinking = names(this._contextGated(largestFirst, CONTEXT_FLOOR.thinking));
+      roster.writing = names(this._contextGated(largestFirst, CONTEXT_FLOOR.writing));
+      roster.research = names(this._contextGated(largestFirst, CONTEXT_FLOOR.research));
       roster.credentials = names(largestFirst);
     }
 
@@ -136,6 +187,10 @@ class ModelScout {
       this._roster = null;
       return null;
     }
+
+    // Flag the placeholder priors so their weakness is observable in production
+    // and Session 3 knows exactly which pairings it must correct with measurement.
+    this.logger.log('[ModelScout] Prior strength — tools/coding: WEAK (largest tool-capable placeholder, Session 3 replaces with measured performance); classification: GROUND-TRUTH (defers to golden-set probe).');
 
     this._roster = roster;
     return roster;
@@ -263,6 +318,22 @@ class ModelScout {
   }
 
   /**
+   * Apply a context-length floor to an already-sorted model list. A model whose
+   * sensed contextLength is below the floor is excluded — UNLESS excluding would
+   * empty the list, in which case the ungated list is returned (never-go-dark).
+   * A null contextLength PASSES the gate: unknown is not evidence of smallness
+   * (sense-don't-predict). No floor (falsy) is an identity pass-through.
+   * @param {Array} sorted - models pre-sorted by the caller's prior
+   * @param {number} [floor]
+   * @returns {Array}
+   */
+  _contextGated(sorted, floor) {
+    if (!floor) return sorted;
+    const gated = sorted.filter(m => m.contextLength === null || m.contextLength >= floor);
+    return gated.length > 0 ? gated : sorted;
+  }
+
+  /**
    * Extract model family from Ollama model metadata.
    * @param {Object} model - Raw Ollama model object
    * @returns {string}
@@ -302,4 +373,4 @@ class ModelScout {
   }
 }
 
-module.exports = { ModelScout };
+module.exports = { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR };

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -696,8 +696,14 @@ class MessageProcessor {
         // Smart-mix: three-path routing (local text / local tools / cloud)
         // Build live context ONCE — passed to classifier, probes, synthesis, guard
         const liveContext = earlyLiveContext || (session ? buildLiveContext(session, pipelineMessage) : null);
-        const { useLocal, useDomainTools, intent, compound, gate, domain } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
-        console.log(`[Message] Smart-mix classification: ${intent} → ${useLocal ? (useDomainTools ? 'local-tools' : 'local') : 'cloud'}${compound ? ' [COMPOUND]' : ''}${gate ? ` (gate=${gate})` : ''}`);
+        const { useLocalPipeline, useDomainTools, intent, compound, gate, domain } = await this._smartMixClassify(pipelineMessage, session, extracted.token, liveContext);
+        // The classifier names a PIPELINE, not a trust destination — the agent-loop
+        // path's actual model/trust is resolved at the chokepoint (RouterChatBridge),
+        // so the log reads the resolver rather than assuming 'cloud'.
+        const pipelineLabel = useLocalPipeline
+          ? (useDomainTools ? 'local-pipeline+tools' : 'local-pipeline')
+          : `agent-loop (trust=${this._resolveJobTrust('tools')})`;
+        console.log(`[Message] Smart-mix classification: ${intent} → ${pipelineLabel}${compound ? ' [COMPOUND]' : ''}${gate ? ` (gate=${gate})` : ''}`);
 
         // Intent-specific feedback: acknowledge the user immediately (fire-and-forget)
         const lang = this._getLanguage();
@@ -725,7 +731,7 @@ class MessageProcessor {
           });
           result = { intent: `smart_mix_flush:${intent}`, provider: 'agent' };
           response = response || 'Sorry, I encountered an error processing your message.';
-        } else if (compound && useLocal && useDomainTools) {
+        } else if (compound && useLocalPipeline && useDomainTools) {
           // Path 2c: Compound intent — decompose into multi-step plan
           if (this.agentLoop?.llmProvider?.clearLocalSkip) {
             this.agentLoop.llmProvider.clearLocalSkip();
@@ -795,7 +801,7 @@ class MessageProcessor {
               response = response || 'Sorry, I encountered an error processing your message.';
             }
           }
-        } else if (useLocal && useDomainTools && intent === 'confirmation') {
+        } else if (useLocalPipeline && useDomainTools && intent === 'confirmation') {
           // Direct execution from Living Context — bypass AgentLoop entirely
           const offerText = liveContext?.lastAssistantAction?.offer || '';
           console.log(`[Message] Confirmation: executing from context — "${offerText.substring(0, 80)}"`);
@@ -840,7 +846,7 @@ class MessageProcessor {
             result = { intent: 'smart_mix_escalated:confirmation', provider: 'agent' };
             response = response || 'Sorry, I encountered an error processing your message.';
           }
-        } else if (useLocal && useDomainTools && intent === 'knowledge') {
+        } else if (useLocalPipeline && useDomainTools && intent === 'knowledge') {
           // Path 2a: Knowledge query — synthesize from enricher + multi-source probes
           if (this.agentLoop?.llmProvider?.clearLocalSkip) {
             this.agentLoop.llmProvider.clearLocalSkip();
@@ -873,7 +879,7 @@ class MessageProcessor {
             result = { intent: 'smart_mix_escalated:knowledge', provider: 'agent' };
             response = response || 'Sorry, I encountered an error processing your message.';
           }
-        } else if (useLocal && useDomainTools) {
+        } else if (useLocalPipeline && useDomainTools) {
           // Path 2b: Domain-specific — local tool-calling with focused subset
           if (this.agentLoop.llmProvider?.clearLocalSkip) {
             this.agentLoop.llmProvider.clearLocalSkip();
@@ -919,7 +925,7 @@ class MessageProcessor {
             result = { intent: `smart_mix_escalated:${intent}`, provider: 'agent' };
             response = response || 'Sorry, I encountered an error processing your message.';
           }
-        } else if (useLocal) {
+        } else if (useLocalPipeline) {
           // Path 1: Greeting/chitchat — MicroPipeline handles locally (fast, no cloud)
           if (this.agentLoop.llmProvider?.clearLocalSkip) {
             this.agentLoop.llmProvider.clearLocalSkip();
@@ -977,7 +983,7 @@ class MessageProcessor {
             } else {
               response = thinkingResult || "I need a moment to think about that — could you ask again?";
             }
-            result = { intent: 'smart_mix_thinking', provider: 'cloud' };
+            result = { intent: 'smart_mix_thinking', provider: this._resolveJobTrust('thinking') === 'local-only' ? 'local' : 'cloud' };
           } catch (thinkErr) {
             console.warn(`[Message] Thinking query failed, escalating to agentLoop: ${thinkErr.message}`);
             response = await this.agentLoop.process(pipelineMessage, extracted.token, {
@@ -993,10 +999,11 @@ class MessageProcessor {
             response = response || 'Sorry, I encountered an error processing your message.';
           }
         } else {
-          // Path 5: Cloud via AgentLoop — trust boundary handles routing.
-          // Do NOT skipLocalForConversation: the tools job chain includes Haiku
-          // after local providers. Skipping local removes the chain entirely
-          // when Ollama is down, preventing Haiku from handling tool calls.
+          // Path 5: AgentLoop path — the trust chokepoint (RouterChatBridge) resolves the
+          // model per job. Under cloud-ok the tools chain is cheapest-tool-capable-cloud
+          // → local; under local-only it is the best local tool-capable model. Do NOT
+          // skipLocalForConversation: the tools chain includes cloud AFTER local, so
+          // skipping local would empty the chain when Ollama is down.
 
           // Pre-enrich: run MemoryContextEnricher so cloud path sees wiki + deck knowledge
           let cloudSuffix = focusContext
@@ -1606,6 +1613,21 @@ class MessageProcessor {
   }
 
   /**
+   * Resolved trust ('local-only'|'cloud-ok') for a job, read from the single
+   * authority (ModelResolver via the RouterChatBridge). Returns 'unknown' when
+   * the resolver is absent (legacy wiring / tests) so callers never assume a
+   * destination — the chokepoint remains the real enforcement.
+   * @param {string} job
+   * @returns {string}
+   * @private
+   */
+  _resolveJobTrust(job) {
+    const resolver = this.agentLoop && this.agentLoop.llmProvider && this.agentLoop.llmProvider.modelResolver;
+    if (!resolver || typeof resolver.resolveTrust !== 'function') return 'unknown';
+    try { return resolver.resolveTrust(job); } catch { return 'unknown'; }
+  }
+
+  /**
    * Record action(s) from a structured executor response onto the session ledger.
    * Handles both single actionRecord objects and arrays.
    *
@@ -1698,7 +1720,7 @@ class MessageProcessor {
    *
    * @param {string} message
    * @param {Object} [session] - SessionManager session for conversation context
-   * @returns {Promise<{useLocal: boolean, useDomainTools: boolean, intent: string}>}
+   * @returns {Promise<{useLocalPipeline: boolean, useDomainTools: boolean, intent: string}>}
    * @private
    */
   async _smartMixClassify(message, session, roomToken, liveContext) {
@@ -1732,30 +1754,34 @@ class MessageProcessor {
 
       let { gate, intent, domain, compound } = classification;
 
-      // Trust boundary: in smart-mix mode (cloud available), everything goes
-      // through cloud except knowledge (dedicated probe pipeline) and compound
-      // (dedicated decompose pipeline). MicroPipeline only fires in local-only.
+      // The classifier chooses the PIPELINE, never a trust destination. Knowledge →
+      // probe pipeline; compound → decompose pipeline; confirmation/selection/declined
+      // → dedicated handlers; everything else → the AgentLoop path, where
+      // RouterChatBridge resolves the model per job WITHIN the trust boundary (the
+      // one chokepoint). Under local-only the AgentLoop path runs a LOCAL model; this
+      // decision does NOT send anything to cloud.
 
-      // Confirmation/selection → cloud (needs full history)
+      // Confirmation/selection → dedicated handler (needs full history)
       if (intent === 'confirmation' || intent === 'selection') {
-        return { useLocal: false, useDomainTools: false, intent, compound: false, gate, domain };
+        return { useLocalPipeline: false, useDomainTools: false, intent, compound: false, gate, domain };
       }
       if (intent === 'confirmation_declined') {
-        return { useLocal: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate, domain };
+        return { useLocalPipeline: true, useDomainTools: false, intent: 'confirmation_declined', compound: false, gate, domain };
       }
       // Knowledge → dedicated handler (probes, deep reads, web fallback, synthesis)
       if (intent === 'knowledge') {
-        return { useLocal: true, useDomainTools: true, intent, compound: !!compound, gate, domain };
+        return { useLocalPipeline: true, useDomainTools: true, intent, compound: !!compound, gate, domain };
       }
       // Compound + domain → compound handler (already cloud-powered)
       if (compound && DOMAIN_INTENTS.has(intent)) {
-        return { useLocal: true, useDomainTools: true, intent, compound: true, gate, domain };
+        return { useLocalPipeline: true, useDomainTools: true, intent, compound: true, gate, domain };
       }
-      // Everything else → cloud via AgentLoop (Haiku, full tools, web search)
-      return { useLocal: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate, domain };
+      // Everything else → AgentLoop path (full tools). The model + trust are the
+      // chokepoint's call per job; this is a pipeline choice, not a cloud decision.
+      return { useLocalPipeline: false, useDomainTools: false, intent: intent || 'complex', compound: !!compound, gate, domain };
     } catch (err) {
       console.warn(`[Message] Smart-mix classification failed: ${err.message}`);
-      return { useLocal: false, useDomainTools: false, intent: 'error', compound: false, gate: null, domain: null };
+      return { useLocalPipeline: false, useDomainTools: false, intent: 'error', compound: false, gate: null, domain: null };
     }
   }
 

--- a/test/unit/integrations/cost-optimization.test.js
+++ b/test/unit/integrations/cost-optimization.test.js
@@ -141,22 +141,24 @@ test('_handleThinkingQuery skips enricher (slim Opus context)', () => {
 // Test 5: Classification roster puts cheapest provider first
 // ---------------------------------------------------------------------------
 test('Router roster: CLASSIFICATION uses cheapest-first chain', () => {
-  const src = require('fs').readFileSync(
-    require.resolve('../../../src/lib/llm/router.js'),
-    'utf8'
-  );
+  // Behavioral assertion (Session 2 replaced the hand-rolled per-job tier
+  // assignments with the ONE generating function — _buildCloudJobChains —
+  // so there is no longer a literal "roster[JOBS.CLASSIFICATION] = ..." line
+  // to grep for; CLOUD_DEPTH.classification = 'cheapest' governs this instead).
+  // Same cost setup as before: two cloud providers of different price, plus
+  // local — the cheapest capable cloud must lead the classification chain.
+  const LLMRouter = require('../../../src/lib/llm/router');
+  const router = new LLMRouter({
+    providers: {
+      'ollama-local': { adapter: 'ollama', type: 'local', model: 'qwen3:8b', endpoint: 'http://localhost:11434' },
+      'claude-haiku': { adapter: 'anthropic', type: 'api', model: 'claude-haiku-4-5-20251001', costModel: { type: 'per_token', inputPer1M: 0.8, outputPer1M: 4.0 } },
+      'gemini-flash': { adapter: 'google', type: 'api', model: 'gemini-1.5-flash', costModel: { type: 'per_token', inputPer1M: 0.075, outputPer1M: 0.3 } },
+    },
+  });
+  const roster = router._resolvePreset('smart-mix');
 
-  // Match the CLASSIFICATION roster assignment line
-  // e.g. roster[JOBS.CLASSIFICATION] = [...new Set([cheapest, ...local].filter(Boolean))];
-  const match = src.match(/roster\[JOBS\.CLASSIFICATION\]\s*=\s*\[\.\.\.new Set\(\[(.*?)\]/);
-  assert.ok(match, 'CLASSIFICATION roster assignment must be found in router.js');
-
-  // The first element in the array literal must be `cheapest`
-  const arrayContents = match[1].trim();
-  assert.ok(
-    arrayContents.startsWith('cheapest'),
-    `cheapest provider must be first in CLASSIFICATION roster, got: "${arrayContents}"`
-  );
+  assert.strictEqual(roster.classification[0], 'gemini-flash', 'cheapest capable cloud must lead the CLASSIFICATION roster');
+  assert.ok(!roster.classification.includes('claude-haiku'), 'cheapest depth is single-hop — the pricier cloud is not a fallback here');
 });
 
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/llm/router-cloud-capability-gate.test.js
+++ b/test/unit/llm/router-cloud-capability-gate.test.js
@@ -59,13 +59,56 @@ test('cloud-first tools job excludes the non-tool cloud model', () => {
   assert.ok(!roster.tools.includes('openai-embed'));
 });
 
-test('non-tools cloud jobs are untouched this session (scope: tools gate only)', () => {
-  // Session 1 gates only the tools job. Other jobs keep cost-tier selection
-  // unchanged (broader per-job capability gating is Session 2). The cheapest
-  // cloud provider still leads a non-tool job.
+test('embedding endpoint excluded from ALL text job chains (Session 2: broader per-job gating)', () => {
+  // Session 1 gated only the tools job. Session 2 generalizes the gate to every
+  // job: the embedding endpoint (known capabilities: ['embedding']) must not
+  // appear in ANY text-generation chain, not just tools.
   const router = routerWithEmbeddingTrap();
   const roster = router._resolvePreset('smart-mix');
-  assert.strictEqual(roster.thinking[0], 'claude-haiku', 'depth job unchanged (Haiku is the priciest → heavy tier here)');
+  const textJobs = ['quick', 'classification', 'synthesis', 'decomposition', 'research', 'thinking', 'writing'];
+  for (const job of textJobs) {
+    assert.ok(!roster[job].includes('openai-embed'), `${job} chain must exclude the embedding endpoint`);
+    assert.strictEqual(roster[job][0], 'claude-haiku', `${job} chain should lead with the tool-capable/text-gen cloud, not the cheaper embedding endpoint`);
+  }
+});
+
+/**
+ * Router with a local model and two descriptor-known, tool-capable cloud
+ * models at different price points (anthropic Haiku pricier, google Gemini
+ * Flash cheaper) — exercises the cost-tier chain (_costTiers/_cloudDepthChain)
+ * against real adapters rather than the bare mock providers in router-jobs.test.js.
+ */
+function routerWithTwoCapableClouds() {
+  const router = new LLMRouter({
+    providers: {
+      'ollama-local': { adapter: 'ollama', type: 'local', model: 'qwen3:8b', endpoint: 'http://localhost:11434' },
+      'claude-haiku': { adapter: 'anthropic', type: 'api', model: 'claude-haiku-4-5-20251001', costModel: { type: 'per_token', inputPer1M: 0.8, outputPer1M: 4.0 } },
+      'gemini-flash': { adapter: 'google', type: 'api', model: 'gemini-1.5-flash', costModel: { type: 'per_token', inputPer1M: 0.075, outputPer1M: 0.3 } },
+    },
+  });
+  return router;
+}
+
+test('quick picks the cheapest capable cloud', () => {
+  const router = routerWithTwoCapableClouds();
+  const roster = router._resolvePreset('smart-mix');
+  assert.strictEqual(roster.quick[0], 'gemini-flash', 'cheapest capable cloud (Gemini Flash) leads quick');
+  assert.ok(!roster.quick.includes('claude-haiku'), 'cheapest depth is single-hop — the pricier cloud is not a fallback here');
+});
+
+test('thinking picks costliest-first (depth)', () => {
+  const router = routerWithTwoCapableClouds();
+  const roster = router._resolvePreset('smart-mix');
+  assert.strictEqual(roster.thinking[0], 'claude-haiku', 'depth job leads with the costliest capable cloud');
+  assert.strictEqual(roster.thinking[1], 'gemini-flash', 'mid/cheaper cloud is the next fallback');
+  assert.strictEqual(roster.thinking[2], 'ollama-local', 'local last (last-local rule)');
+});
+
+test('coding is tool-capable-gated (mid-first)', () => {
+  const router = routerWithEmbeddingTrap();
+  const roster = router._resolvePreset('smart-mix');
+  assert.ok(!roster.coding.includes('openai-embed'), 'embedding endpoint excluded from coding');
+  assert.strictEqual(roster.coding[0], 'claude-haiku', 'coding leads with the tool-capable cloud (mid-tier policy)');
 });
 
 test('unrecognized cloud model is kept in the tools roster (never dark) + logged once', () => {

--- a/test/unit/llm/router.test.js
+++ b/test/unit/llm/router.test.js
@@ -1345,6 +1345,25 @@ if (LegacyLLMRouter) {
     assert.ok(ids.includes('claude-haiku'), 'cloud-fast: Haiku included');
   });
 
+  test('cloud-fast roster keeps credentials local-only (no cloud id in the chain)', () => {
+    const router = new LLMRouter({ auditLog: createMockAuditLog(), notifyUser: createMockNotifyUser() });
+    router.providers.set('anthropic-claude', opusProvider);
+    router.providers.set('claude-sonnet', sonnetProvider);
+    router.providers.set('claude-haiku', cloudProvider);
+    router.providers.set('ollama-fast', localProvider);
+
+    // Roster-level pin: the cloud-fast roster itself never lists cloud under
+    // credentials (key material never leaves the box), independent of the
+    // buildProviderChain enforcement that also blocks it downstream.
+    const roster = router._buildCloudFastRoster();
+    const cloudIds = ['anthropic-claude', 'claude-sonnet', 'claude-haiku'];
+    assert.ok(roster.credentials.length > 0, 'cloud-fast: credentials chain non-empty');
+    assert.ok(
+      roster.credentials.every(id => !cloudIds.includes(id)),
+      'cloud-fast roster: credentials chain is local-only'
+    );
+  });
+
   test('buildProviderChain: cloudTier fast uses flat roster (no job escalation)', () => {
     const router = new LLMRouter({ auditLog: createMockAuditLog(), notifyUser: createMockNotifyUser() });
     router.providers.set('anthropic-claude', opusProvider);
@@ -1372,6 +1391,23 @@ if (LegacyLLMRouter) {
     const { chain } = router.buildProviderChain('writing', { allowCloud: true });
     const ids = chain.map(e => e.id);
     assert.ok(ids.includes('anthropic-claude'), 'smart-mix writing: Opus included');
+  });
+
+  test('buildProviderChain: forceLocal on a smart-mix roster with a cloud primary returns no cloud provider (trust-narrowing invariant)', () => {
+    // A cloud-primary job (tools) under a smart-mix roster normally leads with
+    // cloud. forceLocal must narrow the chain to local-only regardless — this is
+    // the router-level guarantee the trust chokepoint (RouterChatBridge) relies on.
+    const router = new LLMRouter({ auditLog: createMockAuditLog(), notifyUser: createMockNotifyUser() });
+    router.providers.set('claude-haiku', cloudProvider);
+    router.providers.set('ollama-fast', localProvider);
+    router.providers.set('ollama-local', localProvider2);
+    router.setPreset('smart-mix');
+
+    const { chain } = router.buildProviderChain('tools', { forceLocal: true });
+    assert.ok(chain.length > 0, 'forceLocal must still yield a usable chain');
+    for (const entry of chain) {
+      assert.strictEqual(entry.provider.type, 'local', `forceLocal chain must contain only local providers, found ${entry.id}`);
+    }
   });
 }
 

--- a/test/unit/providers/model-scout.test.js
+++ b/test/unit/providers/model-scout.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
-const { ModelScout } = require('../../../src/lib/providers/model-scout');
+const { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR } = require('../../../src/lib/providers/model-scout');
 
 // A realistic mixed pool: two tool-capable chat models of different sizes, a
 // small text-only chat model, an embedding model, and a vision model.
@@ -203,6 +203,95 @@ scenario('generateLocalRoster() returns null when only non-text models exist', a
     await scout.discover();
     assert.strictEqual(scout.generateLocalRoster(), null);
   });
+});
+
+// -- context-length gate: excludes a large low-context model from long-context
+// jobs, but only for the jobs that carry a CONTEXT_FLOOR. Bespoke pool (not the
+// shared TAGS_MODELS/SHOW_BY_MODEL) to avoid cross-test coupling. --
+scenario('context gate excludes a large low-context model from long-context jobs', async () => {
+  const tags = [
+    { name: 'big-shortctx:14b', model: 'big-shortctx:14b', size: 9000000000, modified_at: '2025-02-01T10:00:00Z', details: { family: 'bigmodel', parameter_size: '14B', format: 'gguf' } },
+    { name: 'qwen3:8b', model: 'qwen3:8b', size: 5200000000, modified_at: '2025-01-20T10:00:00Z', details: { family: 'qwen3', parameter_size: '8.2B', format: 'gguf' } },
+  ];
+  const show = {
+    'big-shortctx:14b': { capabilities: ['completion'], model_info: { 'bigmodel.context_length': 4096 } },
+    'qwen3:8b': { capabilities: ['completion', 'tools'], model_info: { 'qwen3.context_length': 40960 } },
+  };
+  await withMock(mockFetch(tags, show), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const roster = scout.generateLocalRoster();
+
+    // The larger model (14B) has a 4096 window — below the 8192 floor — so it
+    // is gated out of thinking despite being the largest.
+    assert.strictEqual(roster.thinking[0], 'qwen3:8b', 'low-context 14B model must be gated out of thinking');
+    assert.ok(!roster.thinking.includes('big-shortctx:14b'), 'low-context model excluded from thinking');
+
+    // quick is ungated (no CONTEXT_FLOOR entry) — the low-context model still
+    // serves it, proving the gate is job-scoped, not a global exclusion.
+    assert.ok(roster.quick.includes('big-shortctx:14b'), 'quick is ungated — low-context model still eligible');
+  });
+});
+
+scenario('context gate never goes dark — all-low-context falls back ungated', async () => {
+  const tags = [
+    { name: 'qwen3:8b', model: 'qwen3:8b', size: 5200000000, modified_at: '2025-01-20T10:00:00Z', details: { family: 'qwen3', parameter_size: '8.2B', format: 'gguf' } },
+    { name: 'gemma2:2b', model: 'gemma2:2b', size: 1600000000, modified_at: '2025-01-10T10:00:00Z', details: { family: 'gemma2', parameter_size: '2.6B', format: 'gguf' } },
+  ];
+  const show = {
+    'qwen3:8b': { capabilities: ['completion', 'tools'], model_info: { 'qwen3.context_length': 4096 } },
+    'gemma2:2b': { capabilities: ['completion'], model_info: { 'gemma2.context_length': 4096 } },
+  };
+  await withMock(mockFetch(tags, show), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const roster = scout.generateLocalRoster();
+
+    // Every model is below the floor — the gate would empty the list, so the
+    // never-go-dark fallback returns the ungated largest-first order.
+    assert.ok(roster.thinking.length > 0, 'thinking must never go dark');
+    assert.strictEqual(roster.thinking[0], 'qwen3:8b', 'ungated largest-first order preserved on fallback');
+  });
+});
+
+scenario('null contextLength passes the gate (unknown is not evidence of smallness)', async () => {
+  const tags = [
+    { name: 'huge:20b', model: 'huge:20b', size: 13000000000, modified_at: '2025-02-05T10:00:00Z', details: { family: 'hugemodel', parameter_size: '20B', format: 'gguf' } },
+    { name: 'qwen3:8b', model: 'qwen3:8b', size: 5200000000, modified_at: '2025-01-20T10:00:00Z', details: { family: 'qwen3', parameter_size: '8.2B', format: 'gguf' } },
+  ];
+  const show = {
+    // No model_info / context_length at all — _extractContextLength returns null.
+    'huge:20b': { capabilities: ['completion'] },
+    'qwen3:8b': { capabilities: ['completion', 'tools'], model_info: { 'qwen3.context_length': 40960 } },
+  };
+  await withMock(mockFetch(tags, show), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const roster = scout.generateLocalRoster();
+
+    assert.ok(roster.thinking.includes('huge:20b'), 'null contextLength passes the gate — unknown is not evidence of smallness');
+    assert.strictEqual(roster.thinking[0], 'huge:20b', 'largest-first order unaffected by an unknown-context model');
+  });
+});
+
+// -- PRIOR_STRENGTH / CONTEXT_FLOOR shape --
+test('PRIOR_STRENGTH shape — tools/coding weak, classification ground-truth', () => {
+  assert.strictEqual(PRIOR_STRENGTH.tools, 'weak');
+  assert.strictEqual(PRIOR_STRENGTH.coding, 'weak');
+  assert.strictEqual(PRIOR_STRENGTH.classification, 'ground-truth');
+  assert.strictEqual(PRIOR_STRENGTH.quick, 'latency');
+  assert.strictEqual(PRIOR_STRENGTH.thinking, 'strong');
+  assert.ok(Object.isFrozen(PRIOR_STRENGTH), 'PRIOR_STRENGTH must be frozen');
+});
+
+test('CONTEXT_FLOOR only long-context jobs', () => {
+  assert.strictEqual(CONTEXT_FLOOR.thinking, 8192);
+  assert.strictEqual(CONTEXT_FLOOR.writing, 8192);
+  assert.strictEqual(CONTEXT_FLOOR.research, 8192);
+  assert.strictEqual(CONTEXT_FLOOR.quick, undefined);
+  assert.strictEqual(CONTEXT_FLOOR.tools, undefined);
+  assert.strictEqual(CONTEXT_FLOOR.credentials, undefined);
+  assert.ok(Object.isFrozen(CONTEXT_FLOOR), 'CONTEXT_FLOOR must be frozen');
 });
 
 // -- hasModel() matches by name and family --

--- a/test/unit/server/message-processor.test.js
+++ b/test/unit/server/message-processor.test.js
@@ -1256,14 +1256,16 @@ asyncTest('TC-D133-04: _smartMixClassify returns domain on compound+domain path'
   assert.ok('domain' in result, 'domain key must be present');
 });
 
-asyncTest('TC-D133-05: _smartMixClassify catch-all cloud path — calendar action carries domain', async () => {
+asyncTest('TC-D133-05: _smartMixClassify catch-all path — calendar action carries domain', async () => {
   // Specimen: {gate:'action',intent:'calendar',domain:'calendar',compound:false}
-  // → domain==='calendar', useLocal===false
+  // → domain==='calendar', useLocalPipeline===false. This routes to the
+  // agent-loop path (not the local pipeline); trust is decided at the
+  // chokepoint (RouterChatBridge), not by this classifier.
   const proc = createSmartMixProcessor({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false });
   const result = await proc._smartMixClassify('book a meeting', null, null, null);
   assert.ok('domain' in result, 'domain key must be present on catch-all cloud path');
   assert.strictEqual(result.domain, 'calendar', 'domain must be calendar');
-  assert.strictEqual(result.useLocal, false, 'calendar action must route to cloud in smart-mix mode');
+  assert.strictEqual(result.useLocalPipeline, false, 'calendar action routes to the agent-loop path, not the local pipeline');
 });
 
 asyncTest('TC-D133-06: _smartMixClassify classify-throws → {gate:null, domain:null, intent:\'error\'} no crash', async () => {
@@ -1305,6 +1307,55 @@ asyncTest('TC-D133-07: _smartMixClassify universal invariant — every path has 
     const result = await proc._smartMixClassify('test', null, null, null);
     assert.ok('domain' in result, `domain key missing for shape: ${JSON.stringify(shape)}`);
   }
+});
+
+asyncTest('_smartMixClassify returns useLocalPipeline (not useLocal) — the lying boolean is gone', async () => {
+  // Structural proof: the returned shape names a pipeline, not a trust
+  // destination. There is no useLocal key anywhere in the result.
+  const proc = createSmartMixProcessor({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false });
+  const result = await proc._smartMixClassify('book a meeting', null, null, null);
+  assert.ok('useLocalPipeline' in result, 'result must carry useLocalPipeline');
+  assert.ok(!('useLocal' in result), 'the old useLocal key must not leak into the returned shape');
+});
+
+asyncTest('action path is not hardcoded to a trust destination', async () => {
+  // The catch-all action path names a PIPELINE (agent-loop), not a cloud
+  // decision — there is no trust field in the returned shape at all. The
+  // absence of a trust field IS the honesty property: the classifier stopped
+  // asserting a destination it does not control.
+  const proc = createSmartMixProcessor({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false });
+  const result = await proc._smartMixClassify('book a meeting', null, null, null);
+  assert.strictEqual(result.useLocalPipeline, false, 'catch-all action does not use the local pipeline');
+  assert.strictEqual(result.useDomainTools, false, 'catch-all action does not use the dedicated domain-tools subset');
+  assert.ok(!('trust' in result), 'no trust field — the chokepoint decides trust, not the classifier');
+  assert.ok(!('useLocal' in result), 'no useLocal leak');
+});
+
+asyncTest('_resolveJobTrust degrades to \'unknown\' without a resolver, reads a stub resolver when present', async () => {
+  // No modelResolver on agentLoop.llmProvider (legacy wiring / tests) → guarded,
+  // never throws, returns 'unknown' so callers never assume a destination.
+  const procNoResolver = createSmartMixProcessor({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false });
+  assert.strictEqual(procNoResolver._resolveJobTrust('tools'), 'unknown', 'no resolver → unknown, never throws');
+
+  // With a stub resolver present, the helper reads through to it.
+  const procWithResolver = createProcessor({
+    intentRouter: { classify: async () => ({ gate: 'action', intent: 'calendar', domain: 'calendar', needsHistory: false, confidence: 0.9, compound: false }) },
+    microPipeline: {
+      _classifyFallback: async () => ({ intent: 'chitchat' }),
+      memoryContextEnricher: null,
+      process: async () => 'local response'
+    },
+    agentLoop: {
+      llmProvider: {
+        resetConversation: function () {},
+        skipLocalForConversation: function () {},
+        chatProviders: new Map([['local', {}], ['cloud', {}]]),
+        modelResolver: { resolveTrust: () => 'local-only' }
+      },
+      process: async () => 'agent response'
+    }
+  });
+  assert.strictEqual(procWithResolver._resolveJobTrust('tools'), 'local-only', 'stub resolver value is read through');
 });
 
 // Summary


### PR DESCRIPTION
# feat(llm): per-job prior strength + resolver-driven smart-mix boundary (Layer 1)

Session 2 of the adaptive-model-selection pack (`briefings/moltagent-adaptive-model-selection.md` §3/§5/§8, briefing 05). Builds on Cleanup A (#223) and Session 1 (#229). This is the session that fixes the routing boundary that failed the local-only reference deployment.

## What changed

**Local prior finished (`src/lib/providers/model-scout.js`)**
- Exported `PRIOR_STRENGTH`: machine-readable per-job declaration of how much the size prior is trusted (`latency` / `ground-truth` / `strong` / `weak`), so Session 3 knows exactly which pairings are placeholders it must correct with measurement. `tools`/`coding` are flagged `weak` in code and in a roster-generation log line.
- `CONTEXT_FLOOR` gates long-context jobs (`thinking`/`writing`/`research`) on the sensed `context_length`: a large model with a short window no longer leads a long-prompt job. `null` context passes (unknown is not evidence of smallness); if the floor would empty a chain, the ungated list stands (never-go-dark). `credentials` stays ungated.
- `classification` is named `ground-truth`: it defers to the golden-set probe (#228) via ModelResolver precedence, not size.

**Cloud cost prior (`src/lib/llm/router.js`)**
- The hand-rolled heavy/workhorse/rest per-job tier assignments collapse into ONE generating function: `_buildCloudJobChains` = per-job capability eligibility × cost rank × `CLOUD_DEPTH` policy (cheapest for shallow jobs; costliest-first for thinking/writing; mid-first for coding, flagged weak).
- The Session-1 capability gate extends from tools-only to **every job**: a known embedding endpoint now appears in NO text chain (previously it could lead the `quick` chain as the cheapest cloud). Unknown descriptors remain fail-open + log-once. `tools` AND `coding` are tool-capability-gated.
- Cost basis stays `provider.costModel` (single custody); budget remains a live per-candidate input at chain execution (`BudgetEnforcer.canSpend`), not duplicated into the static prior.
- Reviewer-found tightening: the cloud-fast roster no longer lists cloud providers under `credentials` (latent quirk; the chokepoint already blocked it downstream — now the roster itself is honest, with a pinning test).

**Smart-mix boundary honesty (`src/lib/server/message-processor.js`)**
- The classifier chooses the PIPELINE, never a trust destination. `useLocal` → `useLocalPipeline` (under `local-only` trust the `false` branch runs a LOCAL model; the old name lied).
- Trust-assuming comments ("everything goes through cloud", "Cloud via AgentLoop (Haiku)") replaced with reads of `ModelResolver.resolveTrust` via a guarded `_resolveJobTrust` helper (degrades to `unknown` when no resolver is wired). The hardcoded `provider: 'cloud'` thinking label now derives from resolved trust.
- No dispatch branch changed; the RouterChatBridge chokepoint remains the only trust enforcement, routed through, never around.

## Trust invariant

Nothing widens. `local-only` narrowing pinned by a new router-level test (cloud-primary tools roster + `forceLocal` → local-only chain). `credentials` local in every roster shape. Live gates below confirm both modes.

## Tests

223/223 unit files. `router-jobs.test.js` passes UNEDITED as the behavior-equivalence guard (all orderings preserved for descriptor-unknown providers). `cost-optimization.test.js` rewritten from a source-text regex assertion to a behavioral one (same invariant, real router). New coverage: context-floor gate (null / floor-empties / job-scoped), `PRIOR_STRENGTH` shape, embedding excluded from all text jobs, quick=cheapest / thinking=costliest-first, coding tool-gated, fail-open log-once, forceLocal narrowing, `useLocalPipeline` structural rename proof, `_resolveJobTrust` null-safety.

## Live verification (both trust modes, real Ollama)

**Local-only (in-process harness: real ModelScout + real Ollama at `[OLLAMA_HOST]` + real LLMRouter/RouterChatBridge/AgentLoop, ToolRegistry with mock clients + spied execute, cloud provider registered in the roster so the chokepoint has something to narrow away):**

- `ModelScout.discover()` sensed 4 models with capabilities (`qwen2.5:3b[completion/tools]`, `gemma2:2b[completion]`, `nomic-embed-text[embedding]`, `qwen3:8b[completion/tools/thinking]`). Generated roster: `tools`/`coding` chains contain **only** tool-capable models; the embedding model appears in **no** text chain; `quick` leads with the smallest model.
- `resolve('tools')` → **qwen3:8b** via `model-scout` (largest tool-capable — not the smallest default that failed the reference deployment).
- EN + DE + PT "rename stack Inbox → Triage": `[RouterChatBridge] Trust local-only — forcing local for job tools` logged on **every** iteration in all three languages; `deck_rename_stack` parsed and dispatched (spy hit) with correct args in all three. The failover chain stayed local (`ollama-local → ollama-fast`); the registered cloud provider never entered it.
- Negative control: identical roster under `cloud-ok` → raw chain `[fake-cloud, ollama-local, ollama-fast]` and fake-cloud **was** invoked (threw by design) — proving local-only narrowing happens at the trust chokepoint, not because cloud was absent.
- Honesty note: Ollama was cold/contended during the run (#124), so `ollama-local` timed out and the tool calls were served by the `ollama-fast` fallback (qwen2.5:3b). The chain policy under test is what's verified live; the qwen3:8b pick is verified at resolve-time.

**Cloud-ok (scratch instance on `:3999` booted from this branch with the live unit's env + credentials, `INITIATIVE_LEVEL=0`, killed after evidence; driven by forged signed Talk webhooks to fake room tokens — reads only):**

- Startup: `Cloud capability classes (smart-mix): anthropic-claude[text-generation/tool-capable/vision], claude-sonnet[…], claude-haiku[…]`; local roster mapped for all 8 jobs with the embedding model in no text job.
- Classification under cloud-ok → Haiku (`Trust=cloud-ok → classification path: cloud/router (Haiku)`), all languages.
- EN action ("Show me the cards on my board") → gate=action/deck → agent-loop `trust=cloud-ok`; `Routed to claude-haiku (job: tools)` — the **cheapest tool-capable** cloud; deck tool executed; reply posted (`chat_outgoing`).
- Thinking message → `smart_mix_thinking`; `llm_call task=thinking provider=anthropic-claude model=claude-opus-4-6` — **costliest-first** for the thinking job, with `Pre-skipping local providers` from the resolver-driven boundary.
- Quick/greeting message → Haiku (cheapest), reply posted.
- DE + PT action messages → gate=action/deck, tools → claude-haiku, `deck_overview` fired, localized replies posted in German and Portuguese (multilingual gate).

## Behavior notes for review

- Cheapest-depth cloud chains stay single-hop (cheapest → local), faithful to the locked assertions in `router-jobs.test.js` — not a full ascending cost chain.
- cloud-fast text jobs are now text-generation-gated too (embedding exclusion consistency) — an intended extension beyond Session 1's tools-only gate.
- With exactly 2 cloud providers, "mid-tier" is the costlier one (pre-existing formula, reproduced faithfully; noted so Session 3 doesn't inherit the label as truth).

## Follow-ups to file

1. `CostTracker.PRICING` vs `provider.costModel` drift — two price homes; routing sorts on `costModel` (kept as single custody basis), accounting reads `PRICING`. Converge on one source.
2. Session 3 anchor: `tools`/`coding` weak prior (local largest-tool-capable, cloud mid-first) must be corrected by measured performance; `PRIOR_STRENGTH` + `CLOUD_DEPTH` mark the seam.
3. `tools` golden-set fixture (spec §5: tools becomes ground-truth once its fixture ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
