### PR TITLE
fix: Wave 1 post-merge — preflight reads appConfig; meeting_check_rsvp uses real tracker API

### DIFF
--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -2442,16 +2442,20 @@ class ToolRegistry {
           const rsvpTracker = this.clients.rsvpTracker;
           if (!rsvpTracker) return 'RSVP tracking is not available.';
 
-          const status = rsvpTracker.getStatus();
-          if (!status || status.length === 0) return 'No meetings are currently being tracked for RSVPs.';
+          // getStatus() is keyed by UID; resolve the title against the
+          // pending summary first, then fetch that event's attendee detail.
+          const pending = rsvpTracker.getPendingSummary();
+          if (!pending || pending.length === 0) return 'No meetings are currently being tracked for RSVPs.';
 
-          // Find matching tracked event
           const lower = args.meeting_title.toLowerCase();
-          const match = status.find(e =>
+          const found = pending.find(e =>
             e.summary && e.summary.toLowerCase().includes(lower)
           );
 
-          if (!match) return `No tracked meeting found matching "${args.meeting_title}".`;
+          if (!found) return `No tracked meeting found matching "${args.meeting_title}".`;
+
+          const match = rsvpTracker.getStatus(found.uid);
+          if (!match.found) return `No tracked meeting found matching "${args.meeting_title}".`;
 
           const lines = match.attendees.map(a => {
             const icon = a.lastStatus === 'ACCEPTED' ? '✅' :

--- a/test/unit/agent/meeting-check-rsvp-handler.test.js
+++ b/test/unit/agent/meeting-check-rsvp-handler.test.js
@@ -1,0 +1,101 @@
+/*
+ * Moltagent - Sovereign AI Security Layer
+ * Copyright (C) 2026 Moltagent Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * meeting_check_rsvp Handler Tests
+ *
+ * The handler was dead code until #226/#227 made the meeting family
+ * registrable, and its first live dispatch crashed: it called
+ * rsvpTracker.getStatus() bare and expected an array, but the real API is
+ * getPendingSummary() -> Array and getStatus(uid) -> single-event object.
+ * These tests exercise the handler through ToolRegistry.execute() against
+ * a stub that mirrors the REAL RsvpTracker return shapes, so any future
+ * drift between handler and tracker API fails here instead of in Talk.
+ *
+ * Run: node test/unit/agent/meeting-check-rsvp-handler.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const { ToolRegistry } = require('../../../src/lib/agent/tool-registry');
+
+console.log('\n=== meeting_check_rsvp Handler Tests ===\n');
+
+/** Truthy mock client: any property access yields a callable no-op. */
+function mockClient() {
+  return new Proxy({}, { get: () => () => {} });
+}
+
+const quietLogger = { info: () => {}, warn: () => {}, error: () => {}, log: () => {} };
+
+/** Stub mirroring RsvpTracker's actual public API shapes. */
+function stubTracker(events) {
+  return {
+    getPendingSummary: () => events.map(e => ({
+      uid: e.uid,
+      summary: e.summary,
+      pending: 0, accepted: 0, declined: 0, tentative: 0,
+    })),
+    getStatus: (uid) => {
+      const e = events.find(ev => ev.uid === uid);
+      if (!e) return { found: false };
+      return {
+        found: true,
+        summary: e.summary,
+        attendees: e.attendees,
+        allResponded: e.attendees.every(a => a.lastStatus !== 'NEEDS-ACTION'),
+      };
+    },
+  };
+}
+
+function buildRegistry(rsvpTracker) {
+  return new ToolRegistry({
+    meetingComposer: mockClient(),
+    rsvpTracker,
+    logger: quietLogger,
+  });
+}
+
+const TEAM_SYNC = {
+  uid: 'uid-team-sync',
+  summary: 'Team Sync Q3',
+  attendees: [
+    { name: 'Alice', email: 'alice@example.org', lastStatus: 'ACCEPTED' },
+    { name: 'Bob', email: 'bob@example.org', lastStatus: 'NEEDS-ACTION' },
+  ],
+};
+
+asyncTest('TC-RSVP-001: no tracked meetings → informative empty answer', async () => {
+  const registry = buildRegistry(stubTracker([]));
+  const out = await registry.execute('meeting_check_rsvp', { meeting_title: 'Team Sync' });
+  assert.strictEqual(out.success, true);
+  assert.ok(/No meetings are currently being tracked/.test(out.result), out.result);
+});
+
+asyncTest('TC-RSVP-002: case-insensitive title substring resolves to attendee detail', async () => {
+  const registry = buildRegistry(stubTracker([TEAM_SYNC]));
+  const out = await registry.execute('meeting_check_rsvp', { meeting_title: 'team sync' });
+  assert.strictEqual(out.success, true);
+  assert.ok(out.result.includes('Team Sync Q3'), out.result);
+  assert.ok(out.result.includes('Alice') && out.result.includes('ACCEPTED'), out.result);
+  assert.ok(out.result.includes('Bob') && out.result.includes('NEEDS-ACTION'), out.result);
+});
+
+asyncTest('TC-RSVP-003: unmatched title → not-found answer, no throw', async () => {
+  const registry = buildRegistry(stubTracker([TEAM_SYNC]));
+  const out = await registry.execute('meeting_check_rsvp', { meeting_title: 'Budget Review' });
+  assert.strictEqual(out.success, true);
+  assert.ok(/No tracked meeting found matching "Budget Review"/.test(out.result), out.result);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -699,7 +699,9 @@ async function initialize() {
   // demotes the halt (deployment escape hatch).
   try {
     const { BootPreflight } = require('./src/lib/boot/preflight');
-    const preflight = new BootPreflight({ config: CONFIG, ncRequestManager, logger: console });
+    // appConfig, not the local CONFIG view: the manifest reads voice.speachesUrl,
+    // search.searxng.url, and ollama.embeddingModel, which only appConfig carries.
+    const preflight = new BootPreflight({ config: appConfig, ncRequestManager, logger: console });
     const { halt } = await preflight.run();
     if (halt) {
       if ((process.env.MOLTAGENT_PREFLIGHT || '').toLowerCase() === 'warn') {


### PR DESCRIPTION
Two small fixes found by the Wave 1 post-merge live verification on the first deployed boot (#247 follow-up).

## 1. Preflight reads `appConfig`, not the narrow `CONFIG` view

`BootPreflight`'s manifest reads `voice.speachesUrl`, `search.searxng.url`, and `ollama.embeddingModel` — keys that exist only on `appConfig` (`src/lib/config.js`; the `embeddingModel` comment there explicitly names the preflight manifest as a reader). The construction site passed webhook-server's local `CONFIG` object instead, which carries none of those keys, so all three optional probes reported "not configured" regardless of the environment.

Same class as #226: a module's documented contract broken at the construction site. One-line rewire.

**Live false negative on the first deployed boot:**

```
[PREFLIGHT] Speaches STT/TTS: OPTIONAL, not configured (SPEACHES_URL / WHISPER_URL) — voice disabled this boot
...8 seconds later, same env...
[INIT] VoiceManager ready (Speaches: [VOICE_HOST]:8014)
```

Note: after this fix the embedding-model probe will actually probe (appConfig defaults `EMBEDDING_MODEL` to `nomic-embed-text`), so the preflight table gains a real OK/MISSING line for it on the next boot.

## 2. `meeting_check_rsvp` composes the real RsvpTracker API

The handler called `rsvpTracker.getStatus()` bare and expected an array of tracked events; the tracker's actual API is `getPendingSummary() → Array` and `getStatus(uid) → one event's detail`. This was dead code until #226/#227 made the meeting family registrable — the first live Talk dispatch ever crashed:

```
[AgentLoop] Tool call: meeting_check_rsvp({"meeting_title":"Team Sync"})
[meeting_check_rsvp] status.find is not a function
[ToolRegistry] Tool meeting_check_rsvp returned a failure string (migration seam #70): Failed to check RSVPs: status.find is not a function
```

(The #70 seam framed it honestly; the user got a clean failure line, not a hang.)

Handler now resolves the title against `getPendingSummary()` and fetches attendee detail via `getStatus(uid)`. New handler-level tests (`test/unit/agent/meeting-check-rsvp-handler.test.js`) pin the real tracker shapes so handler/API drift fails in CI, not in Talk. `meeting_compose` was checked against `MeetingComposer.process(message, userId, conversationToken)` — its handler matches; no change needed.

## Wave 1 post-merge evidence (the #247 follow-up this sweep was for)

Captured on the first deployed boot (service on `next` @ `8ea25da`):

- **B1 boot lines**: per-family `[BOOT] ToolRegistry: <family> tools registered (…)` for all 12 families, including `meeting tools registered (2 tools; meetingComposer present)` — 74 tools total. **This closes #226's remaining evidence gap**: the family registers AND dispatches (see the live `Tool call: meeting_check_rsvp` line above — reached end-to-end from a forged Talk webhook, DE message, gate=action/domain=calendar).
- **Preflight table**: all required deps OK (NC API/Talk/Deck/Collectives/Mail/News, Ollama); optionals correctly degrade — modulo the false negative fixed here.
- **ToolCapabilityProbe**: live and correctly refusing to cache an errored probe (`gemma2:2b: probe errored … not caching, will retry next boot`).

## Tests

- `test/unit/boot/preflight.test.js` 7/7
- `test/unit/agent/meeting-check-rsvp-handler.test.js` 3/3 (new)
- `test/unit/agent/tool-registry-boot-contract.test.js` 5/5, `tool-subset-derivation.test.js` 6/6
- `npm run lint`: 0 errors

`[VERIFIED: meeting_check_rsvp dispatched end-to-end from a forged Talk webhook on the first deployed Wave-1 boot; handler crash reproduced live, fix pinned by handler-level tests. Preflight false negative reproduced live against [VOICE_HOST] voice env; rewired ctor site verified by preflight unit suite. Hosts as placeholders per privacy pass.]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
