### PR TITLE
fix(wikisteward): signal integrity and the body medium (Phases 1-4 + Cleanup A)

### DIFF
--- a/scripts/cleanup-wiki-signal-integrity.js
+++ b/scripts/cleanup-wiki-signal-integrity.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+'use strict';
+
+/*
+ * Architecture Brief
+ * ------------------
+ * Problem: Before the signal-integrity fixes (Phases 3 and 4), every flag
+ * idempotency check keyed on strings the medium kept rewriting, so live
+ * pages accumulated contradiction-flag walls (one pair reached 179 stacked
+ * blocks); NC Text round-trips left escaped wikilinks that re-flooded
+ * Related sections; the root-create fallback strewed flat pages at the
+ * collective root; and the access_count=0 tautology marked real content
+ * pages compost_ready. The steward now writes correctly, but the corpus
+ * still carries the old damage.
+ *
+ * Pattern: One-shot repair script, pin-structural-pages.js lineage.
+ * DRY-RUN BY DEFAULT — prints every intended change and writes nothing.
+ * The write pass (--write) runs only after human approval of the dry-run
+ * report. NC file versioning / trash are the undo.
+ *
+ * What it does per page (one pass):
+ *   1. Collapse steward flag walls to ONE block per (marker, partner) pair —
+ *      the Phase 3 key. First occurrence wins; the claim text of dropped
+ *      blocks is gone (it was LLM rewording of the same finding).
+ *   2. Persist the Phase 4 medium repair: content is read through the
+ *      sanitizing chokepoint (attributes, <link href>, escaped wikilinks all
+ *      canonicalized) and written back clean.
+ *   3. Dedupe Related entries by link target (structural markup matching).
+ *   4. Strip stale verification_note frontmatter (Phase 3 deleted the writer).
+ *   5. Unmark compost_ready born from the access_count=0 tautology
+ *      (compost_ready true while access_count is 0/absent).
+ *   6. Trash stray root pages (flat fallback-born .md at the collective
+ *      root) — EXCEPT the configured keep-list: the "Moltagent Knowledge"
+ *      stray stays until the Phase 5 root-create fallback fix is live,
+ *      because deleting it earlier lets the live fallback recreate it.
+ *
+ * Writes go path-addressed via writePageContent — deliberately NOT
+ * writePageWithFrontmatter, whose title lookup falls back to creating
+ * root pages on a miss (the Phase 5 wound this corpus documents).
+ *
+ * Usage (dry run):
+ *   NC_CREDENTIAL_FILE=... NC_URL=... NC_USER=... node scripts/cleanup-wiki-signal-integrity.js
+ * Write pass (after dry-run approval):
+ *   ... node scripts/cleanup-wiki-signal-integrity.js --write
+ *
+ * @module cleanup-wiki-signal-integrity
+ */
+
+const NCRequestManager = require('../src/lib/nc-request-manager');
+const CollectivesClient = require('../src/lib/integrations/collectives-client');
+const { parseFrontmatter, serializeFrontmatter } = require('../src/lib/knowledge/frontmatter');
+
+const WRITE = process.argv.includes('--write');
+
+// Steward flag markers (system-emitted constants; see wiki-steward.js Phase 3)
+const FLAG_MARKERS = [
+  { marker: 'Contradiction flagged by Knowledge Steward', partnerRe: /conflicts with \[\[([^\]]+)\]\]|conflicts with \[([^\]]+)\]\(/ },
+  { marker: 'Near-duplicate flagged by Connection Steward', partnerRe: /same entity as \[\[([^\]]+)\]\]|same entity as \[([^\]]+)\]\(/ },
+];
+
+// Stray root pages that must NOT be touched yet (Phase 5 dependency).
+const KEEP_STRAYS = new Set(['Moltagent Knowledge']);
+
+// Bootstrap sections are legitimate root children (proper folder sections).
+const BOOTSTRAP_SECTIONS = new Set([
+  'People', 'Projects', 'Procedures', 'Research', 'Meta',
+  'Components', 'Infrastructure', 'Organizations', 'Agents', 'Documents', 'Sessions',
+].map(s => s.toLowerCase()));
+
+/** Collapse flag walls: keep the first line per (marker, partner) pair. */
+function collapseFlagWalls(body) {
+  const lines = body.split('\n');
+  const seenPairs = new Set();
+  const out = [];
+  let dropped = 0;
+  let prevDropped = false;
+  for (const line of lines) {
+    const flag = FLAG_MARKERS.find(f => line.includes(f.marker));
+    if (!flag) {
+      // Swallow at most one blank separator following a dropped flag line so
+      // collapsed walls don't leave hundreds of empty lines behind.
+      if (prevDropped && line.trim() === '') { prevDropped = false; continue; }
+      prevDropped = false;
+      out.push(line);
+      continue;
+    }
+    const m = flag.partnerRe.exec(line);
+    const partner = m ? (m[1] || m[2] || '').trim() : `__unparsed:${line.slice(0, 80)}`;
+    const key = `${flag.marker}::${partner}`;
+    if (seenPairs.has(key)) { dropped++; prevDropped = true; continue; }
+    seenPairs.add(key);
+    prevDropped = false;
+    out.push(line);
+  }
+  return { body: out.join('\n'), dropped, pairs: seenPairs.size };
+}
+
+/** Dedupe Related-section entries by link target (first occurrence wins). */
+function dedupeRelated(body) {
+  const lines = body.split('\n');
+  const out = [];
+  const seenTargets = new Set();
+  let inRelated = false;
+  let dropped = 0;
+  for (const line of lines) {
+    if (/^##\s+Related\s*$/.test(line.trim())) { inRelated = true; out.push(line); continue; }
+    if (/^##?#?\s+\S/.test(line) && !/^##\s+Related/.test(line)) inRelated = false;
+    if (inRelated) {
+      const m = /^\s*-\s*(?:\[\[([^\]]+)\]\]|\[([^\]]+)\]\()/.exec(line);
+      if (m) {
+        const target = (m[1] || m[2] || '').trim().toLowerCase();
+        if (seenTargets.has(target)) { dropped++; continue; }
+        seenTargets.add(target);
+      }
+    }
+    out.push(line);
+  }
+  return { body: out.join('\n'), dropped };
+}
+
+async function main() {
+  console.log(`=== Cleanup A: wiki signal-integrity repair — ${WRITE ? 'WRITE PASS' : 'DRY RUN (no writes)'} ===\n`);
+
+  const nc = new NCRequestManager({
+    nextcloud: { url: process.env.NC_URL, username: process.env.NC_USER },
+  });
+  nc.setBootstrapCredential();
+  await nc.resolveCanonicalUsername();
+  const client = new CollectivesClient(nc, { collectiveName: 'Moltagent Knowledge' });
+  const collectiveId = await client.resolveCollective();
+  const pages = await client.listPages(collectiveId);
+  const pageList = Array.isArray(pages) ? pages : [];
+  console.log(`collective ${collectiveId}: ${pageList.length} pages\n`);
+
+  const landing = pageList.find(p => p.parentId === 0 || p.parentId == null);
+
+  const bodyRepairs = [];
+  const compostUnmarks = [];
+
+  for (const p of pageList) {
+    if (landing && p.id === landing.id) continue;
+    const pagePath = p.filePath ? `${p.filePath}/${p.fileName}` : p.fileName;
+    if (!pagePath) continue;
+
+    let content;
+    try {
+      // Sanitized read: the Phase 4 chokepoint canonicalizes Tiptap
+      // attributes, <link href> marks, and escaped wikilinks right here.
+      content = await client.readPageContent(pagePath);
+    } catch (err) {
+      console.log(`READ FAILED ${pagePath}: ${err.message}`);
+      continue;
+    }
+    if (content == null) continue;
+
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    const walls = collapseFlagWalls(body);
+    const related = dedupeRelated(walls.body);
+
+    const fm = { ...frontmatter };
+    const fmChanges = [];
+    if ('verification_note' in fm) { delete fm.verification_note; fmChanges.push('verification_note stripped'); }
+    if (fm.compost_ready === true && !(Number(fm.access_count) > 0)) {
+      delete fm.compost_ready;
+      delete fm.compost_reason;
+      delete fm.compost_marked_at;
+      fmChanges.push('compost_ready unmarked (access_count=0 tautology)');
+      compostUnmarks.push(p.title);
+    }
+
+    const hadFm = Object.keys(frontmatter).length > 0;
+    const newContent = hadFm || Object.keys(fm).length > 0
+      ? serializeFrontmatter(fm, related.body)
+      : related.body;
+
+    if (newContent !== content) {
+      bodyRepairs.push({
+        id: p.id,
+        title: p.title,
+        path: pagePath,
+        bytesBefore: content.length,
+        bytesAfter: newContent.length,
+        flagBlocksDropped: walls.dropped,
+        flagPairsKept: walls.pairs,
+        relatedDupesDropped: related.dropped,
+        fmChanges,
+      });
+      if (WRITE) {
+        await client.writePageContent(pagePath, newContent);
+        console.log(`WROTE ${pagePath}`);
+      }
+    }
+  }
+
+  // Stray root pages: flat fallback-born .md files at the collective root.
+  const strays = pageList.filter(p =>
+    landing && p.parentId === landing.id &&
+    !p.filePath && // flat file at root — proper sections are folders
+    !BOOTSTRAP_SECTIONS.has((p.title || '').toLowerCase())
+  );
+
+  console.log('--- Body repairs (walls, related dupes, medium, frontmatter) ---');
+  console.log('| id | page | bytes before → after | flag blocks dropped | pairs kept | related dupes | frontmatter |');
+  console.log('|---|---|---|---|---|---|---|');
+  for (const r of bodyRepairs) {
+    console.log(`| ${r.id} | ${r.title} | ${r.bytesBefore} → ${r.bytesAfter} | ${r.flagBlocksDropped} | ${r.flagPairsKept} | ${r.relatedDupesDropped} | ${r.fmChanges.join('; ') || '—'} |`);
+  }
+
+  console.log('\n--- Stray root pages (flat fallback-born files) ---');
+  for (const s of strays) {
+    const keep = KEEP_STRAYS.has(s.title);
+    const action = keep ? 'KEEP until Phase 5 fallback fix is live' : 'TRASH (soft-delete; NC trash is the undo)';
+    console.log(`  id=${s.id} "${s.title}" (${s.fileName}) → ${action}`);
+    if (WRITE && !keep) {
+      await client.trashPage(collectiveId, s.id);
+      console.log(`  TRASHED ${s.id}`);
+    }
+  }
+
+  console.log(`\n--- compost_ready unmarked (${compostUnmarks.length}) ---`);
+  for (const t of compostUnmarks) console.log(`  ${t}`);
+
+  console.log(`\n${WRITE ? 'Write pass complete.' : 'Dry run complete — nothing written.'}`);
+  console.log(`Pages needing body repair: ${bodyRepairs.length}; strays to trash: ${strays.filter(s => !KEEP_STRAYS.has(s.title)).length}; kept strays: ${strays.filter(s => KEEP_STRAYS.has(s.title)).length}`);
+}
+
+main().catch(err => { console.error('CLEANUP FAILED:', err.message); process.exit(1); });

--- a/src/lib/integrations/collectives-client.js
+++ b/src/lib/integrations/collectives-client.js
@@ -478,6 +478,18 @@ class CollectivesClient {
   /**
    * Sanitize content by stripping Tiptap/Prosemirror internal tags and
    * stray HTML, converting them to clean markdown equivalents.
+   *
+   * This is the read chokepoint that makes the page body a canonical medium:
+   * every consumer of readPageContent sees the same markdown regardless of
+   * how many NC Text round-trips the file survived. The editor injects
+   * attributes (<paragraph dir="ltr">, <listitem dir="ltr">,
+   * <bulletlist bullet="-" isList="true">), emits <link href> marks, and
+   * escapes wikilink brackets — all repaired here, nowhere else.
+   *
+   * LANGUAGE POLICY: every regex in this method matches structural editor
+   * serialization (fixed tags, attributes, bracket escapes), never natural
+   * language. Content between tags passes through untouched.
+   *
    * @private
    * @param {string} content - Raw content that may contain HTML/Tiptap tags
    * @returns {string} Clean markdown content
@@ -487,23 +499,37 @@ class CollectivesClient {
 
     let s = content;
 
-    // Tiptap heading wrappers → markdown headings
-    s = s.replace(/<heading\s+level="(\d)">([\s\S]*?)<\/heading>/gi,
+    // Tiptap heading wrappers → markdown headings (attribute-tolerant: the
+    // NC Text round-trip decorates every tag; a pattern anchored on the bare
+    // tag silently stops matching and the catch-all below destroys structure)
+    s = s.replace(/<heading\b[^>]*level="(\d)"[^>]*>([\s\S]*?)<\/heading>/gi,
       (_, lvl, text) => '#'.repeat(parseInt(lvl)) + ' ' + text.trim());
 
+    // Tiptap link mark → markdown link. Must run before the list/paragraph
+    // unwrapping and the catch-all strip, which would drop the tag and lose
+    // the URL.
+    s = s.replace(/<link\b[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/link>/gi, '[$2]($1)');
+
+    // Tiptap list items (with or without inner paragraph wrapper) → bullets
+    s = s.replace(/<listitem\b[^>]*><paragraph\b[^>]*>([\s\S]*?)<\/paragraph><\/listitem>/gi, '- $1\n');
+    s = s.replace(/<listitem\b[^>]*>([\s\S]*?)<\/listitem>/gi, '- $1\n');
+
     // Tiptap paragraph wrappers → plain text + newline
-    s = s.replace(/<paragraph>([\s\S]*?)<\/paragraph>/gi, '$1\n');
+    s = s.replace(/<paragraph\b[^>]*>([\s\S]*?)<\/paragraph>/gi, '$1\n');
 
     // Tiptap list wrappers
-    s = s.replace(/<bulletlist>/gi, '');
-    s = s.replace(/<\/bulletlist>/gi, '');
-    s = s.replace(/<orderedlist>/gi, '');
-    s = s.replace(/<\/orderedlist>/gi, '');
-    s = s.replace(/<listitem><paragraph>([\s\S]*?)<\/paragraph><\/listitem>/gi, '- $1\n');
-    s = s.replace(/<listitem>([\s\S]*?)<\/listitem>/gi, '- $1\n');
+    s = s.replace(/<\/?bulletlist\b[^>]*>/gi, '');
+    s = s.replace(/<\/?orderedlist\b[^>]*>/gi, '');
 
     // Tiptap hardbreak
-    s = s.replace(/<hardbreak\s*\/?>/gi, '\n');
+    s = s.replace(/<hardbreak\b[^>]*\/?>/gi, '\n');
+
+    // Escaped wikilinks → live markup. NC Text escapes literal brackets on
+    // round-trip (backslash before each bracket on disk), after which the
+    // wikilink resolver and every idempotency check go blind to the link.
+    // Only the full exact \[\[target\]\] shape is repaired; lone escaped
+    // brackets in prose are untouched.
+    s = s.replace(/\\\[\\\[([^\]\\]+?)\\\]\\\]/g, '[[$1]]');
 
     // Standard HTML tags that might leak through
     s = s.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,

--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -142,6 +142,10 @@ class HeartbeatManager {
     // its single call site, so judging is never on the request path.
     this.localJudge = config.localJudge || null;
 
+    // ModelScorecard (optional, maturation loop): handed to WikiSteward so
+    // _assess outcomes record organic (synthesis, model, language) samples.
+    this.modelScorecard = config.modelScorecard || null;
+
     // NicheAssignment (optional, Layer 3): /api/ps snapshot + replan each
     // pulse. A thunk, not an instance — it is constructed asynchronously
     // (after ModelScout discovery), possibly after this manager.
@@ -311,10 +315,11 @@ class HeartbeatManager {
         embeddingClient: this.embeddingClient,
         llmRouter: this.llmRouter,
         observationLog: this._observationLog,
+        modelScorecard: this.modelScorecard,
         logger: console,
         // collectiveId omitted — WikiSteward will resolve it via collectivesClient
       });
-      console.log('[Heartbeat] WikiSteward initialized');
+      console.log(`[Heartbeat] WikiSteward initialized (scorecard: ${this.modelScorecard ? 'wired' : 'absent'})`);
     } catch (err) {
       console.warn('[Heartbeat] WikiSteward initialization failed:', err.message);
       return null;

--- a/src/lib/maintenance/observation-log.js
+++ b/src/lib/maintenance/observation-log.js
@@ -64,6 +64,9 @@ const OBSERVATION_TYPES = Object.freeze({
   NEVER_ACCESSED:  'never_accessed',   // Page created but never retrieved
   COMPOST_READY:   'compost_ready',    // Past decay + never accessed + low confidence
   HIGH_ACCESS:     'high_access',      // Frequently accessed, may need strengthening
+
+  // Steward self-observation — the steward instruments its own senses
+  EMPTY_NEIGHBORHOOD: 'empty_neighborhood', // Neighborhood read 0 pages while the cluster census reports > 0 (#51 class)
 });
 
 // Collect all valid type values for O(1) validation

--- a/src/lib/maintenance/observation-log.js
+++ b/src/lib/maintenance/observation-log.js
@@ -188,13 +188,18 @@ class ObservationLog {
    *
    * @param {string} cluster - Cluster name whose observations to resolve.
    * @param {string|string[]} types - Type tag(s) to resolve within that cluster.
+   * @param {string|string[]} [pages] - Optional page title(s); when provided,
+   *   only observations for those pages transition. Omitting it preserves the
+   *   original (cluster, types) wholesale behavior for existing callers.
    * @returns {number} Count of observations transitioned to resolved.
    */
-  resolve(cluster, types) {
+  resolve(cluster, types, pages) {
     const typeList = Array.isArray(types) ? types : [types];
+    const pageSet = pages != null ? new Set(Array.isArray(pages) ? pages : [pages]) : null;
     let count = 0;
     for (const o of this._observations) {
-      if (o.cluster === cluster && typeList.includes(o.type) && !o.resolved) {
+      if (o.cluster === cluster && typeList.includes(o.type) && !o.resolved
+          && (pageSet === null || pageSet.has(o.page))) {
         o.resolved = true;
         count++;
       }

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -49,7 +49,7 @@
  *         → _intervene(stewardType, assessment, neighborhood)  (per-lens executors)
  *         → _updateSectionSummaries(sections)  (Level 1 refresh if pages changed)
  *         → _updateLandingPage() (Level 0 refresh, throttled by _shouldRefreshIndex)
- *         → observationLog.resolve(cluster, resolvedTypes)
+ *         → observationLog.resolve(cluster, type, pages)  (per executor action)
  *         → _lastVisit.set(cluster, now)
  * - Dependency Map:
  *     heartbeat-manager.js → wiki-steward.js → {
@@ -112,7 +112,8 @@
  * @property {number} pagesModified
  * @property {number} linksAdded
  * @property {number} observationsResolved
- * @property {string[]} resolvedTypes
+ * @property {Array<{type: string, page: string}>} resolutions - What the
+ *   executors actually acted on; the only thing tend() resolves.
  */
 
 /**
@@ -213,7 +214,7 @@ class WikiSteward {
    *   5. Intervene — execute targeted actions from the assessment.
    *   6. Refresh Level 1 section summaries when pages changed.
    *   7. Periodically refresh Level 0 landing page.
-   *   8. Mark observations as resolved for (cluster, resolvedTypes).
+   *   8. Resolve observations per (cluster, type, pages) the executors acted on.
    *   9. Record visit timestamp in _lastVisit.
    *
    * @returns {Promise<TendResult>}
@@ -300,7 +301,7 @@ class WikiSteward {
       interventionResult = await this._intervene(stewardType, assessment, neighborhood);
     } catch (err) {
       this.logger.warn(`[WikiSteward:${stewardType}] _intervene failed: ${err.message}`);
-      interventionResult = { pagesModified: 0, linksAdded: 0, observationsResolved: 0, resolvedTypes: [] };
+      interventionResult = { pagesModified: 0, linksAdded: 0, observationsResolved: 0, resolutions: [] };
     }
 
     // Step 6: refresh Level 1 summaries if pages were modified
@@ -321,10 +322,19 @@ class WikiSteward {
       }
     }
 
-    // Step 8: resolve handled observations
+    // Step 8: resolve exactly what the executors acted on, per (type, pages)
+    // group. observationsResolved is the sum of resolve()'s actual transition
+    // counts — a tend that performed no action resolves zero (G2, #161 class).
+    let observationsResolved = 0;
     try {
-      if (interventionResult.resolvedTypes && interventionResult.resolvedTypes.length > 0) {
-        this.observations.resolve(cluster.name, interventionResult.resolvedTypes);
+      const pagesByType = new Map();
+      for (const r of interventionResult.resolutions || []) {
+        if (!r || !r.type || !r.page) continue;
+        if (!pagesByType.has(r.type)) pagesByType.set(r.type, new Set());
+        pagesByType.get(r.type).add(r.page);
+      }
+      for (const [type, pages] of pagesByType) {
+        observationsResolved += this.observations.resolve(cluster.name, type, [...pages]);
       }
     } catch (err) {
       this.logger.warn(`[WikiSteward] observations.resolve failed: ${err.message}`);
@@ -338,7 +348,7 @@ class WikiSteward {
       cluster: cluster.name,
       pagesModified: interventionResult.pagesModified,
       linksAdded: interventionResult.linksAdded,
-      observationsResolved: interventionResult.observationsResolved,
+      observationsResolved,
       pagesInNeighborhood,
       skipped: false,
     };
@@ -970,7 +980,9 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       pagesModified: 0,
       linksAdded: 0,
       observationsResolved: 0,
-      resolvedTypes: [],
+      // (type, page) pairs the executors actually acted on. tend() resolves
+      // exactly these — visiting is not resolving (G2, #161 class).
+      resolutions: [],
     };
 
     if (!assessment || typeof assessment !== 'object') {
@@ -997,7 +1009,13 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
           try {
             const flagged = await this._flagContradiction(c.pageA, c.pageB, c.claim);
-            if (flagged) results.pagesModified += 2;
+            if (flagged) {
+              results.pagesModified += 2;
+              for (const p of [c.pageA, c.pageB]) {
+                results.resolutions.push({ type: 'contradiction', page: p });
+                results.resolutions.push({ type: 'low_confidence', page: p });
+              }
+            }
           } catch (err) {
             this.logger.warn(`[WikiSteward:knowledge] _flagContradiction failed: ${err.message}`);
           }
@@ -1009,7 +1027,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
           try {
             const lowered = await this._lowerConfidence(s.page, s.reason);
-            if (lowered) results.pagesModified++;
+            if (lowered) {
+              results.pagesModified++;
+              results.resolutions.push({ type: 'stale_content', page: s.page });
+            }
           } catch (err) {
             this.logger.warn(`[WikiSteward:knowledge] _lowerConfidence("${s.page}") failed: ${err.message}`);
           }
@@ -1019,12 +1040,14 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         // referencing page is structural. No guard needed here.
         for (const g of assessment.gaps || []) {
           try {
-            await this._logKnowledgeGap(g.entity, g.referencedIn);
+            const logged = await this._logKnowledgeGap(g.entity, g.referencedIn);
+            if (logged && g.referencedIn) {
+              results.resolutions.push({ type: 'gap', page: g.referencedIn });
+            }
           } catch (err) {
             this.logger.warn(`[WikiSteward:knowledge] _logKnowledgeGap("${g.entity}") failed: ${err.message}`);
           }
         }
-        results.resolvedTypes = ['contradiction', 'stale_content', 'gap', 'low_confidence'];
         break;
       }
 
@@ -1039,6 +1062,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             if (added) {
               results.linksAdded++;
               results.pagesModified++;
+              results.resolutions.push({ type: 'missing_link', page: m.page });
             }
           } catch (err) {
             this.logger.warn(`[WikiSteward:connection] _addWikilink("${m.page}"→"${m.shouldLinkTo}") failed: ${err.message}`);
@@ -1055,6 +1079,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
               if (added) {
                 results.linksAdded++;
                 results.pagesModified++;
+                results.resolutions.push({ type: 'orphan_page', page: o.page });
               }
             } catch (err) {
               this.logger.warn(`[WikiSteward:connection] _addWikilink orphan("${o.page}"→"${target}") failed: ${err.message}`);
@@ -1067,12 +1092,15 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             continue;
           }
           try {
-            await this._flagDuplicate(d.pageA, d.pageB, d.similarity || 0);
+            const flagged = await this._flagDuplicate(d.pageA, d.pageB, d.similarity || 0);
+            if (flagged) {
+              results.resolutions.push({ type: 'near_duplicate', page: d.pageA });
+              results.resolutions.push({ type: 'near_duplicate', page: d.pageB });
+            }
           } catch (err) {
             this.logger.warn(`[WikiSteward:connection] _flagDuplicate failed: ${err.message}`);
           }
         }
-        results.resolvedTypes = ['missing_link', 'orphan_page', 'near_duplicate', 'section_stale'];
         break;
       }
 
@@ -1084,7 +1112,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           }
           try {
             const strengthened = await this._strengthenPage(s.page);
-            if (strengthened) results.pagesModified++;
+            if (strengthened) {
+              results.pagesModified++;
+              results.resolutions.push({ type: 'high_access', page: s.page });
+            }
           } catch (err) {
             this.logger.warn(`[WikiSteward:memory] _strengthenPage("${s.page}") failed: ${err.message}`);
           }
@@ -1095,7 +1126,8 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
             continue;
           }
           try {
-            await this._markForComposting(c.page, c.reason);
+            const marked = await this._markForComposting(c.page, c.reason);
+            if (marked) results.resolutions.push({ type: 'compost_ready', page: c.page });
           } catch (err) {
             this.logger.warn(`[WikiSteward:memory] _markForComposting("${c.page}") failed: ${err.message}`);
           }
@@ -1108,12 +1140,12 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           // Find the full pageRef from neighborhood so _embedPage has path/section
           const pageRef = neighborhood.pages.find(p => p.title === e.page) || { id: null, title: e.page };
           try {
-            await this._embedPage(pageRef);
+            const embedded = await this._embedPage(pageRef);
+            if (embedded) results.resolutions.push({ type: 'unembedded', page: pageRef.title });
           } catch (err) {
             this.logger.warn(`[WikiSteward:memory] _embedPage("${e.page}") failed: ${err.message}`);
           }
         }
-        results.resolvedTypes = ['unembedded', 'never_accessed', 'compost_ready', 'high_access'];
         break;
       }
 
@@ -1121,7 +1153,6 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         this.logger.warn(`[WikiSteward] Unknown stewardType in _intervene: "${stewardType}"`);
     }
 
-    results.observationsResolved = results.resolvedTypes.length;
     return results;
   }
 
@@ -1217,7 +1248,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
    * @returns {Promise<void>}
    */
   async _logKnowledgeGap(entity, referencedIn) {
-    if (!entity) return;
+    if (!entity) return false;
 
     const pendingQuestionsPath = 'Meta/Pending Questions.md';
     const line = `- ${entity} — referenced in [[${referencedIn || 'unknown'}]], no page yet`;
@@ -1230,7 +1261,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
     }
 
     // Idempotency: skip if this exact entity line is already recorded
-    if (existing.includes(`- ${entity} —`)) return;
+    if (existing.includes(`- ${entity} —`)) return false;
 
     const updated = existing
       ? `${existing.trimEnd()}\n${line}\n`
@@ -1240,8 +1271,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       const resolved = await this._resolveWikilinks(updated);
       await this.collectivesClient.writePageContent(pendingQuestionsPath, resolved);
       this.logger.info(`[WikiSteward:knowledge] Logged knowledge gap: "${entity}" (referenced in ${referencedIn})`);
+      return true;
     } catch (err) {
       this.logger.warn(`[WikiSteward:knowledge] _logKnowledgeGap write failed: ${err.message}`);
+      return false;
     }
   }
 

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -43,7 +43,7 @@
  *     heartbeat pulse
  *       → wikiSteward.tend()
  *         → _findNeediest() (observationLog + _lastVisit)
- *         → _nextSteward()  (rotation)
+ *         → _nextSteward(cluster.name)  (per-cluster rotation)
  *         → _readNeighborhood(cluster)  (CollectivesClient + KnowledgeGraph + VectorStore)
  *         → _assess(stewardType, neighborhood)  (llmRouter.route, ONE call)
  *         → _intervene(stewardType, assessment, neighborhood)  (per-lens executors)
@@ -167,9 +167,13 @@ class WikiSteward {
 
     this.config = config || {};
 
-    // Steward rotation — three lenses on the same neighborhood.
-    /** @type {number} */
-    this._stewardIndex = 0;
+    // Steward rotation — three lenses on the same neighborhood, rotated
+    // per cluster. A global index lens-locks every cluster whenever the
+    // cluster count is divisible by three (15 clusters × 3 lenses meant
+    // People only ever saw the knowledge lens). In-memory, same documented
+    // amnesia class as _lastVisit.
+    /** @type {Map<string, number>} */
+    this._lensIndexByCluster = new Map();
     /** @type {string[]} */
     this._stewards = ['knowledge', 'connection', 'memory'];
 
@@ -232,7 +236,7 @@ class WikiSteward {
     }
 
     // Step 2: pick the active steward lens
-    const stewardType = this._nextSteward();
+    const stewardType = this._nextSteward(cluster.name);
 
     this.logger.info(
       `[WikiSteward:${stewardType}] Tending cluster "${cluster.name}" ` +
@@ -391,15 +395,17 @@ class WikiSteward {
   // ---------------------------------------------------------------------------
 
   /**
-   * Rotate through stewards. Each pulse, the next lens walks.
-   * Trivial ring rotation — safe to implement here.
+   * Rotate through stewards per cluster: each cluster advances its own lens
+   * on each of its own visits. Invariant: three consecutive visits to one
+   * cluster use three different lenses, regardless of cluster count.
    *
+   * @param {string} clusterName
    * @returns {string} One of 'knowledge' | 'connection' | 'memory'
    */
-  _nextSteward() {
-    const steward = this._stewards[this._stewardIndex];
-    this._stewardIndex = (this._stewardIndex + 1) % this._stewards.length;
-    return steward;
+  _nextSteward(clusterName) {
+    const idx = this._lensIndexByCluster.get(clusterName) || 0;
+    this._lensIndexByCluster.set(clusterName, (idx + 1) % this._stewards.length);
+    return this._stewards[idx];
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -135,6 +135,10 @@ class WikiSteward {
    * @param {Object} options.embeddingClient
    * @param {Object} options.llmRouter - router.route({ job, content, requirements }) → { result }
    * @param {Object} options.observationLog - Shared ObservationLog instance
+   * @param {Object} [options.modelScorecard] - ModelScorecard (maturation loop).
+   *   Optional and null-safe: when present, every _assess outcome records one
+   *   organic (synthesis, model, language) envelope-validity sample. The
+   *   steward only testifies; the loop owns selection.
    * @param {Object} [options.logger]
    * @param {string} [options.collectiveId]
    * @param {Object} [options.config={}] - Tuning knobs (indexRefreshIntervalMs, bodyPreviewChars, etc.)
@@ -146,6 +150,7 @@ class WikiSteward {
     embeddingClient,
     llmRouter,
     observationLog,
+    modelScorecard,
     logger,
     collectiveId,
     config = {},
@@ -163,6 +168,7 @@ class WikiSteward {
     this.embeddingClient = embeddingClient;
     this.router = llmRouter;
     this.observations = observationLog;
+    this.modelScorecard = modelScorecard || null;
     this.logger = logger || console;
     this.collectiveId = collectiveId || null;
 
@@ -730,14 +736,35 @@ class WikiSteward {
 
     const raw = routerResult?.result || routerResult?.content || '';
 
+    let parsed = null;
+    let parseError = null;
     try {
-      return _extractJsonObject(raw);
+      parsed = _extractJsonObject(raw);
     } catch (err) {
+      parseError = err;
+    }
+
+    // Maturation-loop testimony (Layer 2): one organic sample per assessment.
+    // Envelope validity is the mechanical signal — the same class IntentRouter
+    // records for classification parse failures. Sits outside the fallback
+    // return so success and failure each record exactly once.
+    const envelopeValid = parsed !== null && typeof parsed === 'object';
+    if (this.modelScorecard && routerResult?.model) {
+      try {
+        // Language omitted on purpose: the scorecard defaults to the cockpit language.
+        this.modelScorecard.recordSample('synthesis', routerResult.model, null, envelopeValid);
+      } catch (err) {
+        this.logger.warn(`[WikiSteward:${stewardType}] recordSample failed: ${err.message}`);
+      }
+    }
+
+    if (parseError) {
       this.logger.warn(
-        `[WikiSteward:${stewardType}] Assessment JSON parse failed (${err.message}) — raw (first 400): ${String(raw).slice(0, 400)}`
+        `[WikiSteward:${stewardType}] Assessment JSON parse failed (${parseError.message}) — raw (first 400): ${String(raw).slice(0, 400)}`
       );
       return { actions: [] };
     }
+    return parsed;
   }
 
   /**

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -1195,19 +1195,23 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
   async _flagContradiction(pageA, pageB, claim) {
     if (!pageA || !pageB || !claim) return false;
 
-    const flagA = `> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [[${pageB}]] on "${claim}"`;
-    const flagB = `> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [[${pageA}]] on "${claim}"`;
+    const marker = 'Contradiction flagged by Knowledge Steward';
+    const flagA = `> ⚠️ ${marker}: conflicts with [[${pageB}]] on "${claim}"`;
+    const flagB = `> ⚠️ ${marker}: conflicts with [[${pageA}]] on "${claim}"`;
 
     let modified = false;
 
     // Write to pageA — route through writePageWithFrontmatter so [[pageB]] is resolved.
+    // Dedup keys on (marker, partner title), never on the claim text: the claim
+    // is LLM-worded and the link form mutates on write (PR #50 Fix A class).
     try {
       const resultA = await this.collectivesClient.readPageWithFrontmatter(pageA);
       if (resultA) {
         const body = resultA.body || '';
-        if (!body.includes(flagA)) {
+        if (!this._hasFlagForPair(body, marker, pageB)) {
           const newBody = body + `\n\n${flagA}\n`;
           await this.collectivesClient.writePageWithFrontmatter(pageA, resultA.frontmatter, newBody);
+          this.logger.info(`[WikiSteward:knowledge] Flagged contradiction on "${pageA}" vs "${pageB}"`);
           modified = true;
         }
       }
@@ -1220,9 +1224,10 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       const resultB = await this.collectivesClient.readPageWithFrontmatter(pageB);
       if (resultB) {
         const body = resultB.body || '';
-        if (!body.includes(flagB)) {
+        if (!this._hasFlagForPair(body, marker, pageA)) {
           const newBody = body + `\n\n${flagB}\n`;
           await this.collectivesClient.writePageWithFrontmatter(pageB, resultB.frontmatter, newBody);
+          this.logger.info(`[WikiSteward:knowledge] Flagged contradiction on "${pageB}" vs "${pageA}"`);
           modified = true;
         }
       }
@@ -1259,7 +1264,15 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       ? confidenceSteps[idx + 1]
       : 'low';
     fm.last_verification_attempt = new Date().toISOString().split('T')[0];
-    fm.verification_note = reason || 'Confidence lowered by Knowledge Steward';
+    // verification_note is gone (gate amendment 1): it was LLM-worded prose,
+    // so identical page state produced different bytes on every visit — one
+    // live page accumulated 871 NC versions from this alone. Nothing reads
+    // the field; the reason stays in the log line below.
+    delete fm.verification_note;
+
+    // Equality guard: identical state produces identical bytes — no write,
+    // no pagesModified, no spurious Level 1 refresh.
+    if (JSON.stringify(fm) === JSON.stringify(result.frontmatter)) return false;
 
     await this.collectivesClient.writePageWithFrontmatter(page, fm, result.body || '');
     this.logger.info(`[WikiSteward:knowledge] Lowered confidence for "${page}" to ${fm.confidence}: ${reason}`);
@@ -1378,21 +1391,25 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       detail: `Possible duplicate of [[${pageA}]] (similarity: ${simLabel})`,
     });
 
-    const warningBlock = `> ⚠️ Near-duplicate flagged by Connection Steward: possibly the same entity as [[${pageB}]] (similarity: ${simLabel}). Manual review recommended.`;
-    const warningBlockB = `> ⚠️ Near-duplicate flagged by Connection Steward: possibly the same entity as [[${pageA}]] (similarity: ${simLabel}). Manual review recommended.`;
+    const marker = 'Near-duplicate flagged by Connection Steward';
+    const warningBlock = `> ⚠️ ${marker}: possibly the same entity as [[${pageB}]] (similarity: ${simLabel}). Manual review recommended.`;
+    const warningBlockB = `> ⚠️ ${marker}: possibly the same entity as [[${pageA}]] (similarity: ${simLabel}). Manual review recommended.`;
 
     let modified = false;
 
-    for (const [pageName, warning] of [[pageA, warningBlock], [pageB, warningBlockB]]) {
+    for (const [pageName, warning, partner] of [[pageA, warningBlock, pageB], [pageB, warningBlockB, pageA]]) {
       try {
         const result = await this.collectivesClient.readPageWithFrontmatter(pageName);
         if (!result) continue;
         const body = result.body || '';
-        if (body.includes('Near-duplicate flagged by Connection Steward')) continue; // already flagged
+        // Pair key, not one-flag-ever: a page can be flagged against two
+        // different partners while staying idempotent per pair.
+        if (this._hasFlagForPair(body, marker, partner)) continue;
         const newBody = body + `\n\n${warning}\n`;
         // Route through writePageWithFrontmatter so the [[other page]] reference
         // is resolved to a live Nextcloud link instead of dead text.
         await this.collectivesClient.writePageWithFrontmatter(pageName, result.frontmatter, newBody);
+        this.logger.info(`[WikiSteward:connection] Flagged near-duplicate on "${pageName}" vs "${partner}"`);
         modified = true;
       } catch (err) {
         this.logger.warn(`[WikiSteward:connection] _flagDuplicate write to "${pageName}" failed: ${err.message}`);
@@ -1400,6 +1417,29 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
     }
 
     return modified;
+  }
+
+  /**
+   * Structural idempotency key for pair-keyed steward flags: a flag line for
+   * a (marker, partner) pair exists iff some line carries both the invariant
+   * marker phrase and the partner title as plain substrings. Both survive
+   * wikilink resolution ([[T]] → [T](url)), NC Text round-trips (attribute
+   * injection, escaping), and LLM claim rewording — the three rewriters that
+   * defeated full-string checks and grew the flag walls (PR #50 Fix A class).
+   * Matching a fixed system-emitted marker and a known title is structural
+   * markup matching, inside the language policy — same as the existing
+   * `[target](` check in _addWikilink.
+   *
+   * @param {string} body
+   * @param {string} markerPhrase - System-emitted constant, e.g. 'Contradiction flagged by Knowledge Steward'
+   * @param {string} partnerTitle - Partner page title (plain substring match)
+   * @returns {boolean}
+   */
+  _hasFlagForPair(body, markerPhrase, partnerTitle) {
+    if (!body || !markerPhrase || !partnerTitle) return false;
+    return body.split('\n').some(
+      line => line.includes(markerPhrase) && line.includes(partnerTitle)
+    );
   }
 
   /**

--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -122,6 +122,7 @@
  * @property {number} pagesModified
  * @property {number} linksAdded
  * @property {number} observationsResolved
+ * @property {number} pagesInNeighborhood - Pages actually read for the tended cluster.
  */
 
 class WikiSteward {
@@ -177,6 +178,13 @@ class WikiSteward {
     /** @type {Map<string, number>} */
     this._lastVisit = new Map();
 
+    // Consecutive zero-page neighborhood reads per cluster while the census
+    // reports pages. The failure class that hid #51 for a month: a silent
+    // section-derivation drift reads as "cluster healthy, nothing to tend".
+    // In-memory, same documented amnesia class as _lastVisit.
+    /** @type {Map<string, number>} */
+    this._zeroPageStreak = new Map();
+
     // Level 0 landing page throttling.
     /** @type {number} */
     this._lastIndexRefresh = 0;
@@ -207,7 +215,7 @@ class WikiSteward {
    * @returns {Promise<TendResult>}
    */
   async tend() {
-    const idle = { steward: null, cluster: null, pagesModified: 0, linksAdded: 0, observationsResolved: 0 };
+    const idle = { steward: null, cluster: null, pagesModified: 0, linksAdded: 0, observationsResolved: 0, pagesInNeighborhood: 0 };
 
     // Step 1: pick the neediest cluster
     let cluster;
@@ -238,6 +246,39 @@ class WikiSteward {
     } catch (err) {
       this.logger.warn(`[WikiSteward:${stewardType}] _readNeighborhood failed for "${cluster.name}": ${err.message}`);
       return { ...idle, steward: stewardType, cluster: cluster.name, skipped: 'neighborhood_error' };
+    }
+
+    // Step 3b: count what was actually read against what the census promised.
+    // A zero-page neighborhood for a cluster the census counted pages for is
+    // the #51 failure shape — instrument it instead of tending silence.
+    const pagesInNeighborhood = neighborhood.pages.length;
+    this.logger.info(
+      `[WikiSteward:${stewardType}] Neighborhood "${cluster.name}": ` +
+      `${pagesInNeighborhood} pages (cluster reports ${cluster.pageCount ?? 'unknown'})`
+    );
+    if (pagesInNeighborhood === 0 && (cluster.pageCount || 0) > 0) {
+      const streak = (this._zeroPageStreak.get(cluster.name) || 0) + 1;
+      this._zeroPageStreak.set(cluster.name, streak);
+      if (streak >= 3) {
+        this.logger.error(
+          `[WikiSteward:${stewardType}] FLATLINE: cluster "${cluster.name}" read 0 pages ` +
+          `for ${streak} consecutive cycles while the census reports ${cluster.pageCount}. ` +
+          `First suspects: _getPageSection derivation and the Collectives filePath shape.`
+        );
+      } else {
+        this.logger.warn(
+          `[WikiSteward:${stewardType}] SUSPICIOUS EMPTY SET: cluster "${cluster.name}" ` +
+          `read 0 pages while the census reports ${cluster.pageCount}. ` +
+          `First suspects: _getPageSection derivation and the Collectives filePath shape.`
+        );
+      }
+      this.observations.notice({
+        type: 'empty_neighborhood',
+        cluster: cluster.name,
+        detail: `Read 0 pages; census reports ${cluster.pageCount}`,
+      });
+    } else if (pagesInNeighborhood > 0) {
+      this._zeroPageStreak.delete(cluster.name);
     }
 
     // Step 4: assess through the steward's lens (one LLM call)
@@ -294,6 +335,7 @@ class WikiSteward {
       pagesModified: interventionResult.pagesModified,
       linksAdded: interventionResult.linksAdded,
       observationsResolved: interventionResult.observationsResolved,
+      pagesInNeighborhood,
       skipped: false,
     };
 

--- a/test/fixtures/wikisteward/d2-fixture.md
+++ b/test/fixtures/wikisteward/d2-fixture.md
@@ -1,0 +1,30 @@
+<!-- Fixture provenance: modeled on a raw WebDAV capture of a live person/role
+page pair (D2 discovery, 2026-07-03), name-abstracted per the privacy pass
+([Person Page]/[Role Page], <nc-host> placeholders). The contradiction wall,
+escaped wikilinks, and Related entries are the captured shapes verbatim; the
+Tiptap tag section is synthesized from the production capture quoted in the
+2026-07-02 audit (the live page had been scrubbed by steward rewrites before
+this fixture was cut — the tag forms below are the exact forms observed live). -->
+
+## Contact
+<paragraph dir="ltr">Person Page is the current holder of the Role Page position.</paragraph>
+<bulletlist bullet="-" isList="true"><listitem dir="ltr">Focus: sovereign farm intelligence</listitem><listitem dir="ltr">Region: <link href="https://example.org/region" title="null">Central Europe</link></listitem></bulletlist>
+
+## Inquiry Summary
+<paragraph dir="ltr">Seeking sovereign intelligence solutions with sensor monitoring.</paragraph>
+
+\[\[DM\]\] (reports_to)
+
+## Related
+
+- [Role Page](https://nc-host.example/apps/collectives/Knowledge-18/Role-Page-111111) (holds_role)
+- [[Missing Entity Framework]] (works_on)
+- [Conference Page](https://nc-host.example/apps/collectives/Knowledge-18/Conference-Page-222222) (leads)
+
+> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/apps/collectives/Knowledge-18/Role-Page-111111) on "Identity of the role holder - one page treats it as a role without naming an individual, the other identifies a specific person"
+
+> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/apps/collectives/Knowledge-18/Role-Page-111111) on "The role is described as generic in the index, but a specific person is identified as holding it — potential identity mismatch or incomplete entity definition."
+
+> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/apps/collectives/Knowledge-18/Role-Page-111111) on "Role described as a position in one page, but a person page claims the title — unclear if they are the same entity"
+
+> ⚠️ Near-duplicate flagged by Connection Steward: possibly the same entity as [Role Page](https://nc-host.example/apps/collectives/Knowledge-18/Role-Page-111111) (similarity: 0.87). Manual review recommended.

--- a/test/unit/integrations/collectives-client.test.js
+++ b/test/unit/integrations/collectives-client.test.js
@@ -553,6 +553,109 @@ asyncTest('ensureSection keeps the suffixed page when no real section can be fou
 });
 
 // ============================================================
+// Phase 4: the medium repair at the read chokepoint (G1)
+// ============================================================
+
+const fs = require('fs');
+const path = require('path');
+const D2_FIXTURE = fs.readFileSync(
+  path.join(__dirname, '../../fixtures/wikisteward/d2-fixture.md'), 'utf8');
+
+test('_sanitizeContent: D2 fixture round-trips to clean markdown, zero Tiptap remnants', () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  const out = client._sanitizeContent(D2_FIXTURE);
+
+  for (const remnant of ['<paragraph', '<listitem', '<bulletlist', '<orderedlist', '<link href', '<hardbreak']) {
+    assert.ok(!out.includes(remnant), `no ${remnant} remnant after sanitize`);
+  }
+  assert.ok(!out.includes('\\[\\['), 'no escaped wikilinks remain');
+  // Structure converted, not destroyed:
+  assert.ok(out.includes('- Focus: sovereign farm intelligence'), 'listitem became a bullet');
+  assert.ok(out.includes('[Central Europe](https://example.org/region)'), '<link href> became a markdown link');
+  assert.ok(out.includes('[[DM]]'), 'escaped wikilink repaired to live markup');
+  assert.ok(out.includes('Contradiction flagged by Knowledge Steward'), 'flag blocks pass through untouched');
+});
+
+test('_sanitizeContent: attribute-carrying Tiptap tags convert (not strip)', () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  const out = client._sanitizeContent(
+    '<heading level="2" dir="ltr">Title</heading>\n' +
+    '<paragraph dir="ltr">Text line.</paragraph>\n' +
+    '<bulletlist bullet="-" isList="true"><listitem dir="ltr">item one</listitem></bulletlist>\n' +
+    '<hardbreak />'
+  );
+  assert.ok(out.includes('## Title'), 'heading with attributes converts');
+  assert.ok(out.includes('Text line.'), 'paragraph content preserved');
+  assert.ok(out.includes('- item one'), 'listitem with attributes becomes a bullet');
+});
+
+test('_sanitizeContent: <link href> converts to markdown link, title attribute dropped', () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  const out = client._sanitizeContent('See <link href="https://example.org/doc" title="null">the doc</link>.');
+  assert.strictEqual(out, 'See [the doc](https://example.org/doc).');
+});
+
+test('_sanitizeContent: repairs full escaped wikilinks only; lone escaped brackets untouched', () => {
+  const client = new CollectivesClient(createCollectivesMockNC());
+  const out = client._sanitizeContent(
+    'Links to \\[\\[Conference November 26, 2025\\]\\] here.\nStatus \\[incomplete\\] in prose.'
+  );
+  assert.ok(out.includes('[[Conference November 26, 2025]]'), 'full escaped wikilink repaired');
+  assert.ok(out.includes('Status \\[incomplete\\] in prose.'), 'lone escaped brackets left alone');
+});
+
+// Cross-module: a body that arrives escaped on disk dedups correctly in
+// _addWikilink once the read chokepoint has repaired it. No belt lands in
+// _addWikilink itself — the sanitizer is the component that got stronger.
+asyncTest('_addWikilink dedups against an escaped-on-disk link after a sanitized read', async () => {
+  const escapedBody = `---
+type: person
+---
+# John Smith
+
+## Related
+
+- \\[\\[Target Page\\]\\] (related)
+`;
+  const mockNC = createMockNCRequestManager({
+    'GET:/ocs/v2.php/apps/collectives/api/v1.0/collectives': {
+      status: 200, body: { ocs: { data: SAMPLE_COLLECTIVES } }, headers: {}
+    },
+    'GET:/ocs/v2.php/search/providers/collectives-page-content/search?term=John%20Smith&limit=10': {
+      status: 200,
+      body: { ocs: { data: { entries: [
+        { title: 'John Smith', subline: '', resourceUrl: '/wiki/People/John Smith' }
+      ] } } },
+      headers: {}
+    },
+    'GET:/ocs/v2.php/apps/collectives/api/v1.0/collectives/10/pages': {
+      status: 200, body: { ocs: { data: SAMPLE_PAGES } }, headers: {}
+    },
+    'GET:/remote.php/dav/files/testuser/.Collectives/Moltagent Knowledge/People/John Smith/Readme.md': {
+      status: 200, body: escapedBody, headers: {}
+    }
+  });
+  const client = new CollectivesClient(mockNC);
+
+  const { WikiSteward } = require('../../../src/lib/maintenance/wiki-steward');
+  const { ObservationLog } = require('../../../src/lib/maintenance/observation-log');
+  const silent = { debug() {}, info() {}, warn() {}, error() {} };
+  const steward = new WikiSteward({
+    collectivesClient: client,
+    knowledgeGraph: { getEntity: () => null, relatedTo: () => [] },
+    vectorStore: { getMetadata: () => null },
+    embeddingClient: { embed: async () => [0] },
+    llmRouter: { route: async () => ({ result: '{}' }) },
+    observationLog: new ObservationLog({ logger: silent }),
+    logger: silent,
+  });
+
+  const added = await steward._addWikilink('John Smith', 'Target Page', 'related');
+  assert.strictEqual(added, false,
+    'escaped link is live markup after the sanitized read — no duplicate append');
+});
+
+// ============================================================
 // Summary
 // ============================================================
 

--- a/test/unit/maintenance/observation-log.test.js
+++ b/test/unit/maintenance/observation-log.test.js
@@ -214,4 +214,32 @@ test('size() reports total current count including resolved observations', () =>
   assert.strictEqual(log.size(), 2, 'resolved observations should still count toward size() until pruned');
 });
 
+// ---------------------------------------------------------------------------
+// Test 12: resolve() optional pages filter (Phase 2 — page-granular resolution)
+// ---------------------------------------------------------------------------
+test('resolve() with pages filter transitions only matching pages; omitting keeps wholesale behavior', () => {
+  const log = new ObservationLog({ logger: silentLogger });
+  log.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'Alpha', page: 'Page A' });
+  log.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'Alpha', page: 'Page A' });
+  log.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'Alpha', page: 'Page B' });
+  log.notice({ type: OBSERVATION_TYPES.GAP,          cluster: 'Alpha', page: 'Page B' });
+
+  const count = log.resolve('Alpha', OBSERVATION_TYPES.MISSING_LINK, ['Page A']);
+  assert.strictEqual(count, 2, 'only Page A missing_link observations transition');
+  assert.strictEqual(log.getByType(OBSERVATION_TYPES.MISSING_LINK).length, 1, 'Page B remains pending');
+  assert.strictEqual(log.getByType(OBSERVATION_TYPES.GAP).length, 1, 'other types untouched');
+
+  // Backward compatible: omitting pages resolves the rest of the type wholesale.
+  const rest = log.resolve('Alpha', OBSERVATION_TYPES.MISSING_LINK);
+  assert.strictEqual(rest, 1, 'wholesale call resolves the remaining Page B observation');
+});
+
+test('resolve() pages filter accepts a single page string', () => {
+  const log = new ObservationLog({ logger: silentLogger });
+  log.notice({ type: OBSERVATION_TYPES.UNEMBEDDED, cluster: 'Alpha', page: 'Solo' });
+  log.notice({ type: OBSERVATION_TYPES.UNEMBEDDED, cluster: 'Alpha', page: 'Other' });
+  assert.strictEqual(log.resolve('Alpha', OBSERVATION_TYPES.UNEMBEDDED, 'Solo'), 1);
+  assert.strictEqual(log.getByType(OBSERVATION_TYPES.UNEMBEDDED).length, 1);
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -812,42 +812,34 @@ asyncTest('tend() rotates stewards on successive calls', async () => {
   assert.ok(true, 'tend() completed without throwing');
 });
 
-// Test 18: tend() calls observationLog.resolve() after successful intervention
-asyncTest('tend() calls observationLog.resolve after intervention resolves types', async () => {
+// Test 18: a tend whose assessment proposes no actions resolves ZERO
+// observations — visiting is not resolving (G2, #161 class).
+asyncTest('tend() with an empty assessment resolves zero observations and leaves the log untouched', async () => {
   const observationLog = makeObservationLog();
-  observationLog.notice({ type: OBSERVATION_TYPES.CONTRADICTION, cluster: 'People' });
-  observationLog.notice({ type: OBSERVATION_TYPES.GAP, cluster: 'People' });
+  observationLog.notice({ type: OBSERVATION_TYPES.CONTRADICTION, cluster: 'People', page: 'Carlos' });
+  observationLog.notice({ type: OBSERVATION_TYPES.GAP, cluster: 'People', page: 'Carlos' });
 
   const collectivesClient = makeMockCollectivesClient({
-    listPagesResult: [{ id: 1, title: 'Carlos', section: 'people', parentId: 1 }],
+    listPagesResult: [{ id: 1, title: 'Carlos', filePath: 'People', fileName: 'Carlos.md', parentId: 5 }],
     pagesByTitle: {
       'Carlos': { frontmatter: {}, body: 'Carlos works here.', path: 'People/Carlos.md' },
     },
   });
 
-  // Knowledge steward assessment — we force stewardIndex to 0 (knowledge)
   const router = makeMockRouter({
     contradictions: [], stale: [], gaps: [], suspects: [], healthy: ['Carlos'],
   });
 
-  const resolveCalls = [];
-  const origResolve = observationLog.resolve.bind(observationLog);
-  observationLog.resolve = (cluster, types) => {
-    resolveCalls.push({ cluster, types });
-    return origResolve(cluster, types);
-  };
-
   const steward = new WikiSteward(makeFullDeps({ observationLog, collectivesClient, llmRouter: router }));
-  // Force stewardIndex to knowledge (it starts at 0 = knowledge already)
+  steward._findNeediest = async () => ({ name: 'People', pageCount: 1, score: 1, observationCount: 2 });
+
   const result = await steward.tend();
 
-  if (result.cluster !== null) {
-    // If a cluster was tended, resolve should have been called
-    assert.ok(resolveCalls.length > 0 || result.observationsResolved >= 0,
-      'resolve() should have been called after successful intervention');
-  }
-  // If the result was skipped (no pages matched 'people' section), that's also acceptable
-  assert.ok(true, 'tend() completed without throwing');
+  assert.strictEqual(result.observationsResolved, 0, 'no action → zero resolved');
+  assert.strictEqual(observationLog.getByType(OBSERVATION_TYPES.CONTRADICTION).length, 1,
+    'contradiction observation still pending');
+  assert.strictEqual(observationLog.getByType(OBSERVATION_TYPES.GAP).length, 1,
+    'gap observation still pending');
 });
 
 // ---------------------------------------------------------------------------
@@ -1359,6 +1351,73 @@ asyncTest('zero-page streak resets on a non-empty read', async () => {
   await steward.tend(); // zero again → streak restarts at 1, no error
   assert.strictEqual(steward._zeroPageStreak.get('People'), 1, 'streak restarts after reset');
   assert.strictEqual(logger._calls.error.length, 0, 'no FLATLINE across a reset boundary');
+});
+
+// ---------------------------------------------------------------------------
+// PHASE 2: HONEST OBSERVATION RESOLUTION (G2 — visiting is not resolving)
+// ---------------------------------------------------------------------------
+
+asyncTest('tend() with a garbage assessment (parse failure) resolves zero observations', async () => {
+  const observationLog = makeObservationLog();
+  observationLog.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'People', page: 'Carlos' });
+  observationLog.notice({ type: OBSERVATION_TYPES.LOW_CONFIDENCE, cluster: 'People', page: 'Carlos' });
+
+  const collectivesClient = makeMockCollectivesClient({
+    listPagesResult: [{ id: 1, title: 'Carlos', filePath: 'People', fileName: 'Carlos.md', parentId: 5 }],
+    pagesByTitle: {
+      'Carlos': { frontmatter: {}, body: 'Carlos works here.', path: 'People/Carlos.md' },
+    },
+  });
+
+  // Router returns prose, not JSON — the live qwen3:8b failure shape.
+  const router = {
+    async route() { return { result: 'I am ready to assess the cluster.', provider: 'mock', model: 'mock', cost: 0 }; },
+  };
+
+  const steward = new WikiSteward(makeFullDeps({ observationLog, collectivesClient, llmRouter: router }));
+  steward._findNeediest = async () => ({ name: 'People', pageCount: 1, score: 1, observationCount: 2 });
+
+  const result = await steward.tend();
+
+  assert.strictEqual(result.observationsResolved, 0, 'parse failure → zero resolved');
+  assert.strictEqual(observationLog.getByType(OBSERVATION_TYPES.MISSING_LINK).length, 1);
+  assert.strictEqual(observationLog.getByType(OBSERVATION_TYPES.LOW_CONFIDENCE).length, 1);
+});
+
+asyncTest('tend() resolves page-granular: link added to Page A resolves A, leaves B pending', async () => {
+  const observationLog = makeObservationLog();
+  observationLog.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'People', page: 'Page A' });
+  observationLog.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'People', page: 'Page A' });
+  observationLog.notice({ type: OBSERVATION_TYPES.MISSING_LINK, cluster: 'People', page: 'Page B' });
+
+  const collectivesClient = makeMockCollectivesClient({
+    listPagesResult: [
+      { id: 1, title: 'Page A', filePath: 'People', fileName: 'Page A.md', parentId: 5 },
+      { id: 2, title: 'Page B', filePath: 'People', fileName: 'Page B.md', parentId: 5 },
+    ],
+    pagesByTitle: {
+      'Page A': { frontmatter: {}, body: 'A body.', path: 'People/Page A.md' },
+      'Page B': { frontmatter: {}, body: 'B body.', path: 'People/Page B.md' },
+    },
+  });
+
+  // Connection assessment: one link for Page A only.
+  const router = makeMockRouter({
+    missingLinks: [{ page: 'Page A', shouldLinkTo: 'Page B', relationship: 'related' }],
+    orphans: [], nearDuplicates: [], crossCluster: [],
+  });
+
+  const steward = new WikiSteward(makeFullDeps({ observationLog, collectivesClient, llmRouter: router }));
+  steward._findNeediest = async () => ({ name: 'People', pageCount: 2, score: 1, observationCount: 3 });
+  steward._nextSteward = () => 'connection';
+
+  const result = await steward.tend();
+
+  assert.strictEqual(result.linksAdded, 1, 'one link added');
+  assert.strictEqual(result.observationsResolved, 2, 'both Page A missing_link observations resolve, none else');
+  const remaining = observationLog.getByType(OBSERVATION_TYPES.MISSING_LINK);
+  assert.strictEqual(remaining.length, 1, 'Page B observation remains');
+  assert.strictEqual(remaining[0].page, 'Page B');
 });
 
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -1477,4 +1477,133 @@ asyncTest('_assess skips recording when the route result carries no model identi
   assert.strictEqual(modelScorecard._calls.length, 0, 'no model → no sample (recordSample requires a model string)');
 });
 
+// ---------------------------------------------------------------------------
+// PHASE 3: DURABLE FLAG KEYS (G1 — key on what cannot change)
+// ---------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+const D2_FIXTURE = fs.readFileSync(
+  path.join(__dirname, '../../fixtures/wikisteward/d2-fixture.md'), 'utf8');
+
+function makeFlagClient(bodyByTitle) {
+  const writes = [];
+  return {
+    _writes: writes,
+    readPageWithFrontmatter: async (title) => (
+      bodyByTitle[title] !== undefined
+        ? { frontmatter: {}, body: bodyByTitle[title], path: `${title}.md` }
+        : null
+    ),
+    writePageWithFrontmatter: async (title, fm, body) => {
+      writes.push({ title, fm, body });
+      bodyByTitle[title] = body;
+      return `${title}.md`;
+    },
+  };
+}
+
+asyncTest('_flagContradiction dedups on pair key across resolved and unresolved link forms', async () => {
+  const unresolvedForm = '> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [[Role Page]] on "old claim"';
+  const resolvedForm = '> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/x) on "old claim"';
+
+  for (const existing of [unresolvedForm, resolvedForm]) {
+    const client = makeFlagClient({
+      'Person Page': `Some body.\n\n${existing}\n`,
+      'Role Page': 'Role body.',
+    });
+    const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+    const modified = await steward._flagContradiction('Person Page', 'Role Page', 'a newly worded claim');
+    // Person Page already flagged for this pair in either form → only Role Page written.
+    assert.strictEqual(client._writes.filter(w => w.title === 'Person Page').length, 0,
+      `no append when the ${existing === unresolvedForm ? 'unresolved' : 'resolved'} form is present`);
+    assert.strictEqual(client._writes.filter(w => w.title === 'Role Page').length, 1);
+    assert.ok(modified, 'partner side still flagged');
+  }
+});
+
+asyncTest('_flagContradiction: reworded claim for an already-flagged pair does not append', async () => {
+  const client = makeFlagClient({
+    'Person Page': 'Body.\n\n> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/x) on "wording one"\n',
+    'Role Page': 'Body.\n\n> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Person Page](https://nc-host.example/y) on "wording one"\n',
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+  const modified = await steward._flagContradiction('Person Page', 'Role Page', 'wording two, completely different');
+  assert.strictEqual(client._writes.length, 0, 'no write for either page');
+  assert.strictEqual(modified, false);
+});
+
+asyncTest('_flagContradiction: a second partner does append', async () => {
+  const client = makeFlagClient({
+    'Person Page': 'Body.\n\n> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Role Page](https://nc-host.example/x) on "claim"\n',
+    'Other Page': 'Other body.',
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+  const modified = await steward._flagContradiction('Person Page', 'Other Page', 'a different conflict');
+  assert.ok(modified);
+  assert.strictEqual(client._writes.filter(w => w.title === 'Person Page').length, 1,
+    'new partner pair appends on Person Page');
+  assert.ok(client._writes.find(w => w.title === 'Person Page').body.includes('[[Other Page]]'));
+});
+
+asyncTest('_flagDuplicate is per-pair: flagged against one partner, still flags a second', async () => {
+  const client = makeFlagClient({
+    'Page X': 'Body.\n\n> ⚠️ Near-duplicate flagged by Connection Steward: possibly the same entity as [Page Y](https://nc-host.example/y) (similarity: 0.90). Manual review recommended.\n',
+    'Page Z': 'Z body.',
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+
+  // Same pair again → no write on X
+  await steward._flagDuplicate('Page X', 'Page Y', 0.91);
+  assert.strictEqual(client._writes.filter(w => w.title === 'Page X').length, 0, 'same pair stays idempotent');
+
+  // New partner → append
+  const modified = await steward._flagDuplicate('Page X', 'Page Z', 0.8);
+  assert.ok(modified);
+  assert.strictEqual(client._writes.filter(w => w.title === 'Page X').length, 1, 'second partner appends');
+});
+
+asyncTest('D2 fixture: already-walled pair does not grow; flag region is byte-stable', async () => {
+  const client = makeFlagClient({
+    'Person Page': D2_FIXTURE,
+    'Role Page': 'Role body.\n\n> ⚠️ Contradiction flagged by Knowledge Steward: conflicts with [Person Page](https://nc-host.example/p) on "any"\n',
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+  const modified = await steward._flagContradiction('Person Page', 'Role Page', 'yet another wording of the same conflict');
+  assert.strictEqual(client._writes.length, 0, 'wall does not grow — pair key holds on the captured body');
+  assert.strictEqual(modified, false);
+
+  // Duplicate flag: the walled page is already flagged for this pair; only the
+  // partner side (which carries no duplicate flag yet) may be written.
+  await steward._flagDuplicate('Person Page', 'Role Page', 0.99);
+  assert.strictEqual(client._writes.filter(w => w.title === 'Person Page').length, 0,
+    'duplicate flag also keyed per pair on the captured body');
+});
+
+asyncTest('_lowerConfidence deletes verification_note and skips the write on identical state', async () => {
+  const today = new Date().toISOString().split('T')[0];
+  const client = makeFlagClient({});
+  client.readPageWithFrontmatter = async () => ({
+    frontmatter: { confidence: 'low', last_verification_attempt: today, verification_note: 'LLM-worded leftover' },
+    body: 'Body.',
+    path: 'People/Page.md',
+  });
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient: client }));
+
+  // First pass: removing the leftover note is a real change → one write, note gone.
+  const first = await steward._lowerConfidence('Page', 'stale');
+  assert.strictEqual(first, true);
+
+  // Second pass: state identical (low, same day, no note) → no write.
+  client.readPageWithFrontmatter = async () => ({
+    frontmatter: { confidence: 'low', last_verification_attempt: today },
+    body: 'Body.',
+    path: 'People/Page.md',
+  });
+  const second = await steward._lowerConfidence('Page', 'stale');
+  assert.strictEqual(second, false, 'identical state produces identical bytes — no write');
+  assert.strictEqual(client._writes.length, 1, 'only the note-removal write happened');
+  assert.ok(!('verification_note' in client._writes[0].fm), 'written frontmatter carries no verification_note');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -1420,4 +1420,61 @@ asyncTest('tend() resolves page-granular: link added to Page A resolves A, leave
   assert.strictEqual(remaining[0].page, 'Page B');
 });
 
+// ---------------------------------------------------------------------------
+// PHASE 2b: ASSESSMENT OUTCOMES JOIN THE MATURATION LOOP
+// ---------------------------------------------------------------------------
+
+function makeMockScorecard() {
+  const calls = [];
+  return {
+    _calls: calls,
+    recordSample(job, model, language, success, opts) {
+      calls.push({ job, model, language, success, opts });
+    },
+  };
+}
+
+asyncTest('_assess records one successful synthesis sample with the served model', async () => {
+  const modelScorecard = makeMockScorecard();
+  const router = makeMockRouter({ contradictions: [], stale: [], gaps: [] });
+  router.route = async () => ({ result: '{"contradictions": []}', provider: 'ollama-local', model: 'qwen3:8b', cost: 0 });
+  const steward = new WikiSteward(makeFullDeps({ llmRouter: router, modelScorecard }));
+
+  await steward._assess('knowledge', { cluster: 'People', pages: [], graphEdges: [], sections: new Set() });
+
+  assert.strictEqual(modelScorecard._calls.length, 1, 'exactly one sample per assessment');
+  const call = modelScorecard._calls[0];
+  assert.strictEqual(call.job, 'synthesis');
+  assert.strictEqual(call.model, 'qwen3:8b', 'served player from the route() return');
+  assert.strictEqual(call.language, null, 'language omitted — scorecard defaults to cockpit language');
+  assert.strictEqual(call.success, true);
+});
+
+asyncTest('_assess records exactly one failure sample on a parse failure', async () => {
+  const modelScorecard = makeMockScorecard();
+  const router = { async route() { return { result: 'I am ready to assess.', provider: 'ollama-local', model: 'qwen3:8b', cost: 0 }; } };
+  const steward = new WikiSteward(makeFullDeps({ llmRouter: router, modelScorecard }));
+
+  const assessment = await steward._assess('knowledge', { cluster: 'People', pages: [], graphEdges: [], sections: new Set() });
+
+  assert.deepStrictEqual(assessment, { actions: [] }, 'fallback envelope preserved');
+  assert.strictEqual(modelScorecard._calls.length, 1, 'failure records exactly once, outside the catch fallback');
+  assert.strictEqual(modelScorecard._calls[0].success, false);
+});
+
+asyncTest('_assess without a scorecard records nothing and does not throw', async () => {
+  const router = { async route() { return { result: 'not json', provider: 'mock', model: 'mock', cost: 0 }; } };
+  const steward = new WikiSteward(makeFullDeps({ llmRouter: router }));
+  const assessment = await steward._assess('knowledge', { cluster: 'People', pages: [], graphEdges: [], sections: new Set() });
+  assert.deepStrictEqual(assessment, { actions: [] });
+});
+
+asyncTest('_assess skips recording when the route result carries no model identity', async () => {
+  const modelScorecard = makeMockScorecard();
+  const router = { async route() { return { result: '{"contradictions": []}', provider: 'mock', cost: 0 }; } };
+  const steward = new WikiSteward(makeFullDeps({ llmRouter: router, modelScorecard }));
+  await steward._assess('knowledge', { cluster: 'People', pages: [], graphEdges: [], sections: new Set() });
+  assert.strictEqual(modelScorecard._calls.length, 0, 'no model → no sample (recordSample requires a model string)');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -127,13 +127,25 @@ test('WikiSteward constructor: throws when required dep is missing', () => {
   assert.throws(() => new WikiSteward(deps), /requires observationLog/);
 });
 
-// Test 2: _nextSteward() cycles knowledge → connection → memory → knowledge
-test('_nextSteward() cycles through three lenses and wraps', () => {
+// Test 2: _nextSteward(cluster) cycles knowledge → connection → memory → knowledge
+test('_nextSteward() cycles through three lenses and wraps, per cluster', () => {
   const steward = new WikiSteward(makeFullDeps());
-  assert.strictEqual(steward._nextSteward(), 'knowledge');
-  assert.strictEqual(steward._nextSteward(), 'connection');
-  assert.strictEqual(steward._nextSteward(), 'memory');
-  assert.strictEqual(steward._nextSteward(), 'knowledge', 'should wrap back to knowledge');
+  assert.strictEqual(steward._nextSteward('People'), 'knowledge');
+  assert.strictEqual(steward._nextSteward('People'), 'connection');
+  assert.strictEqual(steward._nextSteward('People'), 'memory');
+  assert.strictEqual(steward._nextSteward('People'), 'knowledge', 'should wrap back to knowledge');
+});
+
+// Phase 1b invariant: interleaved clusters advance independently. A global
+// index lens-locks every cluster when clusterCount % lenses === 0.
+test('_nextSteward() keeps independent lens sequences across interleaved clusters', () => {
+  const steward = new WikiSteward(makeFullDeps());
+  assert.strictEqual(steward._nextSteward('People'), 'knowledge');
+  assert.strictEqual(steward._nextSteward('Projects'), 'knowledge', 'second cluster starts its own ring');
+  assert.strictEqual(steward._nextSteward('People'), 'connection');
+  assert.strictEqual(steward._nextSteward('Projects'), 'connection');
+  assert.strictEqual(steward._nextSteward('People'), 'memory');
+  assert.strictEqual(steward._nextSteward('Projects'), 'memory');
 });
 
 // Test 3: tend() returns skipped:'idle' when no clusters and no observations
@@ -1249,6 +1261,19 @@ function makeInstrumentedSteward({ listPagesResult, pagesByTitle, pageCount, log
   steward._findNeediest = async () => ({ name: 'People', pageCount, score: 1, observationCount: 0 });
   return steward;
 }
+
+asyncTest('tend() uses three different lenses across three consecutive visits to one cluster', async () => {
+  const steward = makeInstrumentedSteward({
+    listPagesResult: [{ id: 1, title: 'Carlos', filePath: 'People', fileName: 'Carlos.md', parentId: 5 }],
+    pagesByTitle: { 'Carlos': { frontmatter: {}, body: 'Carlos is a person.', path: 'People/Carlos.md' } },
+    pageCount: 1,
+  });
+
+  const lenses = [];
+  for (let i = 0; i < 3; i++) lenses.push((await steward.tend()).steward);
+  assert.deepStrictEqual([...new Set(lenses)].sort(), ['connection', 'knowledge', 'memory'],
+    'three consecutive visits to one cluster must use all three lenses');
+});
 
 asyncTest('tend() result carries pagesInNeighborhood with the read count', async () => {
   const steward = makeInstrumentedSteward({

--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -1220,4 +1220,120 @@ asyncTest('_intervene: content pages are still processed normally when no struct
   );
 });
 
+// ---------------------------------------------------------------------------
+// PHASE 1: TENDING INSTRUMENTATION (pagesInNeighborhood, empty-set alarm, FLATLINE)
+// ---------------------------------------------------------------------------
+
+/** Logger spy that records calls per level while staying silent. */
+function makeSpyLogger() {
+  const calls = { debug: [], info: [], warn: [], error: [] };
+  return {
+    _calls: calls,
+    debug: (...a) => calls.debug.push(a.join(' ')),
+    info:  (...a) => calls.info.push(a.join(' ')),
+    warn:  (...a) => calls.warn.push(a.join(' ')),
+    error: (...a) => calls.error.push(a.join(' ')),
+  };
+}
+
+/** Steward pinned to a census that promises pages the neighborhood may not have. */
+function makeInstrumentedSteward({ listPagesResult, pagesByTitle, pageCount, logger, observationLog }) {
+  const collectivesClient = makeMockCollectivesClient({ listPagesResult, pagesByTitle });
+  const steward = new WikiSteward(makeFullDeps({
+    collectivesClient,
+    observationLog: observationLog || makeObservationLog(),
+    logger: logger || silentLogger,
+  }));
+  // Census and neighborhood diverge in production via section-derivation drift
+  // (#51). Pin the census side so the divergence is reproducible.
+  steward._findNeediest = async () => ({ name: 'People', pageCount, score: 1, observationCount: 0 });
+  return steward;
+}
+
+asyncTest('tend() result carries pagesInNeighborhood with the read count', async () => {
+  const steward = makeInstrumentedSteward({
+    listPagesResult: [
+      { id: 1, title: 'Carlos', filePath: 'People', fileName: 'Carlos.md', parentId: 5 },
+      { id: 2, title: 'Tobias', filePath: 'People', fileName: 'Tobias.md', parentId: 5 },
+    ],
+    pagesByTitle: {
+      'Carlos': { frontmatter: {}, body: 'Carlos is a person.', path: 'People/Carlos.md' },
+      'Tobias': { frontmatter: {}, body: 'Tobias is a person.', path: 'People/Tobias.md' },
+    },
+    pageCount: 2,
+  });
+
+  const result = await steward.tend();
+  assert.strictEqual(result.pagesInNeighborhood, 2, 'result should count pages actually read');
+});
+
+asyncTest('tend() warns and records empty_neighborhood observation on suspicious empty set', async () => {
+  const logger = makeSpyLogger();
+  const observationLog = makeObservationLog();
+  const steward = makeInstrumentedSteward({
+    listPagesResult: [], // neighborhood reads zero
+    pagesByTitle: {},
+    pageCount: 4,        // census promises four
+    logger,
+    observationLog,
+  });
+
+  const result = await steward.tend();
+
+  assert.strictEqual(result.pagesInNeighborhood, 0);
+  assert.ok(
+    logger._calls.warn.some(m => m.includes('SUSPICIOUS EMPTY SET') && m.includes('_getPageSection')),
+    'warn should name the empty set and the first suspect'
+  );
+  const pending = observationLog.getByType('empty_neighborhood');
+  assert.strictEqual(pending.length, 1, 'one empty_neighborhood observation recorded');
+  assert.strictEqual(pending[0].cluster, 'People', 'observation carries cluster so getNeediest sees it');
+});
+
+asyncTest('tend() escalates to FLATLINE error at three consecutive zero-page cycles', async () => {
+  const logger = makeSpyLogger();
+  const steward = makeInstrumentedSteward({
+    listPagesResult: [],
+    pagesByTitle: {},
+    pageCount: 3,
+    logger,
+  });
+
+  await steward.tend();
+  await steward.tend();
+  assert.strictEqual(logger._calls.error.length, 0, 'no error before streak reaches 3');
+  await steward.tend();
+
+  assert.strictEqual(steward._zeroPageStreak.get('People'), 3, 'streak counts consecutive zeros');
+  assert.ok(
+    logger._calls.error.some(m => m.includes('FLATLINE') && m.includes('People')),
+    'third consecutive zero escalates to error with FLATLINE'
+  );
+});
+
+asyncTest('zero-page streak resets on a non-empty read', async () => {
+  const logger = makeSpyLogger();
+  const pages = [{ id: 1, title: 'Carlos', filePath: 'People', fileName: 'Carlos.md', parentId: 5 }];
+  const listPagesBox = { value: [] };
+  const collectivesClient = makeMockCollectivesClient({
+    pagesByTitle: { 'Carlos': { frontmatter: {}, body: 'Carlos.', path: 'People/Carlos.md' } },
+  });
+  collectivesClient.listPages = async () => listPagesBox.value;
+  const steward = new WikiSteward(makeFullDeps({ collectivesClient, logger }));
+  steward._findNeediest = async () => ({ name: 'People', pageCount: 1, score: 1, observationCount: 0 });
+
+  await steward.tend(); // zero read → streak 1
+  await steward.tend(); // zero read → streak 2
+  assert.strictEqual(steward._zeroPageStreak.get('People'), 2);
+
+  listPagesBox.value = pages; // pages come back
+  await steward.tend();
+  assert.strictEqual(steward._zeroPageStreak.has('People'), false, 'successful read deletes the streak entry');
+
+  listPagesBox.value = [];
+  await steward.tend(); // zero again → streak restarts at 1, no error
+  assert.strictEqual(steward._zeroPageStreak.get('People'), 1, 'streak restarts after reset');
+  assert.strictEqual(logger._calls.error.length, 0, 'no FLATLINE across a reset boundary');
+});
+
 setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -2556,6 +2556,7 @@ async function initialize() {
         resilientWriter,
         costTracker,
         localJudge,
+        modelScorecard,
         // Layer 3 (Session 5): thunk — NicheAssignment is constructed after
         // ModelScout discovery, possibly after this manager. The sink keeps
         // timing capture alive across heartbeat roster rebuilds.


### PR DESCRIPTION
## WikiSteward signal integrity and the body medium (PR 1 of 2)

The steward's signal layer was dishonest and the medium it writes to was unstable. A full audit (2026-07-02) plus live evidence established five generating functions; this PR fixes the three that belong to the signal/medium arc (G1, G2, G5), plus two gate amendments. Identity custody (G3, G4) follows in PR 2.

**Live scale, measured during discovery:** one role page carried **179** stacked contradiction blockquotes against the same partner page, two conference pages carried **298 each**, two session pages ~255 each — 1,301 markers across 11 pages, every wall single-partner with per-run LLM rewording, all journal-invisible (no log line ever carried the phrase). Every tend reported the constant "4 observations resolved" regardless of what happened, including cycles whose assessment failed to parse. One person page accumulated **871 NC file versions** because an LLM-worded frontmatter note changed bytes on every visit.

### Phase 1 — Tending instrumentation (#51 class)
`TendResult.pagesInNeighborhood` + the tend log prints it against the cluster census. Zero pages while the census reports >0 → `SUSPICIOUS EMPTY SET` warn naming the first suspects, plus an `empty_neighborhood` observation (cluster-keyed, so `getNeediest` sees it). Three consecutive zeros → `FLATLINE` at error level.

### Phase 1b — Per-cluster lens rotation (gate amendment)
The global lens ring lens-locked every cluster whenever clusterCount % 3 == 0 — live, with 15 clusters, some clusters *never* saw the knowledge lens (observed and confirmed in the journal: the same cluster always drew the same lens, 75-minute period). Each cluster now advances its own lens index; invariant: three consecutive visits to one cluster use three different lenses.

### Phase 2 — Honest observation resolution (G2, #161 class)
Executors report the `(type, page)` pairs they actually acted on; `tend()` resolves exactly those via `ObservationLog.resolve(cluster, type, pages)` (new optional pages filter, backward compatible) and reports the summed real transition counts. A parse-failed assessment resolves zero. The number in the heartbeat log is now a real number.

### Phase 2b — Synthesis joins the maturation loop
`_assess` was the only recurring LLM traffic the adaptive stack couldn't see. The steward now takes an optional `modelScorecard` (null-safe) and records one organic envelope-validity sample per assessment: `recordSample('synthesis', <served model>, <cockpit language default>, <parsed>)`. The steward only testifies; the loop owns selection.

### Phase 3 — Durable pair keys (G1) + deterministic frontmatter (gate amendment)
Flag idempotency keyed on full strings the medium kept rewriting (wikilink resolution, NC Text round-trips, LLM rewording — PR #50 Fix A class, never ported). New key: invariant marker phrase + partner title as plain substrings, which survive all three rewriters. `_flagDuplicate` moves from one-flag-ever to the same per-pair key. Each flag write now logs one line (the walls were journal-invisible). `_lowerConfidence` deletes the LLM-worded `verification_note` (nothing read it) and gains an equality guard — identical state produces identical bytes, ending the per-visit rewrite churn and the spurious Level 1 refreshes.

### Phase 4 — The medium repair, at the read chokepoint (G1)
`_sanitizeContent` patterns were anchored on bare tags; editor round-trips decorate tags with attributes, so decorated markup fell through to the catch-all strip, which destroys structure (bullets/newlines lost, link URLs dropped) and never touched escaped wikilinks — after which every idempotency check went blind and Related sections flooded again despite PR #50. Now: attribute-tolerant conversions, `<link href>` → markdown link (ordered before the catch-all), exact-shape escaped-wikilink repair. All regexes match structural editor serialization, never natural language.

### Cleanup A — one-shot corpus repair (dry-run shipped, write pass pending approval)
`scripts/cleanup-wiki-signal-integrity.js`: collapses walls to one block per pair, persists the medium repair, dedupes Related entries (dry run found a second resolved-form flood: ~873 duplicate entries across 10 pages), strips stale notes, unmarks tautology composts, trashes stray fallback-born root pages (keep-list honors the PR 2 dependency). Dry-run by default; NC versioning/trash are the undo.

### Verification (live, on the production box)
- Instrumentation: `Neighborhood "<cluster>": N pages (cluster reports M)` lines live from the first post-deploy tend (e.g. `"People": 7 pages (cluster reports 7)`); counts match the census; zero SUSPICIOUS/FLATLINE alarms across ~90 minutes of pulses.
- Honest resolution: every post-deploy Done. line reports a real count — the constant 4 is gone. A zero-action tend logged `0 pages modified, 0 links added, 0 observations resolved` and the same cluster's obsCount was unchanged (0) on its next Tending appearance, one full rotation later.
- Wall stability: the walled role page is byte-identical (81,313 B, 179 flag blocks, flag-region diff empty) across a knowledge-lens revisit of its cluster — the wall stopped growing.
- Lens rotation: the same cluster drew knowledge on its first post-deploy visit and connection on its second — the lens lock is broken in production.
- Maturation signal: `jobs.synthesis.<served cloud model>.EN` live in the scorecard store, organic counters `a=19, b=0, prod=19` after 19 assessments (every envelope parsed — exactly the baseline the loop needs to detect regressions against).
- Suite: 233/233 test files pass; eslint 0 errors.

Fixture provenance: `test/fixtures/wikisteward/d2-fixture.md` is name-abstracted from the production capture; the Tiptap section is synthesized from the audited live forms (the live page had been scrubbed by steward rewrites before capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
