### PR TITLE
feat(llm): niche assignment composes winners under carrying capacity (Session 5)

### DIFF
--- a/src/lib/agent/intent-router.js
+++ b/src/lib/agent/intent-router.js
@@ -498,6 +498,10 @@ class IntentRouter {
       messages: [{ role: 'user', content: userContent }],
       timeout,
       format: INTENT_SCHEMA,
+      // Probe runs are calibration traffic: the residency ledger records
+      // their loads (real evidence of what co-fits) but excludes them from
+      // thrash detection — the boot burst loads every candidate by design.
+      calibration: probe,
       options: {
         num_ctx: 2048,
         temperature: 0.1,

--- a/src/lib/agent/providers/ollama-tools.js
+++ b/src/lib/agent/providers/ollama-tools.js
@@ -7,6 +7,8 @@
  * @version 1.0.0
  */
 
+const { emitOllamaTimings } = require('../../llm/ollama-timings');
+
 class OllamaToolsProvider {
   /**
    * @param {Object} config
@@ -26,6 +28,9 @@ class OllamaToolsProvider {
     // setting governs (the client must not override the box's resource policy —
     // a hardcoded '10m' evicted indefinitely-pinned models on the DGX host).
     this.keepAlive = config.keep_alive;
+    // Residency-signal sink (Layer 3): receives Ollama's server-side timings
+    // per response, same knob shape as keep_alive. Undefined → no capture.
+    this.onTimings = typeof config.onTimings === 'function' ? config.onTimings : null;
     this.logger = logger || console;
     this._fetch = globalThis.fetch;
   }
@@ -57,9 +62,13 @@ class OllamaToolsProvider {
    * @param {Array} params.messages - Conversation messages
    * @param {Array} params.tools - Tool definitions
    * @param {number} [params.timeout] - Override timeout (ms). If not set, uses toolTimeout for tool requests, default timeout otherwise.
+   * @param {boolean} [params.calibration] - Scheduled measurement traffic
+   *   (golden-set probe, judge idle probes). Rides only the timings emit —
+   *   never sent to Ollama — so the residency ledger can exclude it from
+   *   thrash detection.
    * @returns {Promise<{content: string|null, toolCalls: Array|null}>}
    */
-  async chat({ system, messages, tools, timeout, format, model, options }) {
+  async chat({ system, messages, tools, timeout, format, model, options, calibration }) {
     const ollamaMessages = [];
 
     if (system) {
@@ -147,6 +156,7 @@ class OllamaToolsProvider {
         }
 
         const data = await response.json();
+        emitOllamaTimings(this.onTimings, data, body.model, calibration);
         return this._parseResponse(data);
       })();
 

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -549,15 +549,14 @@ class HeartbeatManager {
 
       // NicheAssignment reconcile (Layer 3): refresh the /api/ps residency
       // snapshot and replan. Runs on EVERY pulse — idle windows included,
-      // since that is when the judge's loads move residency — and is cheap
-      // (one GET + in-memory math). Failure is non-fatal by construction.
+      // since that is when the judge's loads move residency. Fire-and-forget:
+      // the pulse never waits on Ollama I/O (the fetch is bounded to 5s and
+      // the replan is in-memory; the next pulse consumes a fresher snapshot).
       const nicheAssignment = this.getNicheAssignment ? this.getNicheAssignment() : null;
       if (nicheAssignment && typeof nicheAssignment.reconcile === 'function') {
-        try {
-          await nicheAssignment.reconcile();
-        } catch (err) {
+        nicheAssignment.reconcile().catch((err) => {
           console.warn('[Heartbeat] Niche-assignment reconcile error:', err.message);
-        }
+        });
       }
 
       // Check quiet hours and working hours.

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -142,6 +142,20 @@ class HeartbeatManager {
     // its single call site, so judging is never on the request path.
     this.localJudge = config.localJudge || null;
 
+    // NicheAssignment (optional, Layer 3): /api/ps snapshot + replan each
+    // pulse. A thunk, not an instance — it is constructed asynchronously
+    // (after ModelScout discovery), possibly after this manager.
+    this.getNicheAssignment = typeof config.getNicheAssignment === 'function'
+      ? config.getNicheAssignment
+      : null;
+
+    // Residency-signal sink, spread into every local provider this manager
+    // (re)builds on a Cockpit roster change — without it, the adapter
+    // timing capture would silently die on the first roster rebuild.
+    this.onOllamaTimings = typeof config.onOllamaTimings === 'function'
+      ? config.onOllamaTimings
+      : null;
+
     // Cockpit (optional, Deck as control plane)
     this.cockpitManager = config.cockpitManager || null;
 
@@ -530,6 +544,19 @@ class HeartbeatManager {
           }
         } catch {
           // Non-fatal — quiet hours fallback still works
+        }
+      }
+
+      // NicheAssignment reconcile (Layer 3): refresh the /api/ps residency
+      // snapshot and replan. Runs on EVERY pulse — idle windows included,
+      // since that is when the judge's loads move residency — and is cheap
+      // (one GET + in-memory math). Failure is non-fatal by construction.
+      const nicheAssignment = this.getNicheAssignment ? this.getNicheAssignment() : null;
+      if (nicheAssignment && typeof nicheAssignment.reconcile === 'function') {
+        try {
+          await nicheAssignment.reconcile();
+        } catch (err) {
+          console.warn('[Heartbeat] Niche-assignment reconcile error:', err.message);
         }
       }
 
@@ -1906,6 +1933,7 @@ class HeartbeatManager {
           type: isLocal ? 'local' : 'api',
           getCredential,
           costModel: isLocal ? { type: 'free' } : undefined,
+          onTimings: isLocal ? (this.onOllamaTimings || undefined) : undefined,
         });
 
         // Register chat provider with RouterChatBridge
@@ -1915,6 +1943,7 @@ class HeartbeatManager {
             chatProvider = new OllamaToolsProvider({
               endpoint: effectiveEndpoint,
               model: playerDef.model,
+              onTimings: this.onOllamaTimings || undefined,
             });
           } else if (protocol === 'anthropic') {
             chatProvider = new ClaudeToolsProvider({

--- a/src/lib/llm/model-resolver.js
+++ b/src/lib/llm/model-resolver.js
@@ -107,15 +107,58 @@ class ModelResolver {
     // proxying correctness by model size. Deliberately NOT cleared by
     // refresh() — refresh() re-snapshots ModelScout/Cockpit, which have no
     // opinion on measured accuracy; the probe's finding survives until the
-    // probe itself revises or clears it.
-    this._groundTruthOverrides = {};
+    // probe itself revises or clears it. Null-prototype (same discipline as
+    // the scorecard's _entry): a job name like 'constructor' must read as
+    // absent, not as Object.prototype's.
+    this._groundTruthOverrides = Object.create(null);
 
     // Which measurement set each override ('golden-set-probe' at install,
     // 'maturation-loop' once ModelScorecard has production evidence). Pure
     // observability — precedence is identical either way.
-    this._groundTruthSources = {};
+    this._groundTruthSources = Object.create(null);
+
+    // Layer 3 (niche assignment): a memory-feasibility remap computed by
+    // NicheAssignment FROM the resolved winners, applied on top of them.
+    // Not a precedence tier — it consumes the precedence chain's output and
+    // trades per-job fit for co-residence. Like the ground-truth overrides,
+    // deliberately NOT cleared by refresh(): the remap reflects measured
+    // load behaviour on this box, which a Cockpit-card re-read has no
+    // opinion on; NicheAssignment itself replans and re-sets it.
+    this._assignment = null;
 
     this.refresh();
+  }
+
+  /**
+   * Set (or clear) the niche-assignment remap: job → model, computed by
+   * NicheAssignment under the carrying-capacity ceiling. Applied after the
+   * full precedence resolution, never over a cockpit pin (deliberate human
+   * intent outranks a residency optimization), and only to the model field —
+   * trust and provider are untouched.
+   * @param {Object|null} map - { job: modelName } for remapped jobs only.
+   *   Pass null/empty to clear.
+   * @param {string} [source='niche-assignment'] - Surfaces in resolve().source.
+   */
+  setAssignment(map, source = 'niche-assignment') {
+    const hasEntries = map && typeof map === 'object' && Object.keys(map).length > 0;
+    // Null-prototype copy: job names come from code, but a key like
+    // 'constructor' must read as absent, not as Object.prototype's.
+    this._assignment = hasEntries
+      ? { map: Object.assign(Object.create(null), map), source }
+      : null;
+    this._cache.clear();
+  }
+
+  /**
+   * The precedence chain's pick for a job WITHOUT the niche-assignment remap
+   * applied — the "winner" NicheAssignment plans from. Reading winners
+   * through resolve() would feed the assignment its own output back.
+   * Uncached (cheap in-memory math; called only when re-planning).
+   * @param {string} job
+   * @returns {{ model: string|null, trust: string, source: string }}
+   */
+  resolveWinner(job) {
+    return this._resolveUncached(job || 'tools', { applyAssignment: false });
   }
 
   /**
@@ -235,7 +278,7 @@ class ModelResolver {
   // ---------------------------------------------------------------------------
 
   /** @private */
-  _resolveUncached(job) {
+  _resolveUncached(job, { applyAssignment = true } = {}) {
     const scout = this._scoutRoster ? (this._scoutRoster[job] || null) : null;
     const cockpit = this._cockpitModel || null; // explicit local model from the card, if any
     // Measured per-language classification accuracy (GoldenSetProbe), when the
@@ -293,6 +336,20 @@ class ModelResolver {
       // error loudly if the model is truly absent.
     }
 
+    // Layer 3 remap, applied last: the assignment may move this job onto a
+    // co-resident model, trading per-job fit for no cold load. A cockpit win
+    // is exempt — the human pinned that model on purpose. The displaced
+    // winner stays visible in derivation.assignmentWinner so the journal
+    // shows both what won and what runs.
+    if (applyAssignment && this._assignment && source !== 'cockpit-card') {
+      const assigned = this._assignment.map[job];
+      if (typeof assigned === 'string' && assigned && assigned !== model) {
+        derivation.assignmentWinner = model;
+        model = assigned;
+        source = this._assignment.source;
+      }
+    }
+
     derivation.resolved = model;
     const provider = FAST_JOBS.has(job) ? 'ollama-fast' : 'ollama-local';
     return { model, provider, trust, source, derivation, fellBack };
@@ -309,7 +366,8 @@ class ModelResolver {
     }
     if (!roster) return null;
     // Collapse each job's chain to its top pick (a model name).
-    const out = {};
+    // Null-prototype: looked up by job name in _resolveUncached.
+    const out = Object.create(null);
     for (const [job, models] of Object.entries(roster)) {
       if (Array.isArray(models) && models.length > 0) out[job] = models[0];
     }

--- a/src/lib/llm/model-resolver.js
+++ b/src/lib/llm/model-resolver.js
@@ -141,6 +141,8 @@ class ModelResolver {
    */
   setAssignment(map, source = 'niche-assignment') {
     const hasEntries = map && typeof map === 'object' && Object.keys(map).length > 0;
+    // Clearing an already-empty slot is a no-op — don't flush a warm cache.
+    if (!hasEntries && !this._assignment) return;
     // Null-prototype copy: job names come from code, but a key like
     // 'constructor' must read as absent, not as Object.prototype's.
     this._assignment = hasEntries

--- a/src/lib/llm/niche-assignment.js
+++ b/src/lib/llm/niche-assignment.js
@@ -401,14 +401,18 @@ class NicheAssignment {
       }
     }
 
-    // 6. Publish. Identity plans clear the resolver slot entirely.
+    // 6. Publish — only when the map actually changed. setAssignment clears
+    // the resolver's per-job cache, and replan runs on every heartbeat
+    // pulse; an identity→identity pulse must not flush a warm cache.
     const changed = JSON.stringify({ ...map }) !== JSON.stringify({ ...this._assignmentMap });
     this._assignmentMap = map;
     this._residentPlan = [...resident].sort();
-    try {
-      this.resolver.setAssignment(Object.keys(map).length > 0 ? { ...map } : null);
-    } catch (err) {
-      this.logger.warn(`[NicheAssignment] setAssignment failed: ${err.message}`);
+    if (changed) {
+      try {
+        this.resolver.setAssignment(Object.keys(map).length > 0 ? { ...map } : null);
+      } catch (err) {
+        this.logger.warn(`[NicheAssignment] setAssignment failed: ${err.message}`);
+      }
     }
     if (changed) {
       const remaps = Object.entries(map).map(([j, m]) => `${j}→${m}`).join(', ');

--- a/src/lib/llm/niche-assignment.js
+++ b/src/lib/llm/niche-assignment.js
@@ -178,6 +178,7 @@ class NicheAssignment {
     this._assignmentMap = {}; // job → model, remapped jobs only
     this._residentPlan = []; // model names the plan holds resident
     this._replanTimer = null;
+    this._hasPlanned = false; // first plan always logs (boot observability)
   }
 
   // ---------------------------------------------------------------------------
@@ -414,13 +415,14 @@ class NicheAssignment {
         this.logger.warn(`[NicheAssignment] setAssignment failed: ${err.message}`);
       }
     }
-    if (changed) {
+    if (changed || !this._hasPlanned) {
       const remaps = Object.entries(map).map(([j, m]) => `${j}→${m}`).join(', ');
       this.logger.info(
         `[NicheAssignment] Plan: resident [${this._residentPlan.join(', ')}]` +
         (remaps ? ` — remapped: ${remaps}` : ' — winners stand (no remap)')
       );
     }
+    this._hasPlanned = true;
     return { map: { ...map }, residentPlan: [...this._residentPlan] };
   }
 

--- a/src/lib/llm/niche-assignment.js
+++ b/src/lib/llm/niche-assignment.js
@@ -1,0 +1,495 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * NicheAssignment — Compose per-job winners into a memory-feasible
+ * assignment under carrying capacity (Layer 3 of adaptive model selection).
+ *
+ * Problem:
+ *   Picking the best model per job independently ignores the box. Models
+ *   that do not co-fit in memory displace each other on every job switch,
+ *   `load_duration` becomes the dominant latency, and a "better" roster is
+ *   slower than monoculture. The three states (design doc §7): fragmentation
+ *   (drifting duplicates), monoculture (one model, one bottleneck), and
+ *   modularity (specialists composing through the jobs). This module buys
+ *   modularity WITHOUT trading it for load thrash.
+ *
+ * Pattern:
+ *   Sense, don't predict. The foundation signal is `load_duration` from
+ *   every Ollama response (free, portable, captured at the two adapter
+ *   necks): a large value is the box reporting, empirically, that the model
+ *   was not resident. Thrash = repeated large organic loads across several
+ *   models inside a sliding window — proof those models do not co-fit on
+ *   THIS hardware. The assignment then backs off: the lowest-value job's
+ *   model leaves the resident plan and its jobs remap onto an already-
+ *   resident, capability-eligible model (ModelScout's roster chains carry
+ *   eligibility, so no capability logic is duplicated here). Re-admission
+ *   follows the #232 hysteresis discipline: a non-co-fit verdict stands for
+ *   a cool-off that doubles on each recurrence, so the plan never flaps.
+ *
+ *   Calibration traffic (the golden-set probe's boot burst, the judge's
+ *   idle-cycle probes, any future fixture) is one structural class, marked
+ *   by a `calibration` flag at the adapters (the same shape as the
+ *   scorecard's `synthetic` flag). Its loads feed the residency ledger —
+ *   real loads, real evidence — but never count as thrash: the failure mode
+ *   thrash names is felt latency on organic requests only.
+ *
+ *   The judge is a first-class tenant. ModelScout.selectJudgeModel() pins it
+ *   outside the resolver by design (the gradee must not pick its grader);
+ *   its idle cycles load it regardless of any job's winner, so the plan must
+ *   hold space for it. Jobs MAY be remapped toward the judge's model (a
+ *   colocation dividend) — that moves jobs, never the judge pin, so the
+ *   self-reference the pin prevents stays prevented. Cockpit-pinned models
+ *   are tenants for the same reason: deliberate human intent is not
+ *   negotiable by a residency optimization.
+ *
+ *   Enrichment where present: /api/ps (real residency per loaded model)
+ *   confirms the plan proactively. Where absent — and on hosts where the
+ *   GPU lives behind an HTTP endpoint, `nvidia-smi` is absent by
+ *   construction — the `load_duration` foundation stands alone.
+ *
+ * Data Flow:
+ *   OllamaProvider / OllamaToolsProvider → onTimings → recordTiming()
+ *     → (organic load events) thrash oracle → replan()
+ *   ModelScorecard.onSeatChange (webhook-server tee) → replanSoon()
+ *   HeartbeatManager pulse → reconcile() → /api/ps snapshot → replan()
+ *   replan() → resolver.resolveWinner(job) per job
+ *     → resolver.setAssignment(map, 'niche-assignment')
+ *       → resolve(job) serves the remapped model, winner in derivation
+ *
+ * Dependency Map:
+ *   src/lib/llm/niche-assignment.js
+ *     ← src/lib/providers/model-scout.js (PRIOR_STRENGTH: canonical job list)
+ *
+ * @module llm/niche-assignment
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+const { PRIOR_STRENGTH } = require('../providers/model-scout');
+
+// A load event: an Ollama response whose server-side load_duration exceeds
+// this. Warm responses report milliseconds; a cold load on the reference box
+// exceeds 60s (#124) — three orders of magnitude of separation, so the
+// threshold is not delicate.
+const DEFAULT_LOAD_EVENT_MS = 1000;
+
+// Thrash: at least MIN_EVENTS organic load events across at least MIN_MODELS
+// distinct models within WINDOW_MS. One cold load after a restart or an
+// idle-evicted rarity is normal; several models repeatedly displacing each
+// other inside a quarter hour is the box reporting they do not co-fit.
+const DEFAULT_THRASH_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_THRASH_MIN_EVENTS = 3;
+const DEFAULT_THRASH_MIN_MODELS = 2;
+
+// Hysteresis (#232 discipline): a non-co-fit verdict stands for a cool-off
+// that doubles on each recurrence, capped. Re-admission is slow and earned;
+// the resident plan never flaps on one noisy window.
+const DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
+const DEFAULT_BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
+
+// Felt-latency weight per job: how much it costs the USER when this job's
+// model must cold-load. Request-path jobs that run on every message rank
+// highest; long-form jobs amortize a load over a long generation; credentials
+// is rare. Job names, not natural language — the set does not change when a
+// human language is added (Rule 1 unaffected). Used to pick which model
+// leaves the resident plan when two provably do not co-fit.
+const JOB_WEIGHTS = Object.freeze({
+  classification: 100,
+  quick: 90,
+  tools: 80,
+  coding: 70,
+  thinking: 40,
+  writing: 40,
+  research: 40,
+  credentials: 10,
+});
+
+// Ring-buffer bound for the load-event ledger.
+const MAX_LOAD_EVENTS = 200;
+
+class NicheAssignment {
+  /**
+   * @param {Object} opts
+   * @param {Object} opts.resolver - ModelResolver (resolveWinner, setAssignment).
+   * @param {Object} [opts.modelScout] - ModelScout (rosterFor eligibility
+   *   chains, selectJudgeModel). Null → plan degrades to identity (no remap
+   *   targets can be validated, so winners stand).
+   * @param {string[]} [opts.jobs] - Jobs to plan for. Defaults to the
+   *   canonical job list (PRIOR_STRENGTH keys — one source of truth).
+   * @param {string|null} [opts.ollamaEndpoint] - For /api/ps enrichment.
+   *   Null → foundation-only (load_duration) operation.
+   * @param {Function} [opts.fetchImpl] - Injectable fetch (tests).
+   * @param {Function} [opts.now] - Injectable clock (tests). () => epoch ms.
+   * @param {number} [opts.loadEventMs]
+   * @param {number} [opts.thrashWindowMs]
+   * @param {number} [opts.thrashMinEvents]
+   * @param {number} [opts.thrashMinModels]
+   * @param {number} [opts.backoffMs]
+   * @param {number} [opts.backoffMaxMs]
+   * @param {Object} [opts.logger=console]
+   */
+  constructor({
+    resolver,
+    modelScout,
+    jobs,
+    ollamaEndpoint,
+    fetchImpl,
+    now,
+    loadEventMs = DEFAULT_LOAD_EVENT_MS,
+    thrashWindowMs = DEFAULT_THRASH_WINDOW_MS,
+    thrashMinEvents = DEFAULT_THRASH_MIN_EVENTS,
+    thrashMinModels = DEFAULT_THRASH_MIN_MODELS,
+    backoffMs = DEFAULT_BACKOFF_MS,
+    backoffMaxMs = DEFAULT_BACKOFF_MAX_MS,
+    logger,
+  } = {}) {
+    this.resolver = resolver || null;
+    this.modelScout = modelScout || null;
+    this.jobs = Array.isArray(jobs) && jobs.length > 0 ? [...jobs] : Object.keys(PRIOR_STRENGTH);
+    this.ollamaEndpoint = (typeof ollamaEndpoint === 'string' && ollamaEndpoint)
+      ? ollamaEndpoint.replace(/\/+$/, '')
+      : null;
+    this._fetch = fetchImpl || globalThis.fetch;
+    this._now = typeof now === 'function' ? now : Date.now;
+    this.loadEventMs = Number.isFinite(loadEventMs) && loadEventMs > 0 ? loadEventMs : DEFAULT_LOAD_EVENT_MS;
+    this.thrashWindowMs = Number.isFinite(thrashWindowMs) && thrashWindowMs > 0 ? thrashWindowMs : DEFAULT_THRASH_WINDOW_MS;
+    this.thrashMinEvents = Number.isFinite(thrashMinEvents) && thrashMinEvents > 0 ? thrashMinEvents : DEFAULT_THRASH_MIN_EVENTS;
+    this.thrashMinModels = Number.isFinite(thrashMinModels) && thrashMinModels > 0 ? thrashMinModels : DEFAULT_THRASH_MIN_MODELS;
+    this.backoffMs = Number.isFinite(backoffMs) && backoffMs > 0 ? backoffMs : DEFAULT_BACKOFF_MS;
+    this.backoffMaxMs = Number.isFinite(backoffMaxMs) && backoffMaxMs > 0 ? backoffMaxMs : DEFAULT_BACKOFF_MAX_MS;
+    this.logger = logger || console;
+
+    // Residency ledger: organic load events (ring buffer) + last-served
+    // belief per model. Calibration loads update belief but never enter the
+    // thrash window.
+    this._loadEvents = [];
+    this._lastServed = new Map(); // model → epoch ms
+
+    // Non-co-fit verdicts: pairKey → { strikes, until }.
+    this._nonCoFit = new Map();
+
+    // Last /api/ps snapshot (enrichment; null when absent/unreachable).
+    this._psSnapshot = null;
+    this._psWarned = false;
+
+    // Current plan.
+    this._assignmentMap = {}; // job → model, remapped jobs only
+    this._residentPlan = []; // model names the plan holds resident
+    this._replanTimer = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Foundation signal: the residency ledger
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Record one Ollama response's server-side timings (from the adapter
+   * necks). A load_duration above the threshold is a load event: the model
+   * was not resident and someone paid the cold load. Organic load events
+   * feed the thrash oracle; calibration events only update residency belief.
+   * @param {{ model: string|null, loadDurationMs: number,
+   *   totalDurationMs?: number, evalDurationMs?: number,
+   *   calibration?: boolean }} t
+   */
+  recordTiming(t) {
+    if (!t || typeof t !== 'object' || typeof t.model !== 'string' || !t.model) return;
+    const at = this._now();
+    this._lastServed.set(t.model, at);
+
+    const loadMs = Number.isFinite(t.loadDurationMs) ? t.loadDurationMs : 0;
+    if (loadMs <= this.loadEventMs) return;
+
+    this._loadEvents.push({ model: t.model, at, loadDurationMs: loadMs, calibration: !!t.calibration });
+    if (this._loadEvents.length > MAX_LOAD_EVENTS) {
+      this._loadEvents.splice(0, this._loadEvents.length - MAX_LOAD_EVENTS);
+    }
+    this.logger.info(
+      `[NicheAssignment] Load event: ${t.model} load_duration=${Math.round(loadMs)}ms` +
+      `${t.calibration ? ' (calibration — excluded from thrash)' : ''}`
+    );
+
+    if (!t.calibration) this._checkThrash(at);
+  }
+
+  /**
+   * @private
+   * Thrash oracle over the organic load events in the sliding window. On a
+   * verdict, every pair among the involved models is marked non-co-fit
+   * (with escalating cool-off), the consumed events are dropped so one
+   * episode fires once, and the plan recomputes.
+   */
+  _checkThrash(at) {
+    const cutoff = at - this.thrashWindowMs;
+    const organic = this._loadEvents.filter(e => !e.calibration && e.at >= cutoff);
+    if (organic.length < this.thrashMinEvents) return;
+    const models = [...new Set(organic.map(e => e.model))];
+    if (models.length < this.thrashMinModels) return;
+
+    for (let i = 0; i < models.length; i++) {
+      for (let j = i + 1; j < models.length; j++) {
+        this._markNonCoFit(models[i], models[j], at);
+      }
+    }
+    // Consume the episode: keep only events outside it, so the same window
+    // does not re-fire on the next load.
+    this._loadEvents = this._loadEvents.filter(e => e.calibration || e.at < cutoff);
+    this.logger.warn(
+      `[NicheAssignment] Thrash detected: ${organic.length} load events across ` +
+      `${models.length} models (${models.join(', ')}) within ${Math.round(this.thrashWindowMs / 60000)}min — backing off`
+    );
+    this.replan();
+  }
+
+  /** @private */
+  _markNonCoFit(a, b, at) {
+    const key = this._pairKey(a, b);
+    const prev = this._nonCoFit.get(key);
+    const strikes = (prev ? prev.strikes : 0) + 1;
+    const cooloff = Math.min(this.backoffMs * 2 ** (strikes - 1), this.backoffMaxMs);
+    this._nonCoFit.set(key, { strikes, until: at + cooloff, models: [a, b].sort() });
+    this.logger.warn(
+      `[NicheAssignment] Non-co-fit: ${key} (strike ${strikes}, re-admission in ${Math.round(cooloff / 60000)}min)`
+    );
+  }
+
+  /** @private */
+  _pairKey(a, b) {
+    return [a, b].sort().join(' | ');
+  }
+
+  /** @private Active (not yet cooled-off) non-co-fit pairs. */
+  _activeNonCoFit(at) {
+    const active = [];
+    for (const rec of this._nonCoFit.values()) {
+      if (rec.until > at) active.push(rec);
+    }
+    return active;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Planning
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Debounced replan: collapses a burst of triggers (assertSeats fires
+   * onSeatChange once per persisted seat at boot) into one plan on the next
+   * tick.
+   */
+  replanSoon() {
+    if (this._replanTimer) return;
+    this._replanTimer = setTimeout(() => {
+      this._replanTimer = null;
+      try {
+        this.replan();
+      } catch (err) {
+        this.logger.warn(`[NicheAssignment] replan failed: ${err.message}`);
+      }
+    }, 0);
+    // Never hold the process open for a pending replan.
+    if (typeof this._replanTimer.unref === 'function') this._replanTimer.unref();
+  }
+
+  /**
+   * Recompute the assignment from the current winners, tenants, and
+   * non-co-fit evidence, and push it into the resolver. Pure in-memory
+   * arithmetic — no I/O, no LLM call — so it is safe to call on every seat
+   * change, heartbeat, and thrash verdict.
+   *
+   * With no non-co-fit evidence the assignment is the identity: winners
+   * stand, and the plan simply names the resident set they imply. That is
+   * the correct day-one behaviour ("on a box that can hold all winners,
+   * keep them resident") — remaps exist only where the box has proven a
+   * conflict.
+   *
+   * @returns {{ map: Object, residentPlan: string[] }}
+   */
+  replan() {
+    if (!this.resolver || typeof this.resolver.resolveWinner !== 'function') {
+      return { map: {}, residentPlan: [] };
+    }
+    const at = this._now();
+
+    // 1. Winners per job, with cockpit pins exempt and their models pinned.
+    const winners = Object.create(null); // job → model (remappable jobs)
+    const pinnedModels = new Set(); // cockpit models: forced-resident, never dropped
+    for (const job of this.jobs) {
+      let w;
+      try {
+        w = this.resolver.resolveWinner(job);
+      } catch (_err) {
+        continue;
+      }
+      if (!w || !w.model) continue;
+      if (w.source === 'cockpit-card') {
+        pinnedModels.add(w.model);
+        continue; // exempt from remapping
+      }
+      winners[job] = w.model;
+    }
+
+    // 2. Tenants: the judge pin (loop-exempt by design — see module brief)
+    // and cockpit pins occupy space regardless of job winners.
+    let judgeModel = null;
+    try {
+      judgeModel = this.modelScout?.selectJudgeModel?.()?.name || null;
+    } catch (_err) {
+      judgeModel = null;
+    }
+
+    // 3. Desired resident set and per-model value (felt-latency weight of
+    // the jobs each serves; tenants are beyond value — never dropped).
+    const value = new Map();
+    for (const [job, model] of Object.entries(winners)) {
+      value.set(model, (value.get(model) || 0) + (JOB_WEIGHTS[job] || 1));
+    }
+    const protectedModels = new Set(pinnedModels);
+    if (judgeModel) protectedModels.add(judgeModel);
+    const resident = new Set([...value.keys(), ...protectedModels]);
+
+    // 4. Resolve proven conflicts: while an active non-co-fit pair is fully
+    // inside the plan, evict the lower-value unprotected model. Two
+    // protected models in conflict cannot be resolved by remapping jobs —
+    // physical reality outranks the plan; surface it and move on.
+    const active = this._activeNonCoFit(at);
+    let guard = resident.size + 1;
+    let conflictResolved = true;
+    while (conflictResolved && guard-- > 0) {
+      conflictResolved = false;
+      for (const pair of active) {
+        const [a, b] = pair.models;
+        if (!resident.has(a) || !resident.has(b)) continue;
+        const aProt = protectedModels.has(a);
+        const bProt = protectedModels.has(b);
+        if (aProt && bProt) {
+          this.logger.warn(
+            `[NicheAssignment] Non-co-fit pair ${this._pairKey(a, b)} is judge/cockpit-protected on both sides — cannot remap around it`
+          );
+          continue;
+        }
+        let drop;
+        if (aProt) drop = b;
+        else if (bProt) drop = a;
+        else drop = (value.get(a) || 0) <= (value.get(b) || 0) ? a : b;
+        resident.delete(drop);
+        conflictResolved = true;
+        this.logger.info(`[NicheAssignment] Dropping ${drop} from the resident plan (non-co-fit with ${drop === a ? b : a})`);
+        break;
+      }
+    }
+
+    // 5. Remap each job whose winner left the plan onto the first
+    // capability-eligible resident model (ModelScout's chain carries
+    // eligibility — first entry in rosterFor(job) that is resident). No
+    // eligible resident target → the winner stands (never-go-dark: a cold
+    // load beats a wrong-capability model).
+    const map = Object.create(null);
+    for (const [job, model] of Object.entries(winners)) {
+      if (resident.has(model)) continue;
+      let chain = [];
+      try {
+        chain = this.modelScout?.rosterFor?.(job) || [];
+      } catch (_err) {
+        chain = [];
+      }
+      const target = chain.find(m => resident.has(m));
+      if (target && target !== model) {
+        map[job] = target;
+      } else {
+        resident.add(model); // winner stands; it will be loaded when called
+      }
+    }
+
+    // 6. Publish. Identity plans clear the resolver slot entirely.
+    const changed = JSON.stringify({ ...map }) !== JSON.stringify({ ...this._assignmentMap });
+    this._assignmentMap = map;
+    this._residentPlan = [...resident].sort();
+    try {
+      this.resolver.setAssignment(Object.keys(map).length > 0 ? { ...map } : null);
+    } catch (err) {
+      this.logger.warn(`[NicheAssignment] setAssignment failed: ${err.message}`);
+    }
+    if (changed) {
+      const remaps = Object.entries(map).map(([j, m]) => `${j}→${m}`).join(', ');
+      this.logger.info(
+        `[NicheAssignment] Plan: resident [${this._residentPlan.join(', ')}]` +
+        (remaps ? ` — remapped: ${remaps}` : ' — winners stand (no remap)')
+      );
+    }
+    return { map: { ...map }, residentPlan: [...this._residentPlan] };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enrichment: /api/ps
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Refresh the /api/ps residency snapshot (enrichment — the plan works
+   * without it) and replan. Called from the heartbeat pulse. Absence or
+   * failure degrades silently to foundation-only operation.
+   */
+  async reconcile() {
+    if (this.ollamaEndpoint && typeof this._fetch === 'function') {
+      try {
+        const res = await this._fetch(`${this.ollamaEndpoint}/api/ps`, {
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (res && res.ok) {
+          const data = await res.json();
+          const models = Array.isArray(data?.models) ? data.models : [];
+          this._psSnapshot = {
+            at: this._now(),
+            models: models.map(m => ({
+              name: m.name || m.model,
+              sizeBytes: m.size || 0,
+              sizeVram: m.size_vram || 0,
+              expiresAt: m.expires_at || null,
+            })),
+          };
+        }
+      } catch (err) {
+        if (!this._psWarned) {
+          this._psWarned = true;
+          this.logger.warn(`[NicheAssignment] /api/ps unavailable (${err.message}) — foundation signal (load_duration) only`);
+        }
+      }
+    }
+    return this.replan();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Observability
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One structured status object for logs and the cockpit.
+   * @returns {Object}
+   */
+  getStatus() {
+    const at = this._now();
+    return {
+      residentPlan: [...this._residentPlan],
+      assignment: { ...this._assignmentMap },
+      nonCoFit: this._activeNonCoFit(at).map(r => ({
+        models: [...r.models], strikes: r.strikes, readmissionInMs: Math.max(0, r.until - at),
+      })),
+      recentLoadEvents: this._loadEvents.slice(-10).map(e => ({
+        model: e.model, loadDurationMs: Math.round(e.loadDurationMs), calibration: e.calibration, at: e.at,
+      })),
+      psResident: this._psSnapshot ? this._psSnapshot.models.map(m => m.name) : null,
+      psAgeMs: this._psSnapshot ? at - this._psSnapshot.at : null,
+    };
+  }
+
+  /** Cancel any pending debounced replan (shutdown/tests). */
+  stop() {
+    if (this._replanTimer) {
+      clearTimeout(this._replanTimer);
+      this._replanTimer = null;
+    }
+  }
+}
+
+module.exports = { NicheAssignment, JOB_WEIGHTS };

--- a/src/lib/llm/ollama-timings.js
+++ b/src/lib/llm/ollama-timings.js
@@ -1,0 +1,81 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * emitOllamaTimings — One extraction of Ollama's server-side timing fields,
+ * shared by both adapter necks (Layer 3, niche assignment foundation).
+ *
+ * Problem:
+ *   Ollama reports `load_duration` / `total_duration` / `eval_duration`
+ *   (nanoseconds) in every /api/chat response, but both adapters read the
+ *   body and keep only content + token counts. `load_duration` is the free,
+ *   portable carrying-capacity signal (design doc §7): a large value means
+ *   the model was not resident and the box paid a cold load. Nothing
+ *   upstream ever sees it.
+ *
+ * Pattern:
+ *   The raw response body exists in exactly two places — OllamaProvider
+ *   (generate family) and OllamaToolsProvider (chat family). Rule 5: capture
+ *   at the necks, once each, through one shared helper, and emit to a single
+ *   injected sink (NicheAssignment's residency ledger). The sink never
+ *   throws into the request path: observability must not break inference.
+ *
+ *   The `calibration` flag marks scheduled measurement traffic — the
+ *   golden-set probe's boot burst, the local judge's idle-cycle probes, and
+ *   any future fixture — as one structural class (the same shape as
+ *   ModelScorecard's `synthetic` flag). Calibration loads still feed the
+ *   residency ledger (they are real loads, real evidence of what co-fits);
+ *   they are excluded from thrash detection, whose failure mode is felt
+ *   latency on organic requests only.
+ *
+ * Data Flow:
+ *   OllamaProvider.generate / OllamaToolsProvider.chat
+ *     → response.json() → emitOllamaTimings(sink, data, requestedModel, calibration)
+ *       → sink({ model, loadDurationMs, totalDurationMs, evalDurationMs, calibration })
+ *         → NicheAssignment.recordTiming (residency ledger, thrash oracle)
+ *
+ * Dependency Map:
+ *   src/lib/llm/ollama-timings.js
+ *     ← (no internal imports — standalone, testable in isolation)
+ *
+ * @module llm/ollama-timings
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+const NS_PER_MS = 1e6;
+
+/**
+ * Extract Ollama server-side timings from a parsed /api/chat response and
+ * emit them to the sink. Ollama reports durations in nanoseconds; the sink
+ * receives milliseconds. Absent fields emit as 0 (a warm response can omit
+ * or zero `load_duration`). Never throws: a broken sink must not break the
+ * request that carried the measurement.
+ *
+ * @param {Function|null|undefined} sink - ({ model, loadDurationMs,
+ *   totalDurationMs, evalDurationMs, calibration }) => void
+ * @param {Object} data - Parsed Ollama response body
+ * @param {string} [requestedModel] - Model named in the request; fallback
+ *   when the response omits `model` (the response's own name wins — the
+ *   response is the custodian of which model actually served).
+ * @param {boolean} [calibration=false] - Scheduled measurement traffic
+ *   (probe/judge), excluded from thrash detection by the sink.
+ */
+function emitOllamaTimings(sink, data, requestedModel, calibration = false) {
+  if (typeof sink !== 'function' || !data || typeof data !== 'object') return;
+  const ms = (ns) => (Number.isFinite(ns) && ns > 0 ? ns / NS_PER_MS : 0);
+  try {
+    sink({
+      model: (typeof data.model === 'string' && data.model) ? data.model : (requestedModel || null),
+      loadDurationMs: ms(data.load_duration),
+      totalDurationMs: ms(data.total_duration),
+      evalDurationMs: ms(data.eval_duration),
+      calibration: !!calibration,
+    });
+  } catch (_err) {
+    // Observability never breaks the request path.
+  }
+}
+
+module.exports = { emitOllamaTimings };

--- a/src/lib/llm/providers/ollama-provider.js
+++ b/src/lib/llm/providers/ollama-provider.js
@@ -9,6 +9,7 @@
  */
 
 const BaseProvider = require('./base-provider');
+const { emitOllamaTimings } = require('../ollama-timings');
 
 class OllamaProvider extends BaseProvider {
   /**
@@ -29,6 +30,10 @@ class OllamaProvider extends BaseProvider {
     // config spread (router.js → providers/index.js). Default: undefined → the
     // keep_alive field is omitted so the Ollama server's own setting governs.
     this.keepAlive = config.keep_alive;
+    // Residency-signal sink (Layer 3): receives Ollama's server-side timings
+    // per response. Flows in via the createProvider config spread, like
+    // keep_alive above. Undefined → no capture, zero overhead.
+    this.onTimings = typeof config.onTimings === 'function' ? config.onTimings : null;
     this._fetch = globalThis.fetch;
   }
 
@@ -104,6 +109,7 @@ class OllamaProvider extends BaseProvider {
         }
 
         const data = await response.json();
+        emitOllamaTimings(this.onTimings, data, this.model, options.calibration);
         const tokens = (data.prompt_eval_count || 0) + (data.eval_count || 0);
 
         this.recordSuccess(tokens);

--- a/test/unit/llm/niche-assignment.test.js
+++ b/test/unit/llm/niche-assignment.test.js
@@ -222,7 +222,10 @@ test('with no non-co-fit evidence the plan is the identity: winners stand, resol
   const { map, residentPlan } = na.replan();
   assert.deepStrictEqual(map, {});
   assert.deepStrictEqual(residentPlan, ['big', 'huge', 'small']);
-  assert.strictEqual(resolver.lastAssignment(), null, 'identity plan clears the resolver slot');
+  assert.strictEqual(resolver.assignments.length, 0,
+    'identity→identity publishes nothing (no per-pulse resolver cache flush)');
+  na.replan();
+  assert.strictEqual(resolver.assignments.length, 0, 'repeated identity replans stay silent');
 });
 
 test('under a proven conflict the lowest-value model is dropped and its jobs remap onto a resident model', () => {
@@ -305,7 +308,8 @@ test('never-go-dark: with no capability-eligible resident target the winner stan
   organicLoad(na, 'big');
   organicLoad(na, 'toolbox');
   organicLoad(na, 'big');
-  assert.strictEqual(resolver.lastAssignment(), null, 'no remap — the winner stands');
+  assert.deepStrictEqual(na.getStatus().assignment, {}, 'no remap — the winner stands');
+  assert.strictEqual(resolver.assignments.length, 0, 'an unchanged (identity) plan publishes nothing');
   assert.ok(na.getStatus().residentPlan.includes('big'), 'the winner re-enters the plan');
 });
 
@@ -411,13 +415,16 @@ asyncTest('degradation: no endpoint configured at all — reconcile is foundatio
 // ============================================================
 
 asyncTest('replanSoon collapses a burst (assertSeats boot burst) into one plan on the next tick', async () => {
-  const { na, resolver } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  const { na } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  let replans = 0;
+  const realReplan = na.replan.bind(na);
+  na.replan = () => { replans++; return realReplan(); };
   na.replanSoon();
   na.replanSoon();
   na.replanSoon();
-  assert.strictEqual(resolver.assignments.length, 0, 'nothing published synchronously');
+  assert.strictEqual(replans, 0, 'nothing runs synchronously');
   await new Promise((r) => setTimeout(r, 10));
-  assert.strictEqual(resolver.assignments.length, 1, 'one plan for the whole burst');
+  assert.strictEqual(replans, 1, 'one plan for the whole burst');
   na.stop();
 });
 

--- a/test/unit/llm/niche-assignment.test.js
+++ b/test/unit/llm/niche-assignment.test.js
@@ -1,0 +1,515 @@
+/**
+ * NicheAssignment Unit Tests
+ *
+ * Layer 3: winners composed into a memory-feasible assignment. Covers the
+ * adapter timing helper (ns→ms, custody of the response's model name), the
+ * residency ledger and thrash oracle (organic-only, calibration excluded,
+ * window consumption), conflict resolution under a simulated memory ceiling
+ * (lowest-value drop, judge/cockpit protection, rosterFor remap targets,
+ * never-go-dark), hysteresis re-admission with strike escalation, /api/ps
+ * enrichment and its absence (foundation-only degradation), the replanSoon
+ * debounce, and the ModelResolver setAssignment slot (applied last, cockpit
+ * exempt, winner visible in derivation, resolveWinner unaffected).
+ *
+ * Run: node test/unit/llm/niche-assignment.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const { NicheAssignment, JOB_WEIGHTS } = require('../../../src/lib/llm/niche-assignment');
+const { emitOllamaTimings } = require('../../../src/lib/llm/ollama-timings');
+const { ModelResolver } = require('../../../src/lib/llm/model-resolver');
+
+const silentLogger = { warn: () => {}, log: () => {}, info: () => {}, error: () => {} };
+
+// ------------------------------------------------------------
+// Fakes
+// ------------------------------------------------------------
+
+/** Resolver fake: winners per job + a record of setAssignment calls. */
+function makeResolverFake(winners) {
+  return {
+    assignments: [],
+    resolveWinner(job) {
+      const w = winners[job];
+      if (!w) return { model: null, trust: 'cloud-ok', source: 'fallback' };
+      return { model: w.model, trust: 'cloud-ok', source: w.source || 'model-scout' };
+    },
+    setAssignment(map) {
+      this.assignments.push(map ? { ...map } : null);
+    },
+    lastAssignment() {
+      return this.assignments.length ? this.assignments[this.assignments.length - 1] : undefined;
+    },
+  };
+}
+
+/** Scout fake: eligibility chains per job + a judge pin. */
+function makeScoutFake({ chains = {}, judge = null } = {}) {
+  return {
+    rosterFor: (job) => [...(chains[job] || [])],
+    selectJudgeModel: () => (judge ? { name: judge, paramSize: null, digest: null } : null),
+  };
+}
+
+/** A controllable clock. */
+function makeClock(start = 1_000_000) {
+  let t = start;
+  const now = () => t;
+  now.advance = (ms) => { t += ms; };
+  return now;
+}
+
+function makeAssignment({ winners, chains, judge, jobs, clock, ...rest } = {}) {
+  const resolver = makeResolverFake(winners || {});
+  const na = new NicheAssignment({
+    resolver,
+    modelScout: makeScoutFake({ chains, judge }),
+    jobs: jobs || Object.keys(winners || {}),
+    ollamaEndpoint: null,
+    now: clock || makeClock(),
+    logger: silentLogger,
+    ...rest,
+  });
+  return { na, resolver };
+}
+
+/** Push one organic load event (above the 1s threshold). */
+function organicLoad(na, model, ms = 5000) {
+  na.recordTiming({ model, loadDurationMs: ms, calibration: false });
+}
+
+// ============================================================
+// emitOllamaTimings (the shared adapter-neck helper)
+// ============================================================
+
+test('emitOllamaTimings converts nanoseconds to milliseconds', () => {
+  let seen = null;
+  emitOllamaTimings((t) => { seen = t; }, {
+    model: 'qwen3:8b',
+    load_duration: 63_000_000_000, // 63s in ns
+    total_duration: 70_000_000_000,
+    eval_duration: 5_000_000_000,
+  }, 'requested-model', false);
+  assert.strictEqual(seen.model, 'qwen3:8b');
+  assert.strictEqual(seen.loadDurationMs, 63_000);
+  assert.strictEqual(seen.totalDurationMs, 70_000);
+  assert.strictEqual(seen.evalDurationMs, 5_000);
+  assert.strictEqual(seen.calibration, false);
+});
+
+test('emitOllamaTimings: the response body names the model that served; the request name is only a fallback', () => {
+  let seen = null;
+  const sink = (t) => { seen = t; };
+  emitOllamaTimings(sink, { model: 'served-model', load_duration: 1 }, 'requested-model');
+  assert.strictEqual(seen.model, 'served-model');
+  emitOllamaTimings(sink, { load_duration: 1 }, 'requested-model');
+  assert.strictEqual(seen.model, 'requested-model');
+});
+
+test('emitOllamaTimings: absent duration fields emit as 0; a throwing sink never propagates', () => {
+  let seen = null;
+  emitOllamaTimings((t) => { seen = t; }, { model: 'm' });
+  assert.strictEqual(seen.loadDurationMs, 0);
+  assert.strictEqual(seen.totalDurationMs, 0);
+  assert.doesNotThrow(() => {
+    emitOllamaTimings(() => { throw new Error('broken sink'); }, { model: 'm' });
+  });
+  assert.doesNotThrow(() => emitOllamaTimings(null, { model: 'm' }));
+  assert.doesNotThrow(() => emitOllamaTimings(() => {}, null));
+});
+
+// ============================================================
+// Residency ledger + thrash oracle
+// ============================================================
+
+test('a warm response (load_duration under the threshold) is not a load event', () => {
+  const { na } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  na.recordTiming({ model: 'big', loadDurationMs: 40 });
+  assert.strictEqual(na.getStatus().recentLoadEvents.length, 0);
+});
+
+test('a cold load above the threshold is recorded as a load event', () => {
+  const { na } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  organicLoad(na, 'big', 63_000);
+  const events = na.getStatus().recentLoadEvents;
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].model, 'big');
+  assert.strictEqual(events[0].loadDurationMs, 63_000);
+});
+
+test('thrash: 3 organic load events across 2 models inside the window mark the pair non-co-fit', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({
+    winners: { tools: { model: 'huge' }, thinking: { model: 'big' } },
+    chains: { thinking: ['big', 'huge'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  clock.advance(60_000);
+  organicLoad(na, 'huge');
+  clock.advance(60_000);
+  organicLoad(na, 'big');
+  const nonCoFit = na.getStatus().nonCoFit;
+  assert.strictEqual(nonCoFit.length, 1);
+  assert.deepStrictEqual(nonCoFit[0].models, ['big', 'huge']);
+});
+
+test('no thrash from repeated loads of a SINGLE model (a restart cold start is not a conflict)', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({ winners: { tools: { model: 'big' } }, clock });
+  for (let i = 0; i < 4; i++) {
+    organicLoad(na, 'big');
+    clock.advance(60_000);
+  }
+  assert.strictEqual(na.getStatus().nonCoFit.length, 0);
+});
+
+test('no thrash from events spread wider than the window', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({ winners: { tools: { model: 'huge' }, thinking: { model: 'big' } }, clock });
+  organicLoad(na, 'big');
+  clock.advance(16 * 60 * 1000); // outside the 15-min window
+  organicLoad(na, 'huge');
+  clock.advance(16 * 60 * 1000);
+  organicLoad(na, 'big');
+  assert.strictEqual(na.getStatus().nonCoFit.length, 0);
+});
+
+test('calibration loads are ledgered but NEVER count toward thrash (probe burst, judge cycles)', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({ winners: { tools: { model: 'huge' }, thinking: { model: 'big' } }, clock });
+  // A golden-set boot burst: every candidate cold-loads, flagged calibration.
+  for (const m of ['small', 'big', 'huge', 'small', 'big', 'huge']) {
+    na.recordTiming({ model: m, loadDurationMs: 30_000, calibration: true });
+    clock.advance(30_000);
+  }
+  assert.strictEqual(na.getStatus().nonCoFit.length, 0, 'boot burst must not read as thrash');
+  assert.ok(na.getStatus().recentLoadEvents.every(e => e.calibration));
+});
+
+test('a thrash episode is consumed: the same window does not re-fire on the next single load', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({
+    winners: { tools: { model: 'huge' }, thinking: { model: 'big' } },
+    chains: { thinking: ['big', 'huge'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big'); // fires, strike 1
+  assert.strictEqual(na.getStatus().nonCoFit[0].strikes, 1);
+  clock.advance(1000);
+  organicLoad(na, 'huge'); // one fresh event alone must not re-fire
+  assert.strictEqual(na.getStatus().nonCoFit[0].strikes, 1);
+});
+
+// ============================================================
+// Planning: identity, conflict resolution, remap
+// ============================================================
+
+test('with no non-co-fit evidence the plan is the identity: winners stand, resolver slot cleared', () => {
+  const { na, resolver } = makeAssignment({
+    winners: {
+      classification: { model: 'small' },
+      tools: { model: 'huge' },
+      thinking: { model: 'big' },
+    },
+  });
+  const { map, residentPlan } = na.replan();
+  assert.deepStrictEqual(map, {});
+  assert.deepStrictEqual(residentPlan, ['big', 'huge', 'small']);
+  assert.strictEqual(resolver.lastAssignment(), null, 'identity plan clears the resolver slot');
+});
+
+test('under a proven conflict the lowest-value model is dropped and its jobs remap onto a resident model', () => {
+  const clock = makeClock();
+  const { na, resolver } = makeAssignment({
+    winners: {
+      classification: { model: 'small' }, // weight 100
+      tools: { model: 'huge' },           // weight 80
+      thinking: { model: 'big' },         // weight 40 — lowest, dropped
+    },
+    chains: { thinking: ['big', 'huge', 'small'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big'); // thrash fires and replans
+  const map = resolver.lastAssignment();
+  assert.deepStrictEqual(map, { thinking: 'huge' }, 'thinking remaps to the surviving co-resident specialist');
+  assert.ok(!na.getStatus().residentPlan.includes('big'), 'big left the resident plan');
+});
+
+test('the judge is a protected tenant: a conflict drops the unprotected side even at higher job value', () => {
+  const clock = makeClock();
+  const { na, resolver } = makeAssignment({
+    winners: {
+      tools: { model: 'huge' },   // weight 80 — but unprotected
+      thinking: { model: 'big' }, // weight 40
+    },
+    chains: { tools: ['huge', 'big'] },
+    judge: 'big', // judge pinned to big → big is never dropped
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big');
+  assert.deepStrictEqual(resolver.lastAssignment(), { tools: 'big' }, 'tools colocates with the judge model');
+  assert.ok(na.getStatus().residentPlan.includes('big'), 'judge model stays resident');
+  assert.ok(!na.getStatus().residentPlan.includes('huge'));
+});
+
+test('the judge model is held in the resident plan even when no job wins it', () => {
+  const { na } = makeAssignment({
+    winners: { classification: { model: 'small' } },
+    judge: 'big',
+  });
+  const { residentPlan } = na.replan();
+  assert.deepStrictEqual(residentPlan, ['big', 'small']);
+});
+
+test('cockpit-pinned jobs are exempt: never remapped, their model never dropped', () => {
+  const clock = makeClock();
+  const { na, resolver } = makeAssignment({
+    winners: {
+      tools: { model: 'huge' },                              // weight 80
+      thinking: { model: 'big', source: 'cockpit-card' },    // pinned by the human
+    },
+    chains: { tools: ['huge', 'big'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big');
+  const map = resolver.lastAssignment();
+  assert.ok(!map || !('thinking' in (map || {})), 'a cockpit-pinned job is never remapped');
+  assert.deepStrictEqual(map, { tools: 'big' }, 'the unpinned job moves instead');
+  assert.ok(na.getStatus().residentPlan.includes('big'), 'the pinned model stays resident');
+});
+
+test('never-go-dark: with no capability-eligible resident target the winner stands (cold load beats wrong capability)', () => {
+  const clock = makeClock();
+  const { na, resolver } = makeAssignment({
+    winners: {
+      classification: { model: 'small' },
+      tools: { model: 'toolbox' },   // weight 80
+      thinking: { model: 'big' },    // weight 40 — dropped on conflict
+    },
+    chains: { thinking: [] }, // nothing eligible to remap thinking onto
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'toolbox');
+  organicLoad(na, 'big');
+  assert.strictEqual(resolver.lastAssignment(), null, 'no remap — the winner stands');
+  assert.ok(na.getStatus().residentPlan.includes('big'), 'the winner re-enters the plan');
+});
+
+// ============================================================
+// Hysteresis re-admission
+// ============================================================
+
+test('re-admission: after the cool-off expires the pair is no longer active and the winner is restored', () => {
+  const clock = makeClock();
+  const { na, resolver } = makeAssignment({
+    winners: { tools: { model: 'huge' }, thinking: { model: 'big' } },
+    chains: { thinking: ['big', 'huge'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big');
+  assert.deepStrictEqual(resolver.lastAssignment(), { thinking: 'huge' });
+  clock.advance(61 * 60 * 1000); // past the 60-min first-strike cool-off
+  na.replan();
+  assert.strictEqual(resolver.lastAssignment(), null, 'expired verdict re-admits the winner');
+});
+
+test('strike escalation: a recurring verdict doubles the cool-off (#232 discipline — no flapping)', () => {
+  const clock = makeClock();
+  const { na } = makeAssignment({
+    winners: { tools: { model: 'huge' }, thinking: { model: 'big' } },
+    chains: { thinking: ['big', 'huge'] },
+    clock,
+  });
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big'); // strike 1: 60min
+  const first = na.getStatus().nonCoFit[0].readmissionInMs;
+  clock.advance(61 * 60 * 1000);
+  organicLoad(na, 'big');
+  organicLoad(na, 'huge');
+  organicLoad(na, 'big'); // strike 2: 120min
+  const second = na.getStatus().nonCoFit[0].readmissionInMs;
+  assert.ok(second > first * 1.5, `cool-off must escalate (${second} vs ${first})`);
+});
+
+// ============================================================
+// Enrichment (/api/ps) and degradation
+// ============================================================
+
+asyncTest('reconcile reads /api/ps where present and reports real residency', async () => {
+  const clock = makeClock();
+  const fetchImpl = () => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({
+      models: [
+        { name: 'qwen3:8b', size: 5_900_000_000, size_vram: 0, expires_at: '2318-10-12T00:00:00Z' },
+        { name: 'qwen2.5:3b', size: 2_000_000_000, size_vram: 0, expires_at: '2318-10-12T00:00:00Z' },
+      ],
+    }),
+  });
+  const resolver = makeResolverFake({ tools: { model: 'qwen3:8b' } });
+  const na = new NicheAssignment({
+    resolver,
+    modelScout: makeScoutFake({}),
+    jobs: ['tools'],
+    ollamaEndpoint: 'http://ollama.test:11434',
+    fetchImpl,
+    now: clock,
+    logger: silentLogger,
+  });
+  await na.reconcile();
+  const status = na.getStatus();
+  assert.deepStrictEqual(status.psResident, ['qwen3:8b', 'qwen2.5:3b']);
+  assert.strictEqual(status.psAgeMs, 0);
+});
+
+asyncTest('degradation: with /api/ps unreachable the foundation-only path still produces a working plan', async () => {
+  const { resolver } = { resolver: null };
+  const clock = makeClock();
+  const failingFetch = () => Promise.reject(new Error('ECONNREFUSED'));
+  const resolverFake = makeResolverFake({ tools: { model: 'big' }, classification: { model: 'small' } });
+  const na = new NicheAssignment({
+    resolver: resolverFake,
+    modelScout: makeScoutFake({}),
+    jobs: ['tools', 'classification'],
+    ollamaEndpoint: 'http://ollama.test:11434',
+    fetchImpl: failingFetch,
+    now: clock,
+    logger: silentLogger,
+  });
+  const { residentPlan } = await na.reconcile();
+  assert.deepStrictEqual(residentPlan, ['big', 'small'], 'plan works without enrichment');
+  assert.strictEqual(na.getStatus().psResident, null);
+  void resolver;
+});
+
+asyncTest('degradation: no endpoint configured at all — reconcile is foundation-only by construction', async () => {
+  const { na } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  const { residentPlan } = await na.reconcile();
+  assert.deepStrictEqual(residentPlan, ['big']);
+  assert.strictEqual(na.getStatus().psResident, null);
+});
+
+// ============================================================
+// replanSoon debounce
+// ============================================================
+
+asyncTest('replanSoon collapses a burst (assertSeats boot burst) into one plan on the next tick', async () => {
+  const { na, resolver } = makeAssignment({ winners: { tools: { model: 'big' } } });
+  na.replanSoon();
+  na.replanSoon();
+  na.replanSoon();
+  assert.strictEqual(resolver.assignments.length, 0, 'nothing published synchronously');
+  await new Promise((r) => setTimeout(r, 10));
+  assert.strictEqual(resolver.assignments.length, 1, 'one plan for the whole burst');
+  na.stop();
+});
+
+// ============================================================
+// ModelResolver.setAssignment (the resolver slot)
+// ============================================================
+
+function makeRealResolver({ roster = { tools: ['m-scout'] }, cockpitModel = null } = {}) {
+  const scout = {
+    generateLocalRoster: () => roster,
+    hasModel: () => true,
+  };
+  const cockpitManager = cockpitModel
+    ? { cachedConfig: { system: { modelsConfig: { trust: 'cloud-ok', localDefault: cockpitModel } } } }
+    : null;
+  return new ModelResolver({
+    deployerConfig: { model: 'm-deployer' },
+    envModel: null,
+    modelScout: scout,
+    cockpitManager,
+    logger: silentLogger,
+  });
+}
+
+test('setAssignment remaps the resolved model, keeps trust/provider, and shows the winner in derivation', () => {
+  const resolver = makeRealResolver();
+  const before = resolver.resolve('tools');
+  assert.strictEqual(before.model, 'm-scout');
+  resolver.setAssignment({ tools: 'm-shared' });
+  const after = resolver.resolve('tools');
+  assert.strictEqual(after.model, 'm-shared');
+  assert.strictEqual(after.source, 'niche-assignment');
+  assert.strictEqual(after.derivation.assignmentWinner, 'm-scout', 'the displaced winner stays visible');
+  assert.strictEqual(after.trust, before.trust, 'trust untouched');
+  assert.strictEqual(after.provider, before.provider, 'provider untouched');
+});
+
+test('resolveWinner reads the pre-assignment winner (the plan never feeds on its own output)', () => {
+  const resolver = makeRealResolver();
+  resolver.setAssignment({ tools: 'm-shared' });
+  assert.strictEqual(resolver.resolveWinner('tools').model, 'm-scout');
+  assert.strictEqual(resolver.resolve('tools').model, 'm-shared');
+});
+
+test('a cockpit-card win is never remapped by the assignment', () => {
+  const resolver = makeRealResolver({ cockpitModel: 'm-pinned' });
+  resolver.setAssignment({ tools: 'm-shared' });
+  const r = resolver.resolve('tools');
+  assert.strictEqual(r.model, 'm-pinned');
+  assert.strictEqual(r.source, 'cockpit-card');
+});
+
+test('setAssignment(null) clears the remap; an empty map is treated as clear', () => {
+  const resolver = makeRealResolver();
+  resolver.setAssignment({ tools: 'm-shared' });
+  assert.strictEqual(resolver.resolve('tools').model, 'm-shared');
+  resolver.setAssignment(null);
+  assert.strictEqual(resolver.resolve('tools').model, 'm-scout');
+  resolver.setAssignment({});
+  assert.strictEqual(resolver.resolve('tools').model, 'm-scout');
+});
+
+test('refresh() does not clear the assignment (a Cockpit re-read has no opinion on load behaviour)', () => {
+  const resolver = makeRealResolver();
+  resolver.setAssignment({ tools: 'm-shared' });
+  resolver.refresh();
+  assert.strictEqual(resolver.resolve('tools').model, 'm-shared');
+});
+
+test('an assignment naming an unrelated job leaves other jobs alone; prototype keys read as absent', () => {
+  const resolver = makeRealResolver({ roster: { tools: ['m-scout'], quick: ['m-small'] } });
+  resolver.setAssignment({ quick: 'm-scout' });
+  assert.strictEqual(resolver.resolve('tools').model, 'm-scout');
+  assert.strictEqual(resolver.resolve('quick').model, 'm-scout');
+  resolver.setAssignment({ quick: 'm-small' });
+  const r = resolver.resolve('constructor');
+  assert.notStrictEqual(typeof r.model, 'function', 'prototype pollution guard');
+});
+
+// ============================================================
+// JOB_WEIGHTS sanity (structural, job names only)
+// ============================================================
+
+test('JOB_WEIGHTS ranks request-path jobs above long-form jobs', () => {
+  assert.ok(JOB_WEIGHTS.classification > JOB_WEIGHTS.thinking);
+  assert.ok(JOB_WEIGHTS.quick > JOB_WEIGHTS.writing);
+  assert.ok(JOB_WEIGHTS.tools > JOB_WEIGHTS.credentials);
+});
+
+// ============================================================
+
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -427,6 +427,9 @@ const ModelScorecard = require('./src/lib/llm/model-scorecard');
 const JudgeQueue = require('./src/lib/llm/judge-queue');
 const LocalJudge = require('./src/lib/llm/local-judge');
 
+// Niche assignment (Layer 3, Session 5): winners composed under carrying capacity
+const { NicheAssignment } = require('./src/lib/llm/niche-assignment');
+
 // Local Intelligence: ModelScout + MicroPipeline + DeferralQueue
 let ModelScout, MicroPipeline, MemoryContextEnricher, DeferralQueue, GoldenSetProbe;
 try {
@@ -521,6 +524,12 @@ let costTracker = null; // Cost metering: per-call audit + enriched cost reporti
 let modelScorecard = null; // Maturation loop: per-(job, model, language) scores (Layer 2)
 let judgeQueue = null; // Session 4: bounded judge-then-delete retention of judged-job samples
 let localJudge = null; // Session 4: heartbeat-idle grader for writing/thinking
+let nicheAssignment = null; // Session 5 (Layer 3): carrying-capacity plan over the winners
+
+// Residency-signal sink for every local Ollama adapter (both families).
+// Late-bound: no-ops until NicheAssignment is constructed after discovery,
+// so providers built earlier in this bootstrap still capture from then on.
+const ollamaTimingsSink = (t) => { if (nicheAssignment) nicheAssignment.recordTiming(t); };
 let dailyBriefing = null; // First-message-of-day briefing
 let cockpitManager = null; // Session 27: Cockpit (Deck as control plane)
 let botEnroller = null; // Auto-enable Talk bot in rooms
@@ -801,6 +810,14 @@ async function initialize() {
     // Apply runtime Ollama endpoint override from CONFIG.
     if (llmConfig.providers?.['ollama-local'] && CONFIG.ollama?.url) {
       llmConfig.providers['ollama-local'].endpoint = CONFIG.ollama.url;
+    }
+    // Residency-signal capture (Layer 3): every local Ollama provider in the
+    // router emits server-side timings (load_duration) to the late-bound
+    // sink. Rides the same config spread as keep_alive (#124).
+    for (const p of Object.values(llmConfig.providers || {})) {
+      if (p && typeof p === 'object' && (p.adapter || 'ollama') === 'ollama') {
+        p.onTimings = ollamaTimingsSink;
+      }
     }
     // NOTE: the env var (OLLAMA_MODEL) no longer mutates the router provider's
     // model here. That mutation was a primary source of the model chimerism in
@@ -1563,7 +1580,8 @@ async function initialize() {
           model: ollamaConfig.model || CONFIG.ollama.model,
           timeout: CONFIG.ollama.timeout,
           toolTimeout: CONFIG.ollama.toolTimeout,
-          keep_alive: ollamaConfig.keep_alive  // #124: per-provider knob; undefined → server governs
+          keep_alive: ollamaConfig.keep_alive,  // #124: per-provider knob; undefined → server governs
+          onTimings: ollamaTimingsSink  // Layer 3: residency ledger
         });
         console.log(`[INIT] OllamaToolsProvider ready (${ollamaEndpoint}, ${ollamaConfig.model || CONFIG.ollama.model})`);
       }
@@ -1576,7 +1594,8 @@ async function initialize() {
           model: CONFIG.ollama.modelCredential,
           timeout: CONFIG.ollama.timeout,
           toolTimeout: CONFIG.ollama.toolTimeout,
-          keep_alive: ollamaConfig.keep_alive  // #124
+          keep_alive: ollamaConfig.keep_alive,  // #124
+          onTimings: ollamaTimingsSink  // Layer 3
         });
         console.log(`[INIT] OllamaToolsProvider (credential) ready (${CONFIG.ollama.modelCredential})`);
       }
@@ -1591,7 +1610,8 @@ async function initialize() {
           model: fastModel,
           timeout: 30000,
           toolTimeout: 30000,
-          keep_alive: ollamaConfig.keep_alive  // #124
+          keep_alive: ollamaConfig.keep_alive,  // #124
+          onTimings: ollamaTimingsSink  // Layer 3
         });
         console.log(`[INIT] OllamaToolsProvider (fast) ready (${fastModel})`);
       }
@@ -1605,7 +1625,13 @@ async function initialize() {
       modelScorecard = new ModelScorecard({
         dataDir: path.join(__dirname, 'data'),
         getLanguage: () => cockpitManager?.cachedConfig?.persona?.language || 'EN',
-        onSeatChange: (job, model) => modelResolver?.setGroundTruthOverride?.(job, model, 'maturation-loop'),
+        // Tee: the override lands first, THEN the assignment replans from
+        // the post-change winners. Debounced to the next tick so
+        // assertSeats' boot-time burst collapses to one plan.
+        onSeatChange: (job, model) => {
+          modelResolver?.setGroundTruthOverride?.(job, model, 'maturation-loop');
+          nicheAssignment?.replanSoon?.();
+        },
         // Seats feed the resolver's LOCAL model slot, so only models Ollama
         // actually serves may win one. Cloud fallback samples still record
         // (real data); they just cannot be handed to Ollama as a model name.
@@ -2089,6 +2115,20 @@ async function initialize() {
           for (const d of divergences) {
             console.warn(`[WARN] ${d}`);
           }
+
+          // NicheAssignment (Layer 3, Session 5): composes the per-job
+          // winners into a memory-feasible plan. Constructed here because it
+          // plans from resolver winners AND scout roster chains, both of
+          // which exist only after discovery. The first plan is debounced to
+          // the next tick; the probe/scorecard tee replans as seats land.
+          nicheAssignment = new NicheAssignment({
+            resolver: modelResolver,
+            modelScout,
+            ollamaEndpoint: modelScout.ollamaEndpoint,
+            logger: console,
+          });
+          nicheAssignment.replanSoon();
+          console.log('[INIT] NicheAssignment ready (Layer 3: carrying-capacity plan)');
         }
 
         // Golden-set probe: measure classification accuracy per language and select
@@ -2137,6 +2177,9 @@ async function initialize() {
                   const { summary } = modelResolver.describe(['tools', 'thinking', 'quick', 'classification']);
                   console.log(`[INIT] Model resolver (post-probe): ${summary}`);
                 }
+                // The probe's own override lands outside the scorecard tee,
+                // so replan explicitly from the post-probe winners.
+                nicheAssignment?.replanSoon?.();
               })
               .catch(err => {
                 console.warn(`[INIT] Golden-set probe failed: ${err.message}`);
@@ -2447,7 +2490,10 @@ async function initialize() {
             localChat: (params) => {
               const ollama = routerChatBridge?.chatProviders?.get('ollama-local');
               if (!ollama) throw new Error('ollama-local chat provider not registered');
-              return ollama.chat(params);
+              // Judge traffic is calibration: its loads feed the residency
+              // ledger but never count as thrash (idle-cycle loads are
+              // scheduled, not felt latency on a user request).
+              return ollama.chat({ ...params, calibration: true });
             },
             localCandidates: (job) => modelResolver?.modelScout?.rosterFor?.(job) || [],
             cloudCandidates: (job) => {
@@ -2510,6 +2556,11 @@ async function initialize() {
         resilientWriter,
         costTracker,
         localJudge,
+        // Layer 3 (Session 5): thunk — NicheAssignment is constructed after
+        // ModelScout discovery, possibly after this manager. The sink keeps
+        // timing capture alive across heartbeat roster rebuilds.
+        getNicheAssignment: () => nicheAssignment,
+        onOllamaTimings: ollamaTimingsSink,
         dailyBriefing,
         reviewUser: appConfig.cockpit?.adminUser || appConfig.knowledge?.adminUser || '',
         talkSendQueue: talkQueue,


### PR DESCRIPTION
## What

Layer 3 of adaptive model selection (design doc §7), the pack's final session: per-job winners become a **memory-feasible assignment** instead of an unconstrained best-fit list.

- **`src/lib/llm/ollama-timings.js`** — one shared extraction of Ollama's server-side `load_duration`/`total_duration`/`eval_duration` at the only two places the raw response body exists (`OllamaProvider.generate`, `OllamaToolsProvider.chat`), emitted to an injected sink. The design assumed load_duration was already in the telemetry; it was not — both adapters dropped it.
- **`src/lib/llm/niche-assignment.js`** — residency ledger fed by those timings plus optional `/api/ps` enrichment; thrash oracle (>1s load events, ≥3 across ≥2 models in a 15-min sliding window) marks pairs non-co-fit with #232-style escalating cool-offs; replan drops the lowest-felt-latency-value model and remaps its jobs onto co-resident, capability-eligible models via ModelScout's roster chains (never-go-dark when no eligible target). The judge pin and cockpit pins are protected tenants; jobs may colocate toward the judge's model, the pin itself never moves.
- **Calibration traffic excluded from thrash as a class** — the golden-set probe's boot burst and the judge's idle probes carry a `calibration` flag through adapter options (same shape as the scorecard's `synthetic` flag). Their loads still feed the residency ledger; they never count as thrash.
- **`ModelResolver.setAssignment(map, source)`** — applied after the full precedence chain, cockpit wins exempt, trust/provider untouched, displaced winner visible in `derivation.assignmentWinner`; `resolveWinner()` exposes pre-remap picks so the plan never feeds on its own output. En route: override/roster job lookups hardened to null-prototype objects (a job name like `constructor` previously resolved to `Object.prototype.constructor` — latent since the probe seam).
- **Wiring** — onSeatChange tee (override lands first, then next-tick-debounced replan so assertSeats' boot burst collapses to one plan); heartbeat reconciles `/api/ps` fire-and-forget every pulse; roster rebuilds carry the timings sink so capture survives provider replacement.

## Verification (live on the Bot VM, branch deployed then restored)

- **Cold-load capture, both adapter necks, magnitude-checked.** Chat family (in-service, probe burst): `Load event: gemma2:2b load_duration=2794ms`, `qwen2.5:3b 3117ms`, `qwen3:8b 3032ms` — all `(calibration — excluded from thrash)`. Generate family (harness against `[OLLAMA_HOST]`): cold `loadDurationMs=3411` inside a 10,883ms wall-clock call; warm `loadDurationMs=101` inside an 851ms call; raw `load_duration=104047305ns → 104ms` matches the converted value. The warm/cold split proves the pipe reads Ollama's `load_duration`, not wall-clock time.
- **Calibration exclusion under the worst-case pattern.** Probe cache deleted → boot burst cold-loaded three distinct models within 5 minutes — exactly the shape the thrash oracle hunts — and produced zero thrash verdicts, because every event was calibration-flagged.
- **Real carrying-capacity edge observed.** `/api/ps` (`size_vram: 0` — CPU inference; server keep_alive −1) showed the box holds qwen3:8b + one small model + the embedder; loading a fourth model evicted the LRU small model. `nvidia-smi` is absent by construction (remote Ollama over HTTP), so `/api/ps` is the only enrichment here — the graceful-degradation case is this deployment's normal case.
- **Mixed-job traffic (DE/EN/PT), no thrash.** Three signed webhook messages: DE knowledge → local pipeline (German answer), EN calendar → agent-loop, PT knowledge → local pipeline (Portuguese answer). Zero load events in the window — resident models stayed loaded across job switches.
- **Honest modularity statement for this box.** Boot plan: `[NicheAssignment] Plan: resident [gemma2:2b, qwen3:8b] — winners stand (no remap)`. With three text models on a CPU host, the correct assignment IS quick/classification on the small models and the remaining jobs sharing qwen3:8b with the judge colocated — specialists per niche, not a failure to specialize. Real thrash is not demonstrable on this box (winners co-fit); the thrash→back-off→remap path is covered by tests under a simulated ceiling.
- Tests: 29 new (thrash oracle, calibration exclusion, ceiling-forced job-sharing, judge/cockpit protection, hysteresis re-admission, `/api/ps`-absent degradation, resolver slot). Unit suite 227/227. Reviewer pass applied (churn-free publish, non-blocking heartbeat reconcile).

This completes the adaptive-model-selection pack: sense (capability), rank (per-job prior), learn (maturation + judge), compose (carrying capacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)