### PR TITLE
fix: Wave 0 hot patches — file_write HITL gate, ACL scrub, SOUL language directive, mail cold-sync (#217 #148 #172 #180)

### DIFF
--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -16,6 +16,8 @@ const { classifyConfirmationReply } = require('../shared/confirmation-classifier
  */
 
 // Tools that warrant guardrail evaluation — everything else passes through instantly
+// NOTE(#217): gating policy has two homes (this set + ToolGuard.REQUIRES_APPROVAL);
+// single-home consolidation tracked for F1 retirement.
 const SENSITIVE_TOOLS = new Set([
   'mail_send',
   'file_delete',

--- a/src/lib/integrations/nc-mail-client.js
+++ b/src/lib/integrations/nc-mail-client.js
@@ -43,7 +43,7 @@
  *       (find message by normalized Message-ID header, return databaseId)
  *
  *   resolveThreadUrl(folder, messageId)
- *     → resolveMailbox + resolveMessageDatabaseId
+ *     → resolveMailbox + syncMailbox (warm-only, see #180) + resolveMessageDatabaseId
  *     → {ncUrl}/apps/mail/box/{mailboxId}/thread/{databaseId}
  *
  * Dependency Map:
@@ -171,6 +171,23 @@ class NCMailClient {
   }
 
   /**
+   * Flag-neutral warmth probe: has NC Mail's own database ever synced this
+   * mailbox? Reads one message row from the DB (no IMAP traffic, no \Seen
+   * side effects). A cold mailbox — one NC Mail has never synced — returns
+   * an empty list. Any error or malformed response counts as cold, because
+   * cold is the safe assumption (#180).
+   *
+   * @param {number} mailboxId - The mailbox databaseId to probe
+   * @returns {Promise<boolean>} true when NC Mail's DB holds at least one message
+   */
+  async hasSyncedMessages(mailboxId) {
+    const messages = await this._getJson(
+      `/index.php/apps/mail/api/messages?mailboxId=${encodeURIComponent(mailboxId)}&limit=1`
+    );
+    return Array.isArray(messages) && messages.length > 0;
+  }
+
+  /**
    * Best-effort: ask NC Mail to sync a mailbox from IMAP into its database.
    *
    * The bridge ingests on a heartbeat (minutes) while NC Mail's own background
@@ -178,20 +195,27 @@ class NCMailClient {
    * is usually NOT yet in NC Mail's DB when we look it up — the lookup misses
    * and the link can't be built. A sync here closes that race.
    *
-   * Safe on \Seen: this syncs a mailbox the bridge already reads every pulse
-   * (warm), which fetches envelopes only and does NOT mark messages read.
-   * (A cold first-ever sync of a never-synced mailbox can mark pre-existing
-   * unread mail read; operators warm the trigger mailbox once by enabling its
-   * background sync — after that every sync here is incremental and safe.)
+   * NOTE(#180): an `init: true` full sync of a COLD mailbox (never synced by
+   * NC Mail) marks pre-existing unread mail \Seen — including the just-ingested
+   * trigger message itself — violating the bridge's never-mutate guarantee.
+   * The bridge reading the folder over IMAP does NOT warm NC Mail's DB, so
+   * warmth cannot be assumed; it is checked here, at the chokepoint, so no
+   * caller can trip the cold case: cold → the sync is skipped entirely (the
+   * Message-ID footer fallback holds and NC Mail's background sync warms the
+   * mailbox eventually). Warm → the sync is incremental and flag-neutral
+   * (verified live on the warm path). A plain non-init sync is not a safe
+   * substitute: it 428s without a sync token even on a warm mailbox.
    *
    * Best-effort: returns false on any error and never throws; resolution
    * continues regardless (the message may already be synced).
    *
    * @param {number} mailboxId - The mailbox databaseId to sync
-   * @returns {Promise<boolean>} true on a 2xx sync, false otherwise
+   * @returns {Promise<boolean>} true on a 2xx sync, false when skipped (cold) or on error
    */
   async syncMailbox(mailboxId) {
     try {
+      const warm = await this.hasSyncedMessages(mailboxId);
+      if (!warm) return false;
       const response = await this.nc.request(
         `/index.php/apps/mail/api/mailboxes/${encodeURIComponent(mailboxId)}/sync`,
         {
@@ -224,8 +248,10 @@ class NCMailClient {
       if (!mailbox) return null;
 
       // Close the sync race: pull the mailbox into NC Mail's DB before lookup,
-      // so a just-ingested email is present. Best-effort — a failed sync does
-      // not block resolution (the message may already be synced).
+      // so a just-ingested email is present. Best-effort — a failed or skipped
+      // sync does not block resolution (the message may already be synced).
+      // syncMailbox itself skips cold mailboxes (#180): on a cold mailbox the
+      // lookup below misses and the caller keeps the Message-ID footer.
       await this.syncMailbox(mailbox.mailboxId);
 
       const databaseId = await this.resolveMessageDatabaseId(mailbox.mailboxId, messageId);

--- a/src/security/guards/tool-guard.js
+++ b/src/security/guards/tool-guard.js
@@ -27,6 +27,8 @@ const FORBIDDEN = [
   'access_other_session', 'export_credentials',
 ];
 
+// NOTE(#217): gating policy has two homes (this list + GuardrailEnforcer.SENSITIVE_TOOLS);
+// single-home consolidation tracked for F1 retirement.
 const REQUIRES_APPROVAL = [
   // External communication
   'send_email', 'send_message_external', 'webhook_call',

--- a/test/unit/guards/tool-guard.test.js
+++ b/test/unit/guards/tool-guard.test.js
@@ -927,6 +927,20 @@ test('TC-TG-162: file_read is allowed', () => {
   assert.strictEqual(result.allowed, true);
 });
 
+// NOTE(#217): write-class tools (file_write, wiki_write, file_move) are deliberately
+// NOT in REQUIRES_APPROVAL — they are Cockpit-GATE-governed via
+// GuardrailEnforcer.SENSITIVE_TOOLS (the wiki_write precedent). ToolGuard passing
+// them through is load-bearing: the enforcer is their single gate. If one of these
+// assertions fails, the two-home gating policy changed — reconcile both homes.
+test('TC-TG-163: write-class tools pass ToolGuard (Cockpit-governed, not hardcoded)', () => {
+  const guard = new ToolGuard();
+  for (const tool of ['file_write', 'wiki_write', 'file_move']) {
+    const result = guard.evaluate(tool);
+    assert.strictEqual(result.level, 'ALLOWED', `${tool} should be ALLOWED at ToolGuard`);
+    assert.strictEqual(result.allowed, true, `${tool} should pass through to GuardrailEnforcer`);
+  }
+});
+
 // -----------------------------------------------------------------------------
 // Summary
 // -----------------------------------------------------------------------------

--- a/test/unit/integrations/nc-mail-client.test.js
+++ b/test/unit/integrations/nc-mail-client.test.js
@@ -230,10 +230,12 @@ function makeRoutes() {
     const syncCall = calls.find(c => c.path.includes('/index.php/apps/mail/api/mailboxes/99/sync'));
     assert.ok(syncCall, 'a sync POST should be issued for the resolved mailbox (id 99)');
     assert.strictEqual(syncCall.method, 'POST', 'sync must be a POST');
-    // The sync must precede the messages lookup.
+    // Order (#180): warmth probe (limit=1 DB read) → sync → lookup (limit=50).
+    const probeIdx = calls.findIndex(c => c.path.includes('/api/messages') && c.path.includes('limit=1'));
     const syncIdx = calls.findIndex(c => c.path.includes('/sync'));
-    const msgIdx = calls.findIndex(c => c.path.startsWith('/index.php/apps/mail/api/messages'));
-    assert.ok(syncIdx >= 0 && msgIdx >= 0 && syncIdx < msgIdx, 'sync must precede the messages lookup');
+    const lookupIdx = calls.findIndex(c => c.path.includes('/api/messages') && c.path.includes('limit=50'));
+    assert.ok(probeIdx >= 0 && syncIdx >= 0 && probeIdx < syncIdx, 'warmth probe must precede the sync');
+    assert.ok(lookupIdx >= 0 && syncIdx < lookupIdx, 'sync must precede the messages lookup');
   });
 
   // TC-MAIL-13: a failed sync does NOT block resolution (best-effort).
@@ -252,6 +254,81 @@ function makeRoutes() {
 
     const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
     assert.strictEqual(url, 'https://nc.example.com/apps/mail/box/99/thread/555', 'resolution proceeds despite sync failure');
+  });
+
+  // ------------------------------------------------------------------------
+  // #180: the cold-mailbox guarantee — no init:true sync on a mailbox NC Mail
+  // has never synced (a cold full sync marks pre-existing unread mail \Seen).
+  // ------------------------------------------------------------------------
+
+  /** Mock where NC Mail's DB is COLD for the mailbox: messages endpoint returns []. */
+  function createColdNC(calls) {
+    return {
+      ncUrl: 'https://nc.example.com',
+      request: async (path, opts) => {
+        calls.push({ path, method: (opts && opts.method) || 'GET' });
+        if (path.startsWith('/index.php/apps/mail/api/accounts')) return { status: 200, body: JSON.stringify(ACCOUNTS) };
+        if (path.includes('/sync')) return { status: 200, body: JSON.stringify({ newMessages: [] }) };
+        if (path.startsWith('/index.php/apps/mail/api/mailboxes')) return { status: 200, body: JSON.stringify(MAILBOXES_RESP) };
+        if (path.startsWith('/index.php/apps/mail/api/messages')) return { status: 200, body: JSON.stringify([]) };
+        return { status: 404, body: null };
+      }
+    };
+  }
+
+  // TC-MAIL-14: syncMailbox on a cold mailbox skips the sync POST entirely.
+  await asyncTest('TC-MAIL-14: syncMailbox never issues init sync on a cold mailbox (#180)', async () => {
+    const calls = [];
+    const client = new NCMailClient(createColdNC(calls));
+
+    const synced = await client.syncMailbox(99);
+
+    assert.strictEqual(synced, false, 'cold mailbox → sync reported as skipped');
+    const syncCall = calls.find(c => c.path.includes('/sync'));
+    assert.strictEqual(syncCall, undefined, 'no sync POST may reach a cold mailbox');
+  });
+
+  // TC-MAIL-15: resolveThreadUrl on a cold mailbox returns null (footer fallback)
+  // and issues no sync POST — flags on the human mailbox stay untouched.
+  await asyncTest('TC-MAIL-15: resolveThreadUrl on a cold mailbox skips sync, keeps fallback (#180)', async () => {
+    const calls = [];
+    const client = new NCMailClient(createColdNC(calls));
+
+    const url = await client.resolveThreadUrl('INBOX.INQUIRIES', '<msg1@host>');
+
+    assert.strictEqual(url, null, 'cold mailbox → no link, caller keeps Message-ID footer');
+    const syncCall = calls.find(c => c.path.includes('/sync'));
+    assert.strictEqual(syncCall, undefined, 'no sync POST may reach a cold mailbox');
+  });
+
+  // TC-MAIL-16: a failed warmth probe counts as cold (safe default) — no sync POST.
+  await asyncTest('TC-MAIL-16: failed warmth probe is treated as cold — no sync (#180)', async () => {
+    const calls = [];
+    const nc = {
+      ncUrl: 'https://nc.example.com',
+      request: async (path, opts) => {
+        calls.push({ path, method: (opts && opts.method) || 'GET' });
+        if (path.startsWith('/index.php/apps/mail/api/messages')) return { status: 503, body: null };
+        if (path.includes('/sync')) return { status: 200, body: JSON.stringify({ newMessages: [] }) };
+        return { status: 404, body: null };
+      }
+    };
+    const client = new NCMailClient(nc);
+
+    const synced = await client.syncMailbox(99);
+
+    assert.strictEqual(synced, false, 'probe error → treated as cold');
+    const syncCall = calls.find(c => c.path.includes('/sync'));
+    assert.strictEqual(syncCall, undefined, 'no sync POST when warmth is unknown');
+  });
+
+  // TC-MAIL-17: hasSyncedMessages — warm when the DB holds at least one message.
+  await asyncTest('TC-MAIL-17: hasSyncedMessages true on warm, false on cold DB', async () => {
+    const warmClient = new NCMailClient(createMockNC(makeRoutes()));
+    assert.strictEqual(await warmClient.hasSyncedMessages(99), true, 'messages present → warm');
+
+    const coldClient = new NCMailClient(createColdNC([]));
+    assert.strictEqual(await coldClient.hasSyncedMessages(99), false, 'empty DB → cold');
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);


### PR DESCRIPTION
Wave 0 of the 2026-07-03 backlog triage. Per the briefing's standing constraint, every phase began with a live read of `next` — and the headline finding is **drift**: three of the four hot patches (#217, #148, #172) had already landed on `next` after the triage was written. This PR carries the remainder: the #180 cold-mailbox fix (the one real gap), the #217 dual-home debt markers and design-pinning test, and live production evidence for all four issues so they can be closed.

## Drift report (live `next` vs. briefing premise)

| Phase | Briefing premise | Live state found |
|---|---|---|
| A1 #217 | `file_write` absent from both gate lists | **Landed** via PR #214 (merged): `file_write` in `GuardrailEnforcer.SENSITIVE_TOOLS` + categories + editable set, with Layer 1 coverage. `tool-guard.js` records the deliberate move of write-class tools OUT of `REQUIRES_APPROVAL` (the `wiki_write` precedent: Cockpit-GATE-governed, so automated/workflow writes are not forced through unconditional HITL). The briefing's "both lists" target matched the *destructive* precedent, not the live write precedent — revised per the drift rule. |
| A2 #148 | Username ships in fixture + deploy example | **Landed** via PR #151 (`fb5596c`): `YOUR_*`-as-empty config boundary, fixture scrubbed to `testuser`, service example ships commented-out empty defaults with the #148 warning text. |
| A3 #172 | No language directive in SOUL | **Landed** via PR #174 (`d7cfe06`): `config/SOUL.md` "Reply in the user's language" directive incl. `[Voice transcription]`-is-metadata neutralization; single home, no per-pipeline copies. |
| A4 #180 | `init: true` unconditional | **Still live** — fixed in this PR. |

## What this PR changes

1. **#180** — `syncMailbox` now probes warmth first (`hasSyncedMessages`: a flag-neutral, one-row DB read) and skips the sync entirely on a cold mailbox. Guard sits at the chokepoint so no caller can trip the cold case. Warm path keeps `init: true` (a plain non-init sync 428s without a sync token even on warm — Phase-0 evidence). Failed probe counts as cold, the safe default. Rejected shapes: non-init sync (428s), lazy deferred resolution (adds state for a case the footer fallback already covers).
2. **#217** — `NOTE(#217)` markers at both policy homes naming the two-home gating debt (single-home consolidation tracked for F1 retirement), plus `TC-TG-163` pinning the deliberate split (write-class tools pass ToolGuard; the enforcer is their single gate).

## Layer 1

- `test/unit/integrations/nc-mail-client.test.js`: 17/17 — new TC-MAIL-14..17 (cold skip, cold fallback preserves footer, probe-error-as-cold, warmth probe), TC-MAIL-12 updated for probe→sync→lookup ordering.
- `test/unit/guards/tool-guard.test.js`: 107/107 incl. new TC-TG-163.

## Layer 2 (live on the reference deployment, 2026-07-03)

**#180 — warmth probe against the real NC Mail API** (read-only harness driving the new `NCMailClient` code; shim rejects any non-GET):

```
mailbox "INBOX" (id=6): hasSyncedMessages=true
mailbox "INBOX.Sent" (id=9): hasSyncedMessages=true
mailbox "INBOX.spambucket" (id=14): hasSyncedMessages=false
mailbox "INBOX.INQUIRIES" (id=18): hasSyncedMessages=true
mailbox "INBOX.Trash" (id=24): hasSyncedMessages=false
```

The trigger mailbox (`INBOX.INQUIRIES`) is warm → sync continues to close the ingest race exactly as today. The never-synced mailboxes return cold → with this fix they would receive **no** `init: true` sync (previously they would have). Full cold-ingest reproduction (a genuinely cold *trigger* mailbox on a fresh install) remains the post-merge check; per the issue, the warm case has live evidence and the cold path is now structurally unreachable.

**#172 — reply-language matching, three live Talk runs** (forged signed webhooks, read-only calendar queries; `chat_outgoing` audit lines):

- DE `Was habe ich morgen auf dem Kalender?` → `"Guten Morgen. Heute ist noch ruhig — keine Termine im Kalender, und morgen (Samstag, 4. Juli) ist eb…"`
- PT `O que tenho na agenda amanhã?` → `"Você não tem nenhum compromisso agendado para amanhã (4 de julho).\n\nQuer que eu crie algo ou verifiq…"`
- EN `What is on my calendar tomorrow?` → `"You have no events scheduled for tomorrow (Saturday, July 4th)."`

**#217 — deployed gate state:** the running service's tree contains `file_write` in `SENSITIVE_TOOLS`/`TOOL_CATEGORIES`/`KEYWORD_FALLBACK_MAP`/`EDITABLE_TOOLS`; `GuardrailEnforcer.check('file_write', …)` reaches semantic evaluation (Layer 1 test from #214 asserts no short-circuit).

**#148 — scrub verified:** `git grep` for the literal deployment username on this branch: **zero hits**. Boot INIT on the reference deployment shares only to the deployment's own declared admin (`[INIT] Wiki share with [OPERATOR]: … already a member`) — the operator's own grant, which the issue explicitly preserves.

## Closing guidance (issues stay open; merge authority closes)

- **#217**: close on this PR + #214 (merged). The class fix (one policy home) stays tracked for Wave 3 / F1 retirement.
- **#148**: close on PR #151 + the zero-hit grep above. Affected installs still need the one-line env cleanup from the issue body.
- **#172**: close on PR #174 + the three transcripts above.
- **#180**: close after merge on the next trigger-mailbox ingest journal (lookup path with no init sync on cold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
