### PR TITLE
fix(probe): deterministic measurement + selection hysteresis (#232), post-probe resolver visibility (#233)

### DIFF
--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -460,10 +460,12 @@ class IntentRouter {
    * @param {boolean} [opts.slow=false]
    * @param {string} [opts.language] - Force a specific language's examples
    *   (e.g. for the golden-set probe). Defaults to the cockpit language.
+   * @param {Object} [opts.options] - Ollama decoding options merged over the
+   *   defaults (the golden-set probe pins temperature/seed for determinism).
    * @returns {Promise<{intent: string, domain: string|null, needsHistory: boolean, confidence: number}>}
    * @private
    */
-  async _classifyWithModel(model, message, recentContext = [], { slow = false, language } = {}) {
+  async _classifyWithModel(model, message, recentContext = [], { slow = false, language, options } = {}) {
     const userContent = this._buildUserContent(message, recentContext);
     // The primary (smart) classifier gets 4x the timeout; the fast fallback runs
     // on the base timeout. The caller signals which via `slow`, so timeout
@@ -479,7 +481,8 @@ class IntentRouter {
       format: INTENT_SCHEMA,
       options: {
         num_ctx: 2048,
-        temperature: 0.1
+        temperature: 0.1,
+        ...(options || {})
       }
     });
 
@@ -490,7 +493,11 @@ class IntentRouter {
    * Classify one message with a specific model + language, for the
    * golden-set probe (measured per-language accuracy, not size, picks the
    * classification model). Runs the SAME classification path production
-   * uses so the probe scores exactly what production consumes.
+   * uses so the probe scores exactly what production consumes — except
+   * decoding: the probe pins temperature 0 and a fixed seed so the same
+   * model on the same fixture scores identically run-to-run. Production
+   * samples at 0.1; a measurement that flaps on sampling noise (#232)
+   * cannot anchor a selection with hysteresis.
    * @param {string} model - Ollama model name
    * @param {string} message - Message to classify
    * @param {string} language - Language code the fixture example is written
@@ -499,7 +506,11 @@ class IntentRouter {
    * @returns {Promise<{gate: string, domain: string|null}>}
    */
   async probeClassify(model, message, language) {
-    const r = await this._classifyWithModel(model, message, [], { slow: true, language });
+    const r = await this._classifyWithModel(model, message, [], {
+      slow: true,
+      language,
+      options: { temperature: 0, seed: 42 }
+    });
     return { gate: r.gate, domain: r.domain ?? null };
   }
 

--- a/src/lib/llm/golden-set-probe.js
+++ b/src/lib/llm/golden-set-probe.js
@@ -48,6 +48,17 @@ const crypto = require('crypto');
 const DEFAULT_THRESHOLD = 0.75;
 const CACHE_FILENAME = 'golden-set-probe.json';
 
+// Bump when the MEANING of a cached score changes even though model digest and
+// fixture are identical — e.g. the decoding options probeClassify pins (m2:
+// temperature 0 + fixed seed, #232). Old-revision entries then miss the cache
+// and the candidate is re-measured under the new semantics instead of a stale
+// score masquerading as comparable.
+const MEASUREMENT_REV = 2;
+
+// Reserved cache-file key holding the seated selection (hysteresis state, #232).
+// Never collides with measurement keys, which always contain the fixture salt.
+const SELECTION_KEY = '__selection__';
+
 class GoldenSetProbe {
   /**
    * @param {Object} opts
@@ -73,6 +84,13 @@ class GoldenSetProbe {
     // no classifyFn calls, so it is safe to call repeatedly/synchronously
     // after run() without re-probing.
     this._scores = {};
+
+    // The seated model from a previous cycle (hysteresis, #232). Loaded from
+    // the cache file by run(); tests may set it directly. select() consults it:
+    // a passing incumbent keeps the seat unless a SMALLER challenger clears the
+    // bar by at least one fixture example's worth of accuracy, or the incumbent
+    // itself drops below the bar.
+    this._incumbent = null;
   }
 
   /**
@@ -110,6 +128,13 @@ class GoldenSetProbe {
 
     const diskCache = this._loadCache();
     let cacheChanged = false;
+
+    // Restore the seated model from a previous cycle so hysteresis survives
+    // restarts. Only the identity is restored — its scores still have to come
+    // from a current-revision measurement below to count.
+    if (typeof diskCache[SELECTION_KEY]?.model === 'string') {
+      this._incumbent = diskCache[SELECTION_KEY].model;
+    }
 
     for (const candidate of list) {
       const key = this._cacheKey(candidate);
@@ -161,9 +186,21 @@ class GoldenSetProbe {
       }
     }
 
+    const result = this.select(list);
+
+    // Persist the seat only for a passing winner: a least-bad pick is not a
+    // seated incumbent (it holds nothing against future passers). Clearing on
+    // a no-passer cycle means hysteresis never protects a below-bar model.
+    const seated = result.passed ? result.model : null;
+    if (seated !== (diskCache[SELECTION_KEY]?.model ?? null)) {
+      if (seated) diskCache[SELECTION_KEY] = { model: seated, at: new Date().toISOString() };
+      else delete diskCache[SELECTION_KEY];
+      cacheChanged = true;
+    }
+    this._incumbent = seated;
+
     if (cacheChanged) this._saveCache(diskCache);
 
-    const result = this.select(list);
     if (!result.passed && result.model) {
       const threshold = this._threshold();
       const weak = Object.entries(result.scores || {})
@@ -185,6 +222,14 @@ class GoldenSetProbe {
    * (smallest, since candidates are smallest-first) wins. If none pass,
    * the candidate with the highest minimum-language score is chosen and
    * marked `passed: false`.
+   *
+   * Hysteresis (#232): a hard threshold on a noisy measurement has no stable
+   * fixed point at the boundary, so a seated incumbent (`this._incumbent`)
+   * that still passes keeps the seat unless a smaller challenger clears the
+   * bar by at least one fixture example's worth of accuracy (with a
+   * 12-example fixture, +1/12 ≈ 0.084). The incumbent loses the seat only by
+   * dropping below the bar itself. Larger challengers never displace a
+   * passing incumbent — smallest-passer preference already excludes them.
    * @param {Array<{name: string, digest?: string}>} candidates
    * @returns {{model: string|null, scores: Object|null, passed: boolean, reason: string}}
    */
@@ -214,6 +259,29 @@ class GoldenSetProbe {
       return { model: null, scores: null, passed: false, reason: 'no measurements' };
     }
 
+    const incumbent = this._incumbent
+      ? evaluated.find(e => e.candidate.name === this._incumbent && Object.keys(e.scores).length > 0)
+      : null;
+
+    if (incumbent && incumbent.passesAll) {
+      // Seat defense: only a smaller, measured challenger clearing
+      // bar + margin takes the seat.
+      const displaceBar = threshold + this._margin();
+      const incumbentIdx = evaluated.indexOf(incumbent);
+      const challenger = evaluated.find((e, idx) =>
+        idx < incumbentIdx && e.passesAll && e.minScore >= displaceBar
+      );
+      if (challenger) {
+        return {
+          model: challenger.candidate.name,
+          scores: challenger.scores,
+          passed: true,
+          reason: `challenger cleared bar+margin (${challenger.minScore.toFixed(2)} >= ${displaceBar.toFixed(2)}) over incumbent ${incumbent.candidate.name}`
+        };
+      }
+      return { model: incumbent.candidate.name, scores: incumbent.scores, passed: true, reason: 'incumbent holds seat' };
+    }
+
     const passer = evaluated.find(e => e.passesAll);
     if (passer) {
       return { model: passer.candidate.name, scores: passer.scores, passed: true, reason: 'smallest passer' };
@@ -239,6 +307,22 @@ class GoldenSetProbe {
 
   /**
    * @private
+   * One fixture example's worth of accuracy — the coarsest per-example step
+   * across languages (smallest language set dominates), i.e. the smallest
+   * score difference the fixture can actually resolve. Anything under it is
+   * indistinguishable from measurement granularity, so a challenger must
+   * clear the bar by at least this much to displace an incumbent.
+   */
+  _margin() {
+    const counts = Object.values((this.fixture && this.fixture.languages) || {})
+      .map(items => (Array.isArray(items) ? items.length : 0))
+      .filter(n => n > 0);
+    if (counts.length === 0) return 0;
+    return 1 / Math.min(...counts);
+  }
+
+  /**
+   * @private
    * Fixture salt for the cache key: the declared version PLUS a short content
    * hash of the labeled examples and threshold. Deriving from content (not the
    * hand-bumped integer alone) means editing a message or a DE/PT label
@@ -252,7 +336,7 @@ class GoldenSetProbe {
       threshold: this._threshold(),
     });
     const hash = crypto.createHash('sha1').update(content).digest('hex').slice(0, 8);
-    this._salt = `v${version}_${hash}`;
+    this._salt = `v${version}_m${MEASUREMENT_REV}_${hash}`;
     return this._salt;
   }
 

--- a/test/unit/agent/intent-router.test.js
+++ b/test/unit/agent/intent-router.test.js
@@ -562,4 +562,23 @@ test('#133: action verdict domain survives unchanged', () => {
   assert.strictEqual(result.intent, 'calendar', 'action intent shim must stay domain name');
 });
 
+// -- Determinism (#232): the golden-set probe path pins decoding --
+asyncTest('probeClassify() pins temperature 0 and a fixed seed; classify() keeps production sampling', async () => {
+  const captured = [];
+  const router = new IntentRouter({
+    provider: { chat: async (req) => { captured.push(req.options); return { content: '{"intent":"greeting"}' }; } },
+    config: { classifyTimeout: 5000 },
+    getTrust: () => 'local-only',
+    getSmartModel: () => 'smart-model'
+  });
+
+  await router.probeClassify('probe-model', 'hello', 'EN');
+  assert.strictEqual(captured[0].temperature, 0, 'probe must decode at temperature 0');
+  assert.ok(Number.isFinite(captured[0].seed), 'probe must pin a fixed seed');
+
+  await router.classify('hello');
+  assert.strictEqual(captured[1].temperature, 0.1, 'production classification keeps its own sampling');
+  assert.strictEqual(captured[1].seed, undefined, 'production classification must not inherit the probe seed');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 100);

--- a/test/unit/llm/golden-set-probe.test.js
+++ b/test/unit/llm/golden-set-probe.test.js
@@ -381,6 +381,158 @@ test('TC-PROBE-012: setGroundTruthOverride guards against a falsy job', () => {
   assert.doesNotThrow(() => resolver.setGroundTruthOverride('', 'x'));
 });
 
+// ============================================================
+// Hysteresis (#232): a passing incumbent holds the seat unless a smaller
+// challenger clears bar + one-fixture-example margin, or the incumbent
+// itself drops below the bar. Test fixture: 4 examples/language, bar 0.75,
+// margin 1/4 = 0.25 → displace bar = 1.00.
+// ============================================================
+
+console.log('\n--- Hysteresis (#232) ---\n');
+
+// classifyFn answering the first `correctPerLang[model]` examples of every
+// language correctly and the rest wrong — controlled per-model accuracy.
+function accuracyClassifyFn(fixture, correctPerModel) {
+  const truth = truthMap(fixture);
+  const position = {};
+  for (const items of Object.values(fixture.languages)) {
+    items.forEach((item, i) => { position[item.message] = i; });
+  }
+  return async (model, message) => {
+    const k = correctPerModel[model] ?? 0;
+    if (position[message] < k) return truth[message];
+    return { gate: 'greeting', domain: null };
+  };
+}
+
+asyncTest('TC-HYST-001: challenger at exactly the bar does not displace a passing incumbent', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 3, big: 4 }), // small: 0.75, big: 1.0
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    probe._incumbent = 'big';
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' }
+    ]);
+    assert.strictEqual(result.model, 'big');
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.reason, 'incumbent holds seat');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-HYST-002: challenger clearing bar+margin takes the seat', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 4, big: 4 }), // small: 1.0 >= 0.75+0.25
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    probe._incumbent = 'big';
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' }
+    ]);
+    assert.strictEqual(result.model, 'small');
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.reason.startsWith('challenger cleared bar+margin'), `unexpected reason: ${result.reason}`);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-HYST-003: incumbent below the bar loses the seat to the smallest passer', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 3, big: 2 }), // big: 0.5 < bar; small: 0.75 passes
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    probe._incumbent = 'big';
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' }
+    ]);
+    assert.strictEqual(result.model, 'small');
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.reason, 'smallest passer');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-HYST-004: the seat persists in the cache file and survives a restart', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const candidates = [
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' }
+    ];
+    const probe1 = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 3, big: 4 }),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const r1 = await probe1.run(candidates);
+    assert.strictEqual(r1.model, 'small', 'no incumbent yet: smallest passer wins');
+
+    const persisted = JSON.parse(fs.readFileSync(path.join(cacheDir, 'golden-set-probe.json'), 'utf8'));
+    assert.strictEqual(persisted.__selection__?.model, 'small', 'seat must be persisted');
+
+    // Restart: fresh probe, same cacheDir. Scores come from cache; the seat
+    // must be restored from disk and hold (big never displaces downward,
+    // and nothing smaller than small exists).
+    const probe2 = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 3, big: 4 }),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const r2 = await probe2.run(candidates);
+    assert.strictEqual(r2.model, 'small');
+    assert.strictEqual(r2.reason, 'incumbent holds seat');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-HYST-005: a least-bad (non-passing) pick is not seated as incumbent', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: accuracyClassifyFn(fixture, { small: 1, big: 2 }), // nobody passes
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' }
+    ]);
+    assert.strictEqual(result.passed, false);
+    const persisted = JSON.parse(fs.readFileSync(path.join(cacheDir, 'golden-set-probe.json'), 'utf8'));
+    assert.strictEqual(persisted.__selection__, undefined, 'least-bad must not hold a seat');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
 // Summary
 setTimeout(() => {
   summary();

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -2059,6 +2059,13 @@ async function initialize() {
                 if (sel && sel.model) {
                   modelResolver.setGroundTruthOverride('classification', sel.model);
                   console.log(`[INIT] Golden-set probe: classification -> ${sel.model} (EN ${sel.scores?.EN} DE ${sel.scores?.DE} PT ${sel.scores?.PT}, ${sel.passed ? 'passed' : sel.reason})`);
+                  // The probe lands after the "[INIT] Model resolver:" summary
+                  // (always — the probe is async even on a warm cache), so that
+                  // line never shows the golden-set-probe source (#233). Re-log
+                  // the resolver's ground truth now that the override is in:
+                  // this post-probe line is the one the operator should read.
+                  const { summary } = modelResolver.describe(['tools', 'thinking', 'quick', 'classification']);
+                  console.log(`[INIT] Model resolver (post-probe): ${summary}`);
                 }
               })
               .catch(err => console.warn(`[INIT] Golden-set probe failed: ${err.message}`));


### PR DESCRIPTION
# fix(probe): deterministic measurement + selection hysteresis (#232) and post-probe resolver visibility (#233)

Small fix batch on the two issues filed from the PR #230 deploy session. Scope is exactly #232 (determinism + hysteresis) and #233.

## #232 Part 1 — determinism

**Variance source found:** the probe's classify calls ran through `_classifyWithModel`'s production decoding options — `temperature: 0.1` — so the same model on the same fixture sampled its way to 8/12 one run and 9/12 the next. Fix: `probeClassify` now pins `temperature: 0, seed: 42` via a new options override on `_classifyWithModel`; production classification keeps its own sampling untouched (pinned by test).

The probe cache-key salt gains a measurement revision (`m2`), so pre-deterministic v1 scores can't satisfy the new semantics — the first boot after deploy re-measures every candidate under temp-0, then the cache is warm again.

**Verified:** probe run twice against the boundary model on real Ollama, cold cache both times → identical per-language scores (evidence in the session log below).

## #232 Part 2 — hysteresis

`select()` now consults a seated incumbent:

- A passing incumbent keeps the seat unless a **smaller** challenger clears the bar by **one fixture example's worth of accuracy** (`1/min(per-language example count)`; 12-example fixture → +0.083, displace bar ≈ 0.833).
- The incumbent loses the seat only by dropping below the bar itself.
- Larger challengers never displace a passing incumbent (smallest-passer preference already excludes them).
- A least-bad (non-passing) pick is never seated.
- The seat persists in the probe cache under a reserved `__selection__` key, so hysteresis survives restarts.

For the record (noted on #232, not implemented here): the statistical cure is Session 3's maturation loop — production sample volume shrinks the confidence interval that makes a 12-example fixture flap. This PR treats the symptoms cheaply.

## #233 — override visibility

The `[INIT] Model resolver:` summary always prints before the async probe lands (even warm-cache — same second, but after). Fix: when the override lands, the resolver's `describe()` is re-logged as a clearly marked second line:

```
[INIT] Model resolver (post-probe): tools→… (model-scout), …, classification→<model> (golden-set-probe)
```

The post-probe line is the operator ground truth (#123's line, updated the moment it changes); on a warm-cache boot it appears in the same second as the original summary.

## Tests

Unit: 5 new hysteresis cases (challenger at bar does not displace; challenger at bar+margin does; incumbent below bar loses seat; seat persists across restart via cache file; least-bad never seated) + 1 determinism case (probe pins temp 0/seed; production classification keeps sampling and does not inherit the seed). Full golden-set suite 17/17, intent-router suite 48/48, full unit run in PR checks.

## Live verification (on the box)

**Determinism (standalone double-run, real Ollama, boundary model, cold cache both runs):**

```
[det] Run 1 scores: {"EN":0.75,"DE":0.75,"PT":0.8333333333333334}
[det] Run 2 scores: {"EN":0.75,"DE":0.75,"PT":0.8333333333333334}
[det] IDENTICAL: YES
```

**Restart 1 (branch deployed; m2 revision forces a deterministic re-measure, ~8 min; then the #233 line):**

```
[INIT] Model resolver: tools→qwen3:8b (model-scout), …, classification→gemma2:2b (model-scout)
… (probe replays all candidates under temp 0/seed 42) …
[INIT] Golden-set probe: classification -> qwen2.5:3b (EN 0.75 DE 0.75 PT 0.8333…, passed)
[INIT] Model resolver (post-probe): tools→qwen3:8b (model-scout), thinking→qwen3:8b (model-scout), quick→gemma2:2b (model-scout), classification→qwen2.5:3b (golden-set-probe)
```

Scores match the standalone double-run exactly (third identical measurement). Seat persisted: `__selection__: {"model": "qwen2.5:3b"}` in the probe cache.

**Restart 2 (warm m2 cache — probe application lands the same second as init, ~12s after restart; same pick, same scores, no flap):**

```
12:45:56 [INIT] Model resolver: …, classification→gemma2:2b (model-scout)
12:45:56 [INIT] Golden-set probe: classification -> qwen2.5:3b (EN 0.75 DE 0.75 PT 0.8333…, passed)
12:45:56 [INIT] Model resolver (post-probe): …, classification→qwen2.5:3b (golden-set-probe)
12:45:56 [INIT] Initialization complete
```

Box restored to `next` after evidence capture (prod runs merged code only). Note: the incumbent seat and the m2 measurements persist in the probe cache and take effect on the next boot after this PR merges; the orphaned v1 entries are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
