### PR TITLE
feat: Wave 1 boot assertion layer — registration asserts clients, preflight asserts deps, probe asserts tool capability (#227 #152 #87 #118 #96)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,15 @@ OLLAMA_MODEL=qwen3:8b
 # Credential-dedicated Ollama model (heavier, for sensitive ops; falls back to OLLAMA_MODEL)
 OLLAMA_MODEL_CREDENTIAL=qwen3:14b-fast
 
+# Embedding model for semantic memory (#96). Must be pulled on the Ollama host;
+# the boot preflight probes it as an optional dependency.
+EMBEDDING_MODEL=nomic-embed-text
+
+# Boot preflight (#87): a REQUIRED dependency that is definitively absent
+# (Talk/Deck/Collectives app not installed) halts boot with a remediation line.
+# Set to "warn" to demote that halt to a warning (escape hatch; leave unset).
+# MOLTAGENT_PREFLIGHT=warn
+
 # Claude premium model (deep reasoning, complex writing — expensive)
 CLAUDE_MODEL_PREMIUM=claude-opus-4-6
 

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -80,10 +80,17 @@ class ToolRegistry {
    * @param {import('../integrations/memory-searcher')} [options.memorySearcher]
    * @param {Object} [options.searchAdapters] - Map of commercial search adapters { brave, perplexity, exa }
    * @param {import('../integrations/news-client').NewsClient} [options.newsClient]
+   * @param {import('../integrations/meeting-composer')} [options.meetingComposer]
+   * @param {import('../integrations/rsvp-tracker')} [options.rsvpTracker]
    * @param {Object} [options.logger]
    */
-  constructor({ deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor, logger }) {
-    this.clients = { deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor };
+  // NOTE(#227): every client the construction site passes MUST appear here AND in
+  // this.clients — a name missing from either is silently undefined at runtime and
+  // its tool family never registers (that was #226: meetingComposer/rsvpTracker
+  // dropped → meeting tools dead in production). The TOOL_FAMILIES manifest below
+  // turns that silence into a loud [BOOT][WARN] line.
+  constructor({ deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor, meetingComposer, rsvpTracker, logger }) {
+    this.clients = { deckClient, calDAVClient, systemTagsClient, ncRequestManager, ncFilesClient, ncSearchClient, textExtractor, collectivesClient, learningLog, searxngClient, webReader, contactsClient, memorySearcher, searchAdapters, emailHandler, resilientWriter, newsClient, entityExtractor, meetingComposer, rsvpTracker };
     this.logger = logger || console;
 
     /** @type {Map<string, {name: string, description: string, parameters: Object, handler: Function, domains?: string[], universal?: boolean}>} */
@@ -376,20 +383,57 @@ class ToolRegistry {
   // Private: Default Tool Registration
   // ===========================================================================
 
+  /**
+   * The boot composition contract (#227): which clients each tool family needs.
+   *
+   * `required` mirrors the registrar's own early-return gate — when one is
+   * missing the family is skipped LOUDLY ([BOOT][WARN]) instead of silently.
+   * `optional` names clients the family registers without but degrades
+   * visibly when absent (logged once at boot).
+   *
+   * This list and the registrar gates must stay aligned; the gates remain as
+   * the assertion's fallback so a direct registrar call is still safe.
+   * @private
+   */
+  static get TOOL_FAMILIES() {
+    return [
+      { family: 'deck', method: '_registerDeckTools', required: ['deckClient'] },
+      { family: 'calendar', method: '_registerCalendarTools', required: ['calDAVClient'] },
+      { family: 'meeting', method: '_registerMeetingTools', required: ['meetingComposer'], optional: ['rsvpTracker'] },
+      { family: 'file', method: '_registerFileTools', required: ['ncFilesClient'] },
+      { family: 'search', method: '_registerSearchTools', required: ['ncSearchClient'] },
+      { family: 'tag', method: '_registerTagTools', required: ['systemTagsClient'] },
+      { family: 'memory', method: '_registerMemoryTools', required: ['ncRequestManager'] },
+      { family: 'wiki', method: '_registerWikiTools', required: ['collectivesClient'], optional: ['resilientWriter'] },
+      { family: 'web', method: '_registerWebTools', required: [], optional: ['searxngClient', 'webReader', 'searchAdapters'] },
+      { family: 'contacts', method: '_registerContactsTools', required: ['contactsClient'] },
+      { family: 'memorySearch', method: '_registerMemorySearchTools', required: ['memorySearcher'] },
+      { family: 'workflowDeck', method: '_registerWorkflowDeckTools', required: ['ncRequestManager'], optional: ['deckClient'] },
+    ];
+  }
+
   /** @private */
   _registerDefaultTools() {
-    this._registerDeckTools();
-    this._registerCalendarTools();
-    this._registerMeetingTools();
-    this._registerFileTools();
-    this._registerSearchTools();
-    this._registerTagTools();
-    this._registerMemoryTools();
-    this._registerWikiTools();
-    this._registerWebTools();
-    this._registerContactsTools();
-    this._registerMemorySearchTools();
-    this._registerWorkflowDeckTools();
+    for (const { family, method, required = [], optional = [] } of ToolRegistry.TOOL_FAMILIES) {
+      const missing = required.filter((name) => !this.clients[name]);
+      if (missing.length) {
+        this.logger.warn(
+          `[BOOT][WARN] ToolRegistry: ${family} tools SKIPPED — required client${missing.length > 1 ? 's' : ''} ` +
+          `'${missing.join("', '")}' missing at construction`
+        );
+        continue;
+      }
+      const before = this.tools.size;
+      this[method]();
+      const absentOptional = optional.filter((name) => !this.clients[name]);
+      const degradeNote = absentOptional.length
+        ? `; optional '${absentOptional.join("', '")}' absent — degraded`
+        : '';
+      this.logger.info(
+        `[BOOT] ToolRegistry: ${family} tools registered (${this.tools.size - before} tools` +
+        `${required.length ? `; ${required.join(', ')} present` : ''})${degradeNote}`
+      );
+    }
   }
 
   /**

--- a/src/lib/boot/preflight.js
+++ b/src/lib/boot/preflight.js
@@ -1,0 +1,328 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ */
+
+/**
+ * Moltagent Boot Preflight (#87)
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: the system asserted nothing about its own composition at startup.
+ * A missing OPTIONAL dependency crashed instead of disabling (email → restart
+ * loop); a missing REQUIRED dependency retried forever instead of failing
+ * clearly (Collectives → silent 404 cascade). Same generator, opposite
+ * branches: no startup structure knew required from optional.
+ *
+ * Pattern: ONE declared dependency manifest (data, single home — the parallel-
+ * copies-drift archetype from #87 forbids a second list). The preflight walks
+ * it at boot, probes each entry, and prints one [PREFLIGHT] line per entry:
+ *
+ *   [PREFLIGHT] NC Talk: OK (reachable, app enabled)
+ *   [PREFLIGHT] Speaches STT/TTS: OPTIONAL, not reachable — voice features disabled this boot
+ *   [PREFLIGHT][FATAL] NC Collectives: REQUIRED and not installed — install it: <url>
+ *
+ * Halt discipline (the do-not-brick-production rule from #87):
+ *   - REQUIRED + definitively absent (a 2xx answer proving the app/endpoint
+ *     is not there, or a 404 from the app's own API) → halt=true; the caller
+ *     exits cleanly with the remediation line. One line, one exit, no cascade.
+ *   - REQUIRED + unreachable/timeout (network hiccup, slow NC) → WARN and
+ *     continue. A transient outage is not a misconfiguration; halting here
+ *     would brick healthy installs on a slow morning.
+ *   - OPTIONAL + absent/unreachable/not configured → one line, the feature
+ *     degrades, boot continues.
+ *   - MOLTAGENT_PREFLIGHT=warn demotes even definitive required-absence to a
+ *     warning (deployment escape hatch; documented in .env.example).
+ *
+ * Key Dependencies:
+ *   - NCRequestManager (injected): NC-side probes ride the authenticated
+ *     request path (capabilities, app APIs).
+ *   - global fetch (Node >= 18): non-NC probes (Ollama, SearXNG, Speaches).
+ *
+ * Data Flow:
+ *   run() → probe each manifest entry (NC capabilities fetched once, shared)
+ *         → { halt, results[] } → webhook-server prints the table and exits
+ *           on halt (unless demoted).
+ *
+ * Dependency Map:
+ *   BootPreflight
+ *     ← webhook-server initialize() (after NCRequestManager, before subsystems)
+ *     → NCRequestManager (NC probes), fetch (endpoint probes)
+ *
+ * @module boot/preflight
+ */
+
+'use strict';
+
+const PROBE_TIMEOUT_MS = 5000;
+
+/** Probe outcome statuses. */
+const STATUS = {
+  OK: 'ok',                          // reachable and present
+  MISSING: 'missing',                // definitively absent (2xx proof or app-404)
+  UNREACHABLE: 'unreachable',        // network error / timeout — presence unknown
+  NOT_CONFIGURED: 'not-configured',  // no endpoint configured (optional only)
+};
+
+class BootPreflight {
+  /**
+   * @param {Object} options
+   * @param {Object} options.config - Loaded CONFIG object
+   * @param {Object} options.ncRequestManager - Authenticated NC request manager
+   * @param {Object} [options.logger]
+   * @param {Function} [options.fetchImpl] - Injectable fetch for tests
+   */
+  constructor({ config, ncRequestManager, logger, fetchImpl }) {
+    this.config = config;
+    this.nc = ncRequestManager;
+    this.logger = logger || console;
+    this.fetch = fetchImpl || globalThis.fetch;
+    this._capabilities = undefined; // fetched once, shared by NC-app probes
+  }
+
+  /**
+   * The dependency manifest — the single declared home for what Moltagent is
+   * composed of (#87). `kind` decides the failure branch; `configHint` names
+   * where to fix an absence; `remediation` is the required-absent install
+   * pointer; `feature` names what degrades when an optional entry is absent.
+   */
+  manifest() {
+    const cfg = this.config;
+    const ollamaUrl = cfg.ollama && cfg.ollama.url;
+    const searxngUrl = cfg.search && cfg.search.searxng && cfg.search.searxng.url;
+    const speachesUrl = cfg.voice && cfg.voice.speachesUrl;
+    return [
+      {
+        name: 'Nextcloud API', kind: 'required',
+        configHint: 'NC_URL + nc-password credential',
+        remediation: 'check NC_URL and the nc-password credential',
+        probe: () => this._probeCapabilities(),
+      },
+      {
+        name: 'NC Talk', kind: 'required',
+        configHint: 'Talk (spreed) app on the Nextcloud host',
+        remediation: 'install it: https://apps.nextcloud.com/apps/spreed',
+        probe: () => this._probeCapabilityKey('spreed'),
+      },
+      {
+        name: 'NC Deck', kind: 'required',
+        configHint: 'Deck app on the Nextcloud host',
+        remediation: 'install it: https://apps.nextcloud.com/apps/deck',
+        probe: () => this._probeCapabilityKey('deck'),
+      },
+      {
+        name: 'NC Collectives', kind: 'required',
+        configHint: 'Collectives app on the Nextcloud host',
+        remediation: 'install it: https://apps.nextcloud.com/apps/collectives',
+        // Collectives registers no capability key — probe its own OCS API.
+        probe: () => this._probeNcPath('/ocs/v2.php/apps/collectives/api/v1.0/collectives?format=json'),
+      },
+      {
+        name: 'NC Mail', kind: 'optional', feature: 'email triggers and mail tools',
+        configHint: 'Mail app on the Nextcloud host',
+        probe: () => this._probeNcPath('/index.php/apps/mail/api/accounts'),
+      },
+      {
+        name: 'NC News', kind: 'optional', feature: 'RSS/news tools',
+        configHint: 'News app on the Nextcloud host',
+        probe: () => this._probeNcPath('/index.php/apps/news/api/v1-3/feeds'),
+      },
+      {
+        name: 'Ollama', kind: 'optional', feature: 'local LLM inference',
+        configHint: 'OLLAMA_URL',
+        probe: () => this._probeOllama(ollamaUrl),
+      },
+      {
+        name: `Embedding model (${(cfg.ollama && cfg.ollama.embeddingModel) || 'unset'})`,
+        kind: 'optional', feature: 'semantic memory (#96)',
+        configHint: 'EMBEDDING_MODEL (pull it on the Ollama host)',
+        probe: () => this._probeEmbeddingModel(ollamaUrl, cfg.ollama && cfg.ollama.embeddingModel),
+      },
+      {
+        name: 'SearXNG', kind: 'optional', feature: 'sovereign web search',
+        configHint: 'SEARXNG_URL',
+        probe: () => this._probeHttp(searxngUrl),
+      },
+      {
+        name: 'Speaches STT/TTS', kind: 'optional', feature: 'voice',
+        configHint: 'SPEACHES_URL / WHISPER_URL',
+        probe: () => this._probeHttp(speachesUrl),
+      },
+    ];
+  }
+
+  /**
+   * Run every probe and log the preflight table.
+   * @returns {Promise<{halt: boolean, results: Array}>} halt=true when a
+   *   required dependency is DEFINITIVELY absent (never on mere unreachability).
+   */
+  async run() {
+    const results = [];
+    let halt = false;
+
+    for (const entry of this.manifest()) {
+      let status;
+      let detail = '';
+      try {
+        const outcome = await entry.probe();
+        status = outcome.status;
+        detail = outcome.detail || '';
+      } catch (err) {
+        status = STATUS.UNREACHABLE;
+        detail = err && err.message;
+      }
+      results.push({ name: entry.name, kind: entry.kind, status, detail, feature: entry.feature });
+
+      if (entry.kind === 'required') {
+        if (status === STATUS.OK) {
+          this.logger.info(`[PREFLIGHT] ${entry.name}: OK${detail ? ` (${detail})` : ''}`);
+        } else if (status === STATUS.MISSING) {
+          halt = true;
+          this.logger.error(`[PREFLIGHT][FATAL] ${entry.name}: REQUIRED and not installed — ${entry.remediation}`);
+        } else {
+          // Unreachable ≠ absent: warn, do not brick a healthy install on a hiccup.
+          this.logger.warn(`[PREFLIGHT][WARN] ${entry.name}: REQUIRED but unreachable right now (${detail || 'no response'}) — continuing; check ${entry.configHint}`);
+        }
+      } else {
+        if (status === STATUS.OK) {
+          this.logger.info(`[PREFLIGHT] ${entry.name}: OK${detail ? ` (${detail})` : ''}`);
+        } else if (status === STATUS.NOT_CONFIGURED) {
+          this.logger.info(`[PREFLIGHT] ${entry.name}: OPTIONAL, not configured (${entry.configHint}) — ${entry.feature} disabled this boot`);
+        } else {
+          this.logger.warn(`[PREFLIGHT] ${entry.name}: OPTIONAL, ${status === STATUS.MISSING ? 'not installed' : 'not reachable'} — ${entry.feature} disabled this boot`);
+        }
+      }
+    }
+
+    return { halt, results };
+  }
+
+  /** Fetch NC capabilities once; shared by the NC-app probes. @private */
+  async _getCapabilities() {
+    if (this._capabilities !== undefined) return this._capabilities;
+    try {
+      const res = await this.nc.request('/ocs/v2.php/cloud/capabilities?format=json', {
+        method: 'GET',
+        headers: { 'OCS-APIRequest': 'true', 'Accept': 'application/json' },
+      });
+      if (res && res.status >= 200 && res.status < 300) {
+        const parsed = typeof res.body === 'string' ? JSON.parse(res.body) : res.body;
+        this._capabilities = (parsed && parsed.ocs && parsed.ocs.data && parsed.ocs.data.capabilities) || null;
+      } else {
+        this._capabilities = null;
+      }
+    } catch (_) {
+      this._capabilities = null;
+    }
+    return this._capabilities;
+  }
+
+  /** Nextcloud core reachable = capabilities answered. @private */
+  async _probeCapabilities() {
+    const caps = await this._getCapabilities();
+    return caps
+      ? { status: STATUS.OK, detail: 'capabilities answered' }
+      : { status: STATUS.UNREACHABLE, detail: 'capabilities not answered' };
+  }
+
+  /**
+   * App present = its key appears in a SUCCESSFULLY fetched capabilities
+   * document. Absence is only definitive when the document itself arrived.
+   * @private
+   */
+  async _probeCapabilityKey(key) {
+    const caps = await this._getCapabilities();
+    if (!caps) return { status: STATUS.UNREACHABLE, detail: 'capabilities not answered' };
+    return Object.prototype.hasOwnProperty.call(caps, key)
+      ? { status: STATUS.OK, detail: 'reachable, app enabled' }
+      : { status: STATUS.MISSING, detail: `no '${key}' capability` };
+  }
+
+  /**
+   * Probe an NC app by its own API path: 2xx = present; 404 = definitively
+   * absent (the app's route does not exist); anything else = unknown.
+   * @private
+   */
+  async _probeNcPath(path) {
+    try {
+      const res = await this.nc.request(path, {
+        method: 'GET',
+        headers: { 'OCS-APIRequest': 'true', 'Accept': 'application/json' },
+      });
+      if (res && res.status >= 200 && res.status < 300) return { status: STATUS.OK, detail: 'reachable, app enabled' };
+      if (res && res.status === 404) return { status: STATUS.MISSING, detail: '404 from app API' };
+      return { status: STATUS.UNREACHABLE, detail: `HTTP ${res && res.status}` };
+    } catch (err) {
+      if (err && err.statusCode === 404) return { status: STATUS.MISSING, detail: '404 from app API' };
+      return { status: STATUS.UNREACHABLE, detail: err && err.message };
+    }
+  }
+
+  /** Plain HTTP reachability with timeout; any HTTP answer counts as up. @private */
+  async _probeHttp(url) {
+    if (!url) return { status: STATUS.NOT_CONFIGURED };
+    try {
+      const res = await this._fetchWithTimeout(url);
+      return { status: STATUS.OK, detail: `HTTP ${res.status}` };
+    } catch (err) {
+      return { status: STATUS.UNREACHABLE, detail: err && err.message };
+    }
+  }
+
+  /** Ollama up = /api/tags answers 2xx. @private */
+  async _probeOllama(ollamaUrl) {
+    if (!ollamaUrl) return { status: STATUS.NOT_CONFIGURED };
+    try {
+      const res = await this._fetchWithTimeout(`${ollamaUrl.replace(/\/$/, '')}/api/tags`);
+      return res.ok
+        ? { status: STATUS.OK, detail: 'reachable' }
+        : { status: STATUS.UNREACHABLE, detail: `HTTP ${res.status}` };
+    } catch (err) {
+      return { status: STATUS.UNREACHABLE, detail: err && err.message };
+    }
+  }
+
+  /**
+   * Embedding model present = it appears in Ollama's tag list (matched on the
+   * base name so 'nomic-embed-text:latest' satisfies 'nomic-embed-text').
+   * @private
+   */
+  async _probeEmbeddingModel(ollamaUrl, model) {
+    if (!ollamaUrl || !model) return { status: STATUS.NOT_CONFIGURED };
+    try {
+      const res = await this._fetchWithTimeout(`${ollamaUrl.replace(/\/$/, '')}/api/tags`);
+      if (!res.ok) return { status: STATUS.UNREACHABLE, detail: `HTTP ${res.status}` };
+      const data = await res.json();
+      const models = (data && data.models) || [];
+      const present = models.some((m) => m && typeof m.name === 'string' && m.name.split(':')[0] === model.split(':')[0]);
+      return present
+        ? { status: STATUS.OK, detail: 'pulled on Ollama host' }
+        : { status: STATUS.MISSING, detail: `not in Ollama tag list — ollama pull ${model}` };
+    } catch (err) {
+      return { status: STATUS.UNREACHABLE, detail: err && err.message };
+    }
+  }
+
+  /** @private */
+  async _fetchWithTimeout(url) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    try {
+      return await this.fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+module.exports = { BootPreflight, STATUS };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -268,6 +268,9 @@ const config = {
     // falls back to localhost:11434 — so the placeholder never reaches a client.
     url: envStr('OLLAMA_URL', 'http://YOUR_OLLAMA_IP:11434'),
     model: envStr('OLLAMA_MODEL', 'phi4-mini'),
+    // Embedding model for semantic memory (#96). One home: the EmbeddingClient
+    // construction site and the boot preflight manifest both read this key.
+    embeddingModel: envStr('EMBEDDING_MODEL', 'nomic-embed-text'),
     modelCredential: envStr('OLLAMA_MODEL_CREDENTIAL', null) || envStr('OLLAMA_MODEL', 'phi4-mini'),
     modelFast: envStr('OLLAMA_MODEL_FAST', null) || envStr('OLLAMA_CLASSIFY_MODEL', 'qwen2.5:3b'),
     timeout: envInt('OLLAMA_TIMEOUT', 300000),

--- a/src/lib/llm/model-resolver.js
+++ b/src/lib/llm/model-resolver.js
@@ -126,6 +126,14 @@ class ModelResolver {
     // opinion on; NicheAssignment itself replans and re-sets it.
     this._assignment = null;
 
+    // Models the boot tool-capability probe (#118) measured answering a
+    // tool-requiring instruction with prose. Observability only: describe()
+    // annotates them; resolve() precedence is untouched (reseating on
+    // evidence is the maturation loop's authority, and the runtime chain
+    // already falls back on tool-call failure). Survives refresh() for the
+    // same reason the ground-truth overrides do.
+    this._toolIncapable = new Set();
+
     this.refresh();
   }
 
@@ -243,6 +251,24 @@ class ModelResolver {
   }
 
   /**
+   * Flag a model the boot tool-capability probe (#118) measured returning
+   * prose to a tool-requiring instruction. describe() surfaces the flag;
+   * resolution precedence is deliberately untouched.
+   * @param {string} model
+   */
+  markToolIncapable(model) {
+    if (model) this._toolIncapable.add(model);
+  }
+
+  /**
+   * @param {string} model
+   * @returns {boolean} true when the probe flagged this model prose-only
+   */
+  isToolIncapable(model) {
+    return this._toolIncapable.has(model);
+  }
+
+  /**
    * Build a one-line-per-job interoception report for the startup log.
    * @param {string[]} jobs - Jobs to report (e.g. ['tools','thinking','quick']).
    * @returns {{ summary: string, divergences: string[] }}
@@ -252,7 +278,8 @@ class ModelResolver {
     const divergences = [];
     for (const job of jobs) {
       const r = this.resolve(job);
-      parts.push(`${job}→${r.model || '(none)'} (${r.source})`);
+      const toolFlag = r.model && this._toolIncapable.has(r.model) ? ' ⚠not-tool-capable(#118)' : '';
+      parts.push(`${job}→${r.model || '(none)'} (${r.source})${toolFlag}`);
       const d = r.derivation;
       // Divergence: two distinct, present sources disagree on the model.
       const present = [d.deployerConfig, d.envOverride, d.modelScout, d.cockpitCard].filter(Boolean);

--- a/src/lib/llm/tool-capability-probe.js
+++ b/src/lib/llm/tool-capability-probe.js
@@ -1,0 +1,188 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * ToolCapabilityProbe — Verify at boot that each model assigned to a
+ * tool-capable job ACTUALLY produces tool calls (#118).
+ *
+ * Problem:
+ *   A model's /api/show capabilities declare tool support; some models
+ *   declare it and still answer a tool-requiring instruction with prose.
+ *   That deficiency surfaced downstream, mid-request, as parse fallbacks
+ *   and hallucinated action reports — never at boot, where it belongs.
+ *
+ * Pattern:
+ *   Same probe-and-cache shape as GoldenSetProbe (one probing pattern, not
+ *   two): for each candidate, send ONE trivial function schema plus an
+ *   instruction that requires calling it, through the SAME provider class
+ *   production uses (chatFn injected — the probe owns no transport). A
+ *   response whose toolCalls names the probe function passes; prose fails
+ *   and is flagged in the boot log and ModelResolver.describe(). Results
+ *   are cached on disk keyed by model digest + probe revision so warm
+ *   boots stay fast; an errored measurement (Ollama cold, #124) is NOT
+ *   cached and NOT flagged — cold is not prose.
+ *
+ * Boundary (#118 vs the maturation loop): the probe FLAGS; it does not
+ *   reseat. Reseating on evidence is the ModelScorecard/maturation loop's
+ *   authority — at runtime the existing QUICK chain already falls back on
+ *   tool-call failure. The probe converts that silent runtime discovery
+ *   into a loud boot line.
+ *
+ * Data Flow:
+ *   webhook-server (boot, inside the ModelScout .then, after the golden-set
+ *   probe so the post-probe resolver re-log reflects both — NOTE(#233))
+ *     → probe.run(candidates) → { name, status: 'tool-call'|'prose'|'unmeasured' }
+ *     → modelResolver.markToolIncapable(name) per prose result
+ *
+ * Dependency Map:
+ *   src/lib/llm/tool-capability-probe.js
+ *     ← (no internal imports — standalone; callers inject chatFn)
+ *
+ * @module llm/tool-capability-probe
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const CACHE_FILENAME = 'tool-capability-probe.json';
+
+// Bump when the probe schema/instruction or pass criterion changes — old
+// cached verdicts then re-measure instead of masquerading as comparable.
+const PROBE_REV = 1;
+
+// The trivial probe function: one boolean argument, no room for ambiguity.
+const PROBE_TOOL = {
+  type: 'function',
+  function: {
+    name: 'mark_ready',
+    description: 'Report readiness. Call this function — do not answer in text.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ready: { type: 'boolean', description: 'Always true.' },
+      },
+      required: ['ready'],
+    },
+  },
+};
+
+const PROBE_SYSTEM = 'You are a function-calling assistant. You MUST answer by calling the provided function. Never answer in prose.';
+const PROBE_MESSAGE = 'Call the mark_ready function with ready set to true.';
+
+/** Probe verdicts. */
+const VERDICT = {
+  TOOL_CALL: 'tool-call',   // produced a tool call naming the probe function
+  PROSE: 'prose',           // answered without a usable tool call
+  UNMEASURED: 'unmeasured', // transport error/timeout — presence unknown, retry next boot
+};
+
+class ToolCapabilityProbe {
+  /**
+   * @param {Object} opts
+   * @param {Function} [opts.chatFn] - async (modelName, { system, messages, tools })
+   *   => provider response ({ content, toolCalls }). Production injects the
+   *   real OllamaToolsProvider.chat; tests inject a fake. The probe owns no
+   *   transport of its own.
+   * @param {string} [opts.cacheDir] - Directory for the results cache
+   *   (defaults to `data/` under cwd, same as GoldenSetProbe).
+   * @param {Object} [opts.logger=console]
+   */
+  constructor({ chatFn, cacheDir, logger } = {}) {
+    this.chatFn = typeof chatFn === 'function' ? chatFn : null;
+    this.cacheDir = cacheDir || path.resolve(process.cwd(), 'data');
+    this._cacheFile = path.join(this.cacheDir, CACHE_FILENAME);
+    this.logger = logger || console;
+  }
+
+  /**
+   * Probe each candidate once (sequential — one Ollama host serves these).
+   * @param {Array<{name: string, digest?: string}>} candidates
+   * @returns {Promise<Array<{name: string, status: string, detail: string}>>}
+   */
+  async run(candidates) {
+    const list = Array.isArray(candidates) ? candidates.filter(c => c && typeof c.name === 'string') : [];
+    if (list.length === 0 || !this.chatFn) {
+      if (!this.chatFn) this.logger.warn('[ToolCapabilityProbe] Missing chatFn; skipping probe.');
+      return [];
+    }
+
+    const diskCache = this._loadCache();
+    let cacheChanged = false;
+    const results = [];
+
+    for (const candidate of list) {
+      const key = this._cacheKey(candidate);
+      const cached = diskCache[key];
+      if (cached && cached.status && cached.status !== VERDICT.UNMEASURED) {
+        results.push({ name: candidate.name, status: cached.status, detail: `${cached.detail || ''} (cached)`.trim() });
+        continue;
+      }
+
+      let status;
+      let detail;
+      try {
+        const res = await this.chatFn(candidate.name, {
+          system: PROBE_SYSTEM,
+          messages: [{ role: 'user', content: PROBE_MESSAGE }],
+          tools: [PROBE_TOOL],
+        });
+        const calls = res && Array.isArray(res.toolCalls) ? res.toolCalls : [];
+        if (calls.some(tc => tc && tc.name === PROBE_TOOL.function.name)) {
+          status = VERDICT.TOOL_CALL;
+          detail = 'tool call produced';
+        } else {
+          status = VERDICT.PROSE;
+          const preview = res && typeof res.content === 'string' ? res.content.slice(0, 60) : '';
+          detail = `prose instead of tool call${preview ? `: "${preview}"` : ''}`;
+        }
+      } catch (err) {
+        // Transport error / timeout: NOT evidence of prose (#124 cold-start).
+        // Do not cache, do not flag; retry next boot.
+        status = VERDICT.UNMEASURED;
+        detail = err && err.message;
+        this.logger.warn(`[ToolCapabilityProbe] ${candidate.name}: probe errored (${detail}); not caching, will retry next boot.`);
+      }
+
+      if (status !== VERDICT.UNMEASURED) {
+        diskCache[key] = { status, detail, at: new Date().toISOString() };
+        cacheChanged = true;
+      }
+      results.push({ name: candidate.name, status, detail });
+    }
+
+    if (cacheChanged) this._saveCache(diskCache);
+    return results;
+  }
+
+  /** @private */
+  _cacheKey(candidate) {
+    const id = (candidate && (candidate.digest || candidate.name)) || 'unknown';
+    return `${id}__toolprobe_r${PROBE_REV}`;
+  }
+
+  /** @private */
+  _loadCache() {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this._cacheFile, 'utf8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    } catch (_err) { /* missing/corrupt — start fresh */ }
+    return {};
+  }
+
+  /** @private */
+  _saveCache(cache) {
+    try {
+      if (!fs.existsSync(this.cacheDir)) fs.mkdirSync(this.cacheDir, { recursive: true });
+      const tmp = this._cacheFile + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(cache, null, 2), 'utf8');
+      fs.renameSync(tmp, this._cacheFile);
+    } catch (err) {
+      this.logger.warn(`[ToolCapabilityProbe] Failed to persist probe cache: ${err.message}`);
+    }
+  }
+}
+
+module.exports = { ToolCapabilityProbe, VERDICT };

--- a/test/unit/agent/tool-registry-boot-contract.test.js
+++ b/test/unit/agent/tool-registry-boot-contract.test.js
@@ -1,0 +1,147 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * ToolRegistry Boot Composition Contract Tests (#227)
+ *
+ * The registry asserts its own composition at construction: a missing
+ * required client produces a loud [BOOT][WARN] naming the family and the
+ * client, and the family is skipped visibly. A dropped constructor client
+ * (the #226 class) is caught structurally by parsing the live construction
+ * site in webhook-server.js and asserting every passed key survives into
+ * this.clients.
+ *
+ * Run: node test/unit/agent/tool-registry-boot-contract.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const { ToolRegistry } = require('../../../src/lib/agent/tool-registry');
+
+console.log('\n=== ToolRegistry Boot Contract Tests (#227) ===\n');
+
+/** Truthy mock client: any property access yields a callable no-op. */
+function mockClient() {
+  return new Proxy({}, { get: () => () => {} });
+}
+
+/** Logger that captures lines per level. */
+function captureLogger() {
+  const lines = { info: [], warn: [], error: [], log: [] };
+  return {
+    lines,
+    info: (m) => lines.info.push(String(m)),
+    warn: (m) => lines.warn.push(String(m)),
+    error: (m) => lines.error.push(String(m)),
+    log: (m) => lines.log.push(String(m)),
+  };
+}
+
+/** Client keys the live construction site passes (parsed from webhook-server.js). */
+function constructionSiteKeys() {
+  const serverSrc = fs.readFileSync(path.join(__dirname, '../../../webhook-server.js'), 'utf8');
+  const callMatch = serverSrc.match(/new ToolRegistry\(\{([\s\S]*?)\}\);/);
+  assert.ok(callMatch, 'construction site found in webhook-server.js');
+  return [...callMatch[1].matchAll(/^\s*(\w+)\s*:/gm)].map((m) => m[1]);
+}
+
+/** The full client set: manifest names ∪ construction-site keys. */
+function fullClientSet() {
+  const names = new Set(constructionSiteKeys());
+  for (const fam of ToolRegistry.TOOL_FAMILIES) {
+    for (const n of fam.required || []) names.add(n);
+    for (const n of fam.optional || []) names.add(n);
+  }
+  const clients = {};
+  for (const n of names) clients[n] = mockClient();
+  return clients;
+}
+
+// TC-BOOT-001: missing required client → loud warning, family absent.
+test('TC-BOOT-001: missing meetingComposer → [BOOT][WARN] fired and meeting tools absent', () => {
+  const logger = captureLogger();
+  const clients = fullClientSet();
+  delete clients.meetingComposer;
+
+  const registry = new ToolRegistry({ ...clients, logger });
+
+  const warnLine = logger.lines.warn.find((l) => l.includes('meeting tools SKIPPED'));
+  assert.ok(warnLine, 'a [BOOT][WARN] line must name the skipped family');
+  assert.ok(warnLine.includes('[BOOT][WARN]'), 'warning carries the [BOOT][WARN] prefix');
+  assert.ok(warnLine.includes("'meetingComposer'"), 'warning names the missing client');
+  assert.ok(!registry.tools.has('meeting_compose'), 'meeting_compose must not register');
+  assert.ok(!registry.tools.has('meeting_check_rsvp'), 'meeting_check_rsvp must not register');
+});
+
+// TC-BOOT-002: full client set → all families register, meeting tools present, 74+ tools.
+test('TC-BOOT-002: full client set registers all families (74+ tools incl. meeting)', () => {
+  const logger = captureLogger();
+  const registry = new ToolRegistry({ ...fullClientSet(), logger });
+
+  assert.ok(registry.tools.size >= 74, `expected >= 74 tools, got ${registry.tools.size}`);
+  assert.ok(registry.tools.has('meeting_compose'), 'meeting_compose registers (#226)');
+  assert.ok(registry.tools.has('meeting_check_rsvp'), 'meeting_check_rsvp registers (#226)');
+  assert.strictEqual(logger.lines.warn.filter((l) => l.includes('[BOOT][WARN]')).length, 0,
+    'no [BOOT][WARN] lines with a full client set');
+  const bootLines = logger.lines.info.filter((l) => l.startsWith('[BOOT] ToolRegistry:'));
+  assert.strictEqual(bootLines.length, ToolRegistry.TOOL_FAMILIES.length,
+    'one positive [BOOT] line per family');
+});
+
+// TC-BOOT-003: manifest ↔ registrar alignment — every method exists.
+test('TC-BOOT-003: every TOOL_FAMILIES method exists on the prototype', () => {
+  for (const fam of ToolRegistry.TOOL_FAMILIES) {
+    assert.strictEqual(typeof ToolRegistry.prototype[fam.method], 'function',
+      `${fam.method} (family '${fam.family}') must exist`);
+  }
+});
+
+// TC-BOOT-004: the #226 class, killed structurally — every key the LIVE
+// construction site passes must survive into this.clients. Parses the real
+// `new ToolRegistry({...})` call in webhook-server.js, so a future client
+// added at the call site but dropped by the destructure fails HERE, not in
+// production weeks later.
+test('TC-BOOT-004: every construction-site client key survives into this.clients', () => {
+  const passedKeys = constructionSiteKeys();
+  assert.ok(passedKeys.length >= 15, `sanity: found ${passedKeys.length} construction-site keys`);
+
+  const clients = {};
+  const sentinels = {};
+  for (const key of passedKeys) {
+    sentinels[key] = mockClient();
+    clients[key] = sentinels[key];
+  }
+  const registry = new ToolRegistry({ ...clients, logger: captureLogger() });
+
+  const dropped = passedKeys.filter((key) => registry.clients[key] !== sentinels[key]);
+  assert.deepStrictEqual(dropped, [],
+    `constructor drops construction-site client(s): ${dropped.join(', ')} — align the destructure (#226)`);
+});
+
+// TC-BOOT-005: optional-client degrade is visible, not silent.
+test('TC-BOOT-005: absent optional client logs a visible degrade note', () => {
+  const logger = captureLogger();
+  const clients = fullClientSet();
+  delete clients.rsvpTracker;
+
+  const registry = new ToolRegistry({ ...clients, logger });
+
+  assert.ok(registry.tools.has('meeting_compose'), 'family still registers without optional client');
+  const meetingLine = logger.lines.info.find((l) => l.includes('meeting tools registered'));
+  assert.ok(meetingLine, 'positive [BOOT] line still emitted');
+  assert.ok(meetingLine.includes("optional 'rsvpTracker' absent"), 'degrade note names the absent optional client');
+});
+
+summary();
+exitWithCode();

--- a/test/unit/boot/preflight.test.js
+++ b/test/unit/boot/preflight.test.js
@@ -1,0 +1,182 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * BootPreflight Unit Tests (#87)
+ *
+ * The manifest is one declared object; required-and-definitively-absent
+ * halts, unreachable-required only warns, optional-missing degrades visibly.
+ *
+ * Run: node test/unit/boot/preflight.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const { BootPreflight, STATUS } = require('../../../src/lib/boot/preflight');
+
+console.log('\n=== BootPreflight Tests (#87) ===\n');
+
+const CAPS_FULL = { spreed: {}, deck: {}, theming: {} };
+const CAPS_NO_DECK = { spreed: {}, theming: {} };
+
+function capsBody(caps) {
+  return JSON.stringify({ ocs: { data: { capabilities: caps } } });
+}
+
+/**
+ * Mock NCRequestManager. `overrides` maps path substrings to responses
+ * ({status, body}) or Error instances.
+ */
+function mockNc(caps, overrides = {}) {
+  return {
+    request: async (path) => {
+      for (const [needle, value] of Object.entries(overrides)) {
+        if (path.includes(needle)) {
+          if (value instanceof Error) throw value;
+          return value;
+        }
+      }
+      if (path.includes('/cloud/capabilities')) {
+        if (caps instanceof Error) throw caps;
+        return { status: 200, body: capsBody(caps) };
+      }
+      return { status: 200, body: '[]' };
+    },
+  };
+}
+
+function captureLogger() {
+  const lines = { info: [], warn: [], error: [] };
+  return {
+    lines,
+    info: (m) => lines.info.push(String(m)),
+    warn: (m) => lines.warn.push(String(m)),
+    error: (m) => lines.error.push(String(m)),
+  };
+}
+
+/** Fetch mock: ollama tags OK with the embedding model present. */
+function mockFetch({ tags = ['nomic-embed-text:latest'], fail = false } = {}) {
+  return async (url) => {
+    if (fail) throw new Error('connect ECONNREFUSED');
+    if (String(url).includes('/api/tags')) {
+      return { ok: true, status: 200, json: async () => ({ models: tags.map((n) => ({ name: n })) }) };
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+}
+
+const BASE_CONFIG = {
+  ollama: { url: 'http://ollama.test:11434', embeddingModel: 'nomic-embed-text' },
+  search: { searxng: { url: 'http://searx.test' } },
+  voice: { speachesUrl: 'http://voice.test:8014' },
+};
+
+(async () => {
+  // TC-PF-001: everything present → no halt, all OK.
+  await asyncTest('TC-PF-001: full composition → all OK, no halt', async () => {
+    const logger = captureLogger();
+    const pf = new BootPreflight({
+      config: BASE_CONFIG, ncRequestManager: mockNc(CAPS_FULL), logger, fetchImpl: mockFetch(),
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, false);
+    assert.ok(results.every((r) => r.status === STATUS.OK), JSON.stringify(results));
+    assert.strictEqual(logger.lines.error.length, 0);
+  });
+
+  // TC-PF-002: required app definitively absent (2xx caps without the key) → halt + fatal line.
+  await asyncTest('TC-PF-002: Deck absent from capabilities → halt with remediation', async () => {
+    const logger = captureLogger();
+    const pf = new BootPreflight({
+      config: BASE_CONFIG, ncRequestManager: mockNc(CAPS_NO_DECK), logger, fetchImpl: mockFetch(),
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, true, 'definitive absence of a required app must halt');
+    const deck = results.find((r) => r.name === 'NC Deck');
+    assert.strictEqual(deck.status, STATUS.MISSING);
+    const fatal = logger.lines.error.find((l) => l.includes('NC Deck') && l.includes('[PREFLIGHT][FATAL]'));
+    assert.ok(fatal, 'one fatal line names the dependency');
+    assert.ok(fatal.includes('apps.nextcloud.com/apps/deck'), 'fatal line carries the remediation URL');
+  });
+
+  // TC-PF-003: required unreachable (network error) → NO halt, warn only.
+  await asyncTest('TC-PF-003: capabilities unreachable → warn, never halt (no bricking on hiccups)', async () => {
+    const logger = captureLogger();
+    const pf = new BootPreflight({
+      config: BASE_CONFIG, ncRequestManager: mockNc(new Error('ETIMEDOUT')), logger, fetchImpl: mockFetch(),
+    });
+    const { halt } = await pf.run();
+    assert.strictEqual(halt, false, 'unreachable is not absence — must not halt');
+    assert.ok(logger.lines.warn.some((l) => l.includes('[PREFLIGHT][WARN]')), 'warn lines emitted');
+    assert.strictEqual(logger.lines.error.length, 0, 'no fatal lines');
+  });
+
+  // TC-PF-004: required app API 404 (Collectives removed) → halt.
+  await asyncTest('TC-PF-004: Collectives API 404 → definitive absence, halt', async () => {
+    const logger = captureLogger();
+    const pf = new BootPreflight({
+      config: BASE_CONFIG,
+      ncRequestManager: mockNc(CAPS_FULL, { '/apps/collectives/': { status: 404, body: '' } }),
+      logger, fetchImpl: mockFetch(),
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, true);
+    assert.strictEqual(results.find((r) => r.name === 'NC Collectives').status, STATUS.MISSING);
+  });
+
+  // TC-PF-005: optional unreachable → boot continues, one visible degrade line.
+  await asyncTest('TC-PF-005: Speaches down → optional degrade line, no halt', async () => {
+    const logger = captureLogger();
+    const fetchImpl = async (url) => {
+      if (String(url).startsWith('http://voice.test')) throw new Error('connect ECONNREFUSED');
+      return mockFetch()(url);
+    };
+    const pf = new BootPreflight({
+      config: BASE_CONFIG, ncRequestManager: mockNc(CAPS_FULL), logger, fetchImpl,
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, false, 'optional absence never halts');
+    assert.strictEqual(results.find((r) => r.name === 'Speaches STT/TTS').status, STATUS.UNREACHABLE);
+    const line = logger.lines.warn.find((l) => l.includes('Speaches STT/TTS') && l.includes('voice disabled this boot'));
+    assert.ok(line, 'degrade line names the feature that turns off');
+  });
+
+  // TC-PF-006: optional not configured → says so once, no warning noise.
+  await asyncTest('TC-PF-006: unset optional endpoint → not-configured info line', async () => {
+    const logger = captureLogger();
+    const config = { ...BASE_CONFIG, voice: { speachesUrl: '' } };
+    const pf = new BootPreflight({
+      config, ncRequestManager: mockNc(CAPS_FULL), logger, fetchImpl: mockFetch(),
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, false);
+    assert.strictEqual(results.find((r) => r.name === 'Speaches STT/TTS').status, STATUS.NOT_CONFIGURED);
+    assert.ok(logger.lines.info.some((l) => l.includes('Speaches STT/TTS') && l.includes('not configured')));
+  });
+
+  // TC-PF-007: embedding model missing from Ollama tags → definitive optional MISSING with pull hint.
+  await asyncTest('TC-PF-007: embedding model not pulled → missing with remediation detail', async () => {
+    const logger = captureLogger();
+    const pf = new BootPreflight({
+      config: BASE_CONFIG, ncRequestManager: mockNc(CAPS_FULL),
+      logger, fetchImpl: mockFetch({ tags: ['qwen3:8b'] }),
+    });
+    const { halt, results } = await pf.run();
+    assert.strictEqual(halt, false);
+    const emb = results.find((r) => r.name.startsWith('Embedding model'));
+    assert.strictEqual(emb.status, STATUS.MISSING);
+    assert.ok(emb.detail.includes('ollama pull nomic-embed-text'));
+  });
+
+  setTimeout(() => { summary(); exitWithCode(); }, 500);
+})();

--- a/test/unit/llm/tool-capability-probe.test.js
+++ b/test/unit/llm/tool-capability-probe.test.js
@@ -1,0 +1,111 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * ToolCapabilityProbe Unit Tests (#118)
+ *
+ * Run: node test/unit/llm/tool-capability-probe.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const { ToolCapabilityProbe, VERDICT } = require('../../../src/lib/llm/tool-capability-probe');
+
+console.log('\n=== ToolCapabilityProbe Tests (#118) ===\n');
+
+function tmpCacheDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'toolprobe-'));
+}
+
+function captureLogger() {
+  const lines = { warn: [], log: [], info: [] };
+  return {
+    lines,
+    warn: (m) => lines.warn.push(String(m)),
+    log: (m) => lines.log.push(String(m)),
+    info: (m) => lines.info.push(String(m)),
+    error: () => {},
+  };
+}
+
+(async () => {
+  // TC-TCP-001: a model that answers with the probe tool call passes.
+  await asyncTest('TC-TCP-001: tool-call response → tool-call verdict', async () => {
+    const probe = new ToolCapabilityProbe({
+      chatFn: async () => ({ content: null, toolCalls: [{ id: 'x', name: 'mark_ready', arguments: { ready: true } }] }),
+      cacheDir: tmpCacheDir(), logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'qwen3:8b' }]);
+    assert.strictEqual(v.status, VERDICT.TOOL_CALL);
+  });
+
+  // TC-TCP-002: prose response → flagged.
+  await asyncTest('TC-TCP-002: prose response → prose verdict', async () => {
+    const probe = new ToolCapabilityProbe({
+      chatFn: async () => ({ content: 'I am ready to help!', toolCalls: null }),
+      cacheDir: tmpCacheDir(), logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'gemma2:2b' }]);
+    assert.strictEqual(v.status, VERDICT.PROSE);
+    assert.ok(v.detail.includes('prose'), 'detail names the failure shape');
+  });
+
+  // TC-TCP-003: a tool call to the WRONG function is not a pass.
+  await asyncTest('TC-TCP-003: wrong function name → prose verdict', async () => {
+    const probe = new ToolCapabilityProbe({
+      chatFn: async () => ({ content: '', toolCalls: [{ id: 'x', name: 'unrelated_fn', arguments: {} }] }),
+      cacheDir: tmpCacheDir(), logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'm' }]);
+    assert.strictEqual(v.status, VERDICT.PROSE);
+  });
+
+  // TC-TCP-004: transport error → unmeasured, NOT cached, NOT flagged (#124 cold ≠ prose).
+  await asyncTest('TC-TCP-004: transport error → unmeasured and not cached', async () => {
+    const dir = tmpCacheDir();
+    let calls = 0;
+    const probe = new ToolCapabilityProbe({
+      chatFn: async () => { calls++; throw new Error('socket hang up (cold start)'); },
+      cacheDir: dir, logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
+    assert.strictEqual(v.status, VERDICT.UNMEASURED);
+
+    // Second run re-probes (no poisoned cache entry).
+    const [v2] = await probe.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
+    assert.strictEqual(v2.status, VERDICT.UNMEASURED);
+    assert.strictEqual(calls, 2, 'errored measurement must not be served from cache');
+  });
+
+  // TC-TCP-005: verdicts are cached by digest — warm run makes no chatFn calls.
+  await asyncTest('TC-TCP-005: cached verdict served without a new probe call', async () => {
+    const dir = tmpCacheDir();
+    let calls = 0;
+    const chatFn = async () => { calls++; return { content: null, toolCalls: [{ name: 'mark_ready' }] }; };
+    const probe1 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    await probe1.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
+    assert.strictEqual(calls, 1);
+
+    const probe2 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v] = await probe2.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
+    assert.strictEqual(calls, 1, 'warm boot serves the cached verdict');
+    assert.strictEqual(v.status, VERDICT.TOOL_CALL);
+    assert.ok(v.detail.includes('cached'));
+  });
+
+  // TC-TCP-006: no chatFn → skip loudly, empty result.
+  await asyncTest('TC-TCP-006: missing chatFn skips with a warning', async () => {
+    const logger = captureLogger();
+    const probe = new ToolCapabilityProbe({ cacheDir: tmpCacheDir(), logger });
+    const out = await probe.run([{ name: 'm' }]);
+    assert.deepStrictEqual(out, []);
+    assert.ok(logger.lines.warn.some((l) => l.includes('Missing chatFn')));
+  });
+
+  setTimeout(() => { summary(); exitWithCode(); }, 500);
+})();

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -2168,7 +2168,7 @@ async function initialize() {
             });
             const clsCandidates = modelScout.getClassificationCandidates();
             probe.run(clsCandidates)
-              .then(sel => {
+              .then(async sel => {
                 if (sel && sel.model) {
                   modelResolver.setGroundTruthOverride('classification', sel.model);
                   console.log(`[INIT] Golden-set probe: classification -> ${sel.model} (EN ${sel.scores?.EN} DE ${sel.scores?.DE} PT ${sel.scores?.PT}, ${sel.passed ? 'passed' : sel.reason})`);
@@ -2188,14 +2188,60 @@ async function initialize() {
                   );
                   modelScorecard.assertSeats();
                 }
+                // Tool-capability probe (#118): each LOCAL model currently
+                // resolved for a tool-capable job answers one trivial
+                // function-call instruction through the production provider
+                // class. Prose → flagged in the boot log + describe(); the
+                // probe never reseats (that is the maturation loop's
+                // authority; the runtime chain already falls back on
+                // tool-call failure). Runs sequentially AFTER the golden-set
+                // probe so the single post-probe resolver re-log below
+                // reflects both measurements — NOTE(#233): the re-log remains
+                // the one channel that closes the summary-vs-async-probe race.
+                try {
+                  if (OllamaToolsProvider) {
+                    const { ToolCapabilityProbe, VERDICT } = require('./src/lib/llm/tool-capability-probe');
+                    const probeProvider = new OllamaToolsProvider({
+                      endpoint: CONFIG.ollama.url,
+                      model: CONFIG.ollama.model,
+                      toolTimeout: CONFIG.ollama.toolTimeout,
+                    });
+                    const toolProbe = new ToolCapabilityProbe({
+                      chatFn: (model, req) => probeProvider.chat({ ...req, model }),
+                      cacheDir: path.join(__dirname, 'data'),
+                      logger: console,
+                    });
+                    const seen = new Set();
+                    const toolCandidates = [];
+                    for (const job of ['tools', 'quick']) {
+                      const r = modelResolver.resolve(job);
+                      if (r.model && String(r.provider || '').startsWith('ollama') && !seen.has(r.model)) {
+                        seen.add(r.model);
+                        const disc = (modelScout._discovered || []).find(m => m && m.name === r.model);
+                        toolCandidates.push({ name: r.model, digest: disc && disc.digest });
+                      }
+                    }
+                    const verdicts = await toolProbe.run(toolCandidates);
+                    for (const v of verdicts) {
+                      if (v.status === VERDICT.PROSE) {
+                        modelResolver.markToolIncapable(v.name);
+                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} answered a tool-requiring instruction with prose — flagged (#118); runtime chain falls back on tool-call failure`);
+                      } else if (v.status === VERDICT.TOOL_CALL) {
+                        console.log(`[INIT] Tool-capability probe: ${v.name} → tool call OK${/\(cached\)/.test(v.detail || '') ? ' (cached)' : ''}`);
+                      }
+                    }
+                  }
+                } catch (err) {
+                  console.warn(`[INIT] Tool-capability probe failed: ${err.message}`);
+                }
                 if (sel?.model || modelScorecard) {
                   // The probe lands after the "[INIT] Model resolver:" summary
                   // (always — the probe is async even on a warm cache), so that
                   // line never shows the measured source (#233). Re-log the
-                  // resolver's ground truth after BOTH the probe's override
+                  // resolver's ground truth after BOTH probes' findings
                   // and the scorecard's seat assertion, so the line the
                   // operator reads reflects the final authority
-                  // (golden-set-probe or maturation-loop).
+                  // (golden-set-probe or maturation-loop) plus any #118 flag.
                   const { summary } = modelResolver.describe(['tools', 'thinking', 'quick', 'classification']);
                   console.log(`[INIT] Model resolver (post-probe): ${summary}`);
                 }

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -692,6 +692,28 @@ async function initialize() {
     process.exit(1);
   }
 
+  // 1.0.1. Boot preflight (#87): walk the declared dependency manifest.
+  // Required-and-definitively-absent halts with one remediation line; optional-
+  // and-missing logs once and the feature degrades. Unreachable-required only
+  // warns — a transient hiccup is not a misconfiguration. MOLTAGENT_PREFLIGHT=warn
+  // demotes the halt (deployment escape hatch).
+  try {
+    const { BootPreflight } = require('./src/lib/boot/preflight');
+    const preflight = new BootPreflight({ config: CONFIG, ncRequestManager, logger: console });
+    const { halt } = await preflight.run();
+    if (halt) {
+      if ((process.env.MOLTAGENT_PREFLIGHT || '').toLowerCase() === 'warn') {
+        console.warn('[PREFLIGHT][WARN] required dependency missing but MOLTAGENT_PREFLIGHT=warn — continuing');
+      } else {
+        console.error('[PREFLIGHT][FATAL] required dependency missing — exiting (set MOLTAGENT_PREFLIGHT=warn to demote)');
+        process.exit(1);
+      }
+    }
+  } catch (err) {
+    // The preflight is observability; it must never take a boot down by itself.
+    console.warn(`[PREFLIGHT][WARN] preflight failed to run: ${err.message}`);
+  }
+
   // 1.1. Initialize Talk Send Queue (serializes outbound Talk messages)
   talkQueue = new TalkSendQueue(ncRequestManager);
   console.log('[INIT] Talk Send Queue ready');
@@ -1343,7 +1365,7 @@ async function initialize() {
     const EmbeddingClient = require('./src/lib/memory/embedding-client');
     embeddingClient = new EmbeddingClient({
       ollamaUrl: CONFIG.ollama.url,
-      model: 'nomic-embed-text',
+      model: CONFIG.ollama.embeddingModel,
       logger: console
     });
     console.log('[INIT] EmbeddingClient ready');


### PR DESCRIPTION
Wave 1 of the 2026-07-03 backlog triage: **the boot assertion layer**.

## The generating function

The system asserted nothing about its own composition at startup. Missing constructor clients (#226), missing dependencies (#87), wrong call signatures (#152→#127), and tool-incapable models (#118) all failed silently and surfaced later, downstream, in disguise. One composition contract at boot converts the whole failure category from "discovered in production weeks later" to "loud at boot." Leverage point: what the boot sequence can see about its own composition.

## Drift report

**B2 (#152/#127) needed no code**: PR #155 (`698a4ee`) already conformed `ToolActivator` to the two-arg convention, and `consoleAuditLog` on `next` already carries the never-throw guard (`data === undefined` handling, comment citing #152/#127). The briefing's tally rule was applied to live code: **131 two-arg callers (`auditLog('event', {...})`) vs 0 single-object callers** — the two-arg convention survives, opposite to the issue's filing-time premise. Live evidence below closes the loop.

## What this PR builds

**B1 — #227 (fixes #226):** `ToolRegistry` gains a `TOOL_FAMILIES` manifest (one home): per family, the required clients (mirroring each registrar's early-return gate) and optional ones that degrade visibly. `_registerDefaultTools` walks it — required-and-missing emits `[BOOT][WARN] ToolRegistry: <family> tools SKIPPED — required client '<name>' missing at construction` and skips loudly; present emits one positive `[BOOT]` line with the tool count. Constructor destructure realigned with the call site: `meetingComposer`/`rsvpTracker` now survive into `this.clients` — the #226 dead feature registers again. TC-BOOT-004 kills the class structurally: it parses the live `new ToolRegistry({...})` call in `webhook-server.js` and asserts every passed key survives the destructure, so the next constructor-drop fails in CI, not in production.

**B3 — #87 (+#96 rider):** `BootPreflight` (`src/lib/boot/preflight.js`) walks ONE declared dependency manifest: Nextcloud API, Talk, Deck, Collectives required; Mail, News, Ollama, embedding model, SearXNG, Speaches optional with the degrading feature named. Halt discipline: required + **definitively absent** (capability key absent from a 2xx capabilities document, or the app's own API 404s) → one `[PREFLIGHT][FATAL]` line with the App Store remediation URL, clean exit — no cascade, no retry loop. Required + merely **unreachable** → warn and continue (a transient NC hiccup is not a misconfiguration; halting there would brick healthy installs — the #87 "don't build this on a rushed Friday" clause). `MOLTAGENT_PREFLIGHT=warn` demotes the halt (documented escape hatch). #96 rider: `EmbeddingClient` reads `CONFIG.ollama.embeddingModel` (`EMBEDDING_MODEL`, default `nomic-embed-text`) instead of the hardcoded literal; the preflight probes it against the Ollama tag list and names the `ollama pull` remediation — the systemic home for #96's concern.

**B4 — #118:** `ToolCapabilityProbe` — same probe-and-cache shape as `GoldenSetProbe` (one probing pattern): each local model resolved for a tool-capable job answers one trivial function schema through the production `OllamaToolsProvider` class. Prose → `[BOOT][WARN]` + `⚠not-tool-capable(#118)` in `ModelResolver.describe()`. Transport error = unmeasured: not cached, not flagged (a #124 cold start is not prose). Digest-keyed disk cache keeps warm boots LLM-call-free. Boundary honored: the probe **flags, never reseats** (reseating is the maturation loop's authority; the runtime chain already falls back on tool-call failure), and it runs inside the existing post-golden-set sequence so the single post-probe resolver re-log reflects both measurements — no new #233 race surface (`NOTE(#233)` marker at the site).

## Layer 1

`npm run test:unit`: **230/230 test files** on this branch, including new suites:
- `tool-registry-boot-contract.test.js` — TC-BOOT-001..005 (missing-required warning + family absence; full-set 74+ tools incl. `meeting_compose`/`meeting_check_rsvp`; manifest↔prototype alignment; construction-site parity; optional-degrade visibility)
- `boot/preflight.test.js` — TC-PF-001..007 (full-OK; definitive-absence halt with remediation URL; unreachable-never-halts; Collectives-404 halt; optional degrade; not-configured; embedding-model-missing with pull hint)
- `llm/tool-capability-probe.test.js` — TC-TCP-001..006 (pass; prose; wrong-function; error-not-cached; digest-cache warm path; missing-chatFn skip)

## Layer 2 (live on the reference deployment, 2026-07-03)

**B3 preflight against the real NC + Ollama + endpoints** (the new module, read-only probes, unit env values):

```
[PREFLIGHT] Nextcloud API: OK (capabilities answered)
[PREFLIGHT] NC Talk: OK (reachable, app enabled)
[PREFLIGHT] NC Deck: OK (reachable, app enabled)
[PREFLIGHT] NC Collectives: OK (reachable, app enabled)
[PREFLIGHT] NC Mail: OK (reachable, app enabled)
[PREFLIGHT] NC News: OK (reachable, app enabled)
[PREFLIGHT] Ollama: OK (reachable)
[PREFLIGHT] Embedding model (nomic-embed-text): OK (pulled on Ollama host)
[PREFLIGHT] SearXNG: OK (HTTP 200)
[PREFLIGHT] Speaches STT/TTS: OK (HTTP 200)
halt=false
```

**B4 probe against the real Ollama host** (production provider class, live generations):

```
qwen3:8b: tool-call — tool call produced
qwen2.5:3b: tool-call — tool call produced
```

**B2/#127 free-close evidence:** today's boot journal on the reference deployment shows **zero** `SkillForge discovery errors` lines; `brave-search` and `google-calendar` auto-activate (`[INIT] SkillForge auto-activated: brave-search, google-calendar`); `[AUDIT]` lines render real payloads throughout (e.g. `credential_fetched: {"name":"claude-api-key"}`).

**#26 re-baseline:** 24h window = **24 error/warn lines vs the 830/day April baseline**; full breakdown posted on #26 (16× #126 divergence warning, 8× audit-logger fallback line — one per boot). #25 superseded-comment and #39 disposition-comment posted per the briefing's closing checklist.

**Deferred to post-merge deployment** (this session could not restart the shared production service — the parallel WikiSteward workstream holds the checkout, per HANDOFF discipline): the B1 positive `[BOOT] ToolRegistry: meeting tools registered` line, the in-boot preflight table, and a `meeting_compose` Talk exercise for #226's final close. The module-level Layer 2 above ran the identical code paths against the identical live endpoints.

## Free-close ledger

- **#226** — closes on B1 (constructor realignment + TC-BOOT-002/004); final confirmation = post-merge boot line + a `meeting_compose` Talk exercise.
- **#127** — closes on the zero-discovery-error boot evidence above (fix itself landed in #153/#155).
- **#152** — evidence captured; respecting the standing hold, left for merge authority.
- **#25 / #39** — superseded/disposition comments posted; merge authority closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
