### PR TITLE
feat(llm): cloud chain ordering from judged evidence — quality veto on the cost anchor (#237)

### DIFF
--- a/src/lib/llm/local-judge.js
+++ b/src/lib/llm/local-judge.js
@@ -356,7 +356,12 @@ class LocalJudge {
         if (!cand || !cand.model || typeof cand.chat !== 'function') continue;
         for (const lang of this._fixtureLanguages(job)) {
           if (budget <= 0) return;
-          if (this._cellMass(job, cand.model, lang) >= this.coldMassFloor) continue;
+          // #237 re-audition: a demoted pairing whose cool-off elapsed is
+          // probe-eligible despite warmth — one probe per fixture language
+          // per cool-off period; everything downstream (quota, trust gate,
+          // budget gate, cost recording) is untouched.
+          if (this._cellMass(job, cand.model, lang) >= this.coldMassFloor
+            && !this._isRecheckDue(job, cand.model, lang)) continue;
           const gate = this.budgetEnforcer.canSpendProactive(this.cloudProbeCostEstimate);
           if (!gate || !gate.allowed) {
             this.logger.info('[LocalJudge] Proactive budget exhausted — synthetic cloud probes halted');
@@ -466,6 +471,21 @@ class LocalJudge {
       return this.gapFloor;
     }
     return Math.min(1, Math.max(this.gapFloor, judgeSize / judgedSize));
+  }
+
+  /**
+   * @private #237: whether the scorecard says a demoted (job, model,
+   * language) pairing is due its re-audition probe. Null-safe: a scorecard
+   * without demotion support (or a throwing one) means no recheck, never a
+   * broken probe pass.
+   */
+  _isRecheckDue(job, model, lang) {
+    try {
+      return typeof this.scorecard?.isRecheckDue === 'function'
+        && !!this.scorecard.isRecheckDue(job, model, lang);
+    } catch (_err) {
+      return false;
+    }
   }
 
   /** @private Evidential mass of a (job, model, language) cell — its confidence. */

--- a/src/lib/llm/model-scorecard.js
+++ b/src/lib/llm/model-scorecard.js
@@ -28,6 +28,11 @@
  *   under-sampled pairings, which is how a demoted model earns retries; for
  *   destructive jobs (tools) the bonus is gated by a floor so exploration
  *   never hands a job with side effects to a model with a failing record.
+ *   One selection mechanism spans local and cloud (#237): the local slot
+ *   learns through seats, the cloud chains learn through DEMOTIONS — a
+ *   quality veto the router reads via isDemoted() when it builds cloud
+ *   chains, with its own hysteresis band and escalating re-audition
+ *   cool-off (isRecheckDue(), consumed by LocalJudge's cold-cell gate).
  *
  * Data Flow:
  *   AgentLoop / MicroPipeline / RouterChatBridge / IntentRouter /
@@ -87,6 +92,28 @@ const DEFAULT_EXPLORATION_FLOOR = 0.5;
 // decision; tools creates cards, sends mail, writes files.
 const DEFAULT_DESTRUCTIVE_JOBS = ['tools'];
 
+// --- Cloud demotion (#237): a quality veto on the cost anchor -------------
+// A model with PROVEN quality problems for a job loses its claim to its
+// cost position in the cloud chain. The trigger requires one full
+// fixture-quantum of evidential mass in a single failing language cell —
+// the same weight the entire install-time golden-set measurement carries
+// per language — so a cell that merely stopped attracting probes can never
+// trigger a demotion. The band around the destructive floor is two margins
+// wide (demote below floor−margin, reinstate at floor+margin), twice the
+// seat's one-sided margin: cloud evidence is sparser and noisier, so the
+// veto moves later and releases later (#232 discipline, cloud regime).
+const DEFAULT_DEMOTION_MASS_FLOOR = 12;
+
+// Escalating re-audition cool-off: recheck after 7d × 2^(strikes−1),
+// capped at 56d. A failed recheck is confirmation, not a new offense — the
+// per-language recheck cadence simply restarts at the same period.
+const DEMOTION_RECHECK_BASE_MS = 7 * 24 * 60 * 60 * 1000;
+const DEMOTION_RECHECK_CAP_MS = 56 * 24 * 60 * 60 * 1000;
+
+// A re-demotion within this window of a reinstatement is a consecutive
+// failure and escalates strikes; a later one starts over at 1.
+const DEMOTION_STRIKE_MEMORY_MS = 14 * 24 * 60 * 60 * 1000;
+
 class ModelScorecard {
   /**
    * @param {Object} [opts]
@@ -113,6 +140,8 @@ class ModelScorecard {
    * @param {number} [opts.explorationFloor] - Minimum mean for the bonus on
    *   destructive jobs.
    * @param {string[]} [opts.destructiveJobs]
+   * @param {number} [opts.demotionMassFloor] - Evidential mass a single
+   *   language cell must carry before it can trigger a cloud demotion (#237).
    * @param {Object} [opts.logger=console]
    */
   constructor({
@@ -126,6 +155,7 @@ class ModelScorecard {
     escalationWeight = DEFAULT_ESCALATION_WEIGHT,
     explorationFloor = DEFAULT_EXPLORATION_FLOOR,
     destructiveJobs = DEFAULT_DESTRUCTIVE_JOBS,
+    demotionMassFloor = DEFAULT_DEMOTION_MASS_FLOOR,
     logger,
   } = {}) {
     this.dataDir = dataDir === null ? null : (dataDir || path.resolve(process.cwd(), 'data'));
@@ -140,7 +170,14 @@ class ModelScorecard {
       ? escalationWeight : DEFAULT_ESCALATION_WEIGHT;
     this.explorationFloor = Number.isFinite(explorationFloor) ? explorationFloor : DEFAULT_EXPLORATION_FLOOR;
     this.destructiveJobs = new Set(Array.isArray(destructiveJobs) ? destructiveJobs : DEFAULT_DESTRUCTIVE_JOBS);
+    this.demotionMassFloor = Number.isFinite(demotionMassFloor) && demotionMassFloor > 0
+      ? demotionMassFloor : DEFAULT_DEMOTION_MASS_FLOOR;
     this.logger = logger || console;
+
+    // #237 bridge: fired when a (job, model) demotion forms or lifts, so
+    // the router can rebuild the active preset roster in place. Assigned
+    // post-construction (the costTracker pattern) — see webhook-server.
+    this.onCloudDemotionChange = null;
 
     this._saveTimer = null;
     this._state = this._load();
@@ -167,7 +204,7 @@ class ModelScorecard {
    *   but does not count as production evidence, so it adds no UCB
    *   optimism — the same discipline as the golden-set seed, whose fixture
    *   numbers must never supply exploration bonus against real traffic.
-   * @returns {{recorded: boolean, seatChanged: boolean}}
+   * @returns {{recorded: boolean, seatChanged: boolean, demotionChanged: boolean}}
    */
   recordSample(job, model, language, success, { weight = 1, synthetic = false } = {}) {
     if (typeof job !== 'string' || !job || typeof model !== 'string' || !model) {
@@ -194,12 +231,17 @@ class ModelScorecard {
     }
 
     const seatChanged = this._evaluate(job);
-    // A seat change repoints live routing — persist immediately. Plain
-    // samples are statistics; they coalesce into a debounced write so the
-    // hot path never pays a synchronous disk write per LLM call.
-    if (seatChanged) this._persistNow();
+    const demotionChanged = this._evaluateCloudDemotions(job);
+    // A recheck-due sample (organic or probe) counts as that language's
+    // re-audition for this cool-off period, whether it passed or failed.
+    this._noteRecheckSample(job, model, lang);
+    // A seat or demotion change repoints live routing — persist
+    // immediately. Plain samples are statistics; they coalesce into a
+    // debounced write so the hot path never pays a synchronous disk write
+    // per LLM call.
+    if (seatChanged || demotionChanged) this._persistNow();
     else this._scheduleSave();
-    return { recorded: true, seatChanged };
+    return { recorded: true, seatChanged, demotionChanged };
   }
 
   /**
@@ -304,6 +346,54 @@ class ModelScorecard {
    */
   getPairings(job) {
     return this._state.jobs[job] || {};
+  }
+
+  /**
+   * #237: whether a (job, model) pairing carries an ACTIVE cloud demotion.
+   * The only consumer that acts on this is the router's cloud chain
+   * building — the flag is computed for any model meeting the condition,
+   * and an uninstalled or local name in the table is inert.
+   * @param {string} job
+   * @param {string} model - Model NAME (the scorecard's key), not a
+   *   provider ID; the router translates at its filter site.
+   * @returns {boolean}
+   */
+  isDemoted(job, model) {
+    const rec = this._demotionRecord(job, model);
+    return !!(rec && rec.at);
+  }
+
+  /**
+   * #237 re-audition: whether a demoted (job, model) pairing's cool-off has
+   * elapsed and the given language has not yet had its re-check sample this
+   * period. The judge's cold-cell chokepoint consults this to make warm
+   * cells probe-eligible again — one probe per fixture language per
+   * cool-off period, nothing more.
+   * @param {string} job
+   * @param {string} model
+   * @param {string} [language] - Omitted: true when ANY re-check is due.
+   * @returns {boolean}
+   */
+  isRecheckDue(job, model, language) {
+    const rec = this._demotionRecord(job, model);
+    if (!rec || !rec.at || !rec.recheckAt) return false;
+    const recheckAt = Date.parse(rec.recheckAt);
+    if (!Number.isFinite(recheckAt) || Date.now() < recheckAt) return false;
+    if (typeof language !== 'string' || !language) return true;
+    const stamp = rec.rechecked?.[language.toUpperCase()];
+    const last = stamp ? Date.parse(stamp) : NaN;
+    if (!Number.isFinite(last)) return true;
+    return Date.now() - last >= this._recheckPeriodMs(rec.strikes);
+  }
+
+  /**
+   * Observability (#237): the raw demotion table —
+   * job → model → { at, recheckAt, strikes, trigger, rechecked } for active
+   * demotions, { reinstatedAt, strikes } for reinstated strike memory.
+   * @returns {Object}
+   */
+  getCloudDemotions() {
+    return JSON.parse(JSON.stringify(this._state.cloudDemotions || {}));
   }
 
   // ---------------------------------------------------------------------------
@@ -430,9 +520,145 @@ class ModelScorecard {
     return true;
   }
 
+  /**
+   * @private
+   * #237: re-evaluate every model's cloud-demotion state for a job. Called
+   * from recordSample beside _evaluate, and idempotent: only a boundary
+   * crossing (demote or reinstate) changes anything; inside the dead band
+   * the incumbent state — demoted or not — holds.
+   *
+   * Demote: ∃ measured language cell with mass ≥ demotionMassFloor AND
+   * posterior mean < explorationFloor − margin. Min-language semantics,
+   * same as seats, restricted to cells that actually carry the mass floor
+   * so an empty PT cell can neither trigger nor block.
+   *
+   * Reinstate: every qualifying cell (mass ≥ floor) has
+   * mean ≥ explorationFloor + margin — and at least one such cell exists
+   * (no evidence is not evidence of recovery).
+   *
+   * @returns {boolean} whether any demotion formed or lifted
+   */
+  _evaluateCloudDemotions(job) {
+    const names = new Set([
+      ...Object.keys(this._state.jobs[job] || {}),
+      ...Object.keys(this._state.cloudDemotions[job] || {}),
+    ]);
+    let changed = false;
+    for (const model of names) {
+      if (this._evaluateModelDemotion(job, model)) changed = true;
+    }
+    return changed;
+  }
+
+  /** @private One model's demote/reinstate decision. See _evaluateCloudDemotions. */
+  _evaluateModelDemotion(job, model) {
+    const demoteBar = this.explorationFloor - this.margin;
+    const reinstateBar = this.explorationFloor + this.margin;
+
+    const qualifying = [];
+    for (const [lang, entry] of Object.entries(this._state.jobs[job]?.[model] || {})) {
+      const mass = (entry.a || 0) + (entry.b || 0);
+      if (!Number.isFinite(mass) || mass < this.demotionMassFloor) continue;
+      const mean = (entry.a || 0) / mass;
+      if (!Number.isFinite(mean)) continue; // corrupt cell: neither triggers nor blocks
+      qualifying.push({ lang, mass, mean });
+    }
+
+    const rec = this._demotionRecord(job, model);
+    const active = !!(rec && rec.at);
+
+    if (!active) {
+      let worst = null;
+      for (const q of qualifying) {
+        if (q.mean < demoteBar && (!worst || q.mean < worst.mean)) worst = q;
+      }
+      if (!worst) return false;
+      const now = Date.now();
+      // Consecutive-failure memory: a re-demotion shortly after a
+      // reinstatement escalates the cool-off; a distant one starts over.
+      const reinstatedAt = rec?.reinstatedAt ? Date.parse(rec.reinstatedAt) : NaN;
+      const strikes = Number.isFinite(reinstatedAt) && (now - reinstatedAt) < DEMOTION_STRIKE_MEMORY_MS
+        ? (rec.strikes || 0) + 1 : 1;
+      this._demotionSlot(job)[model] = {
+        at: new Date(now).toISOString(),
+        recheckAt: new Date(now + this._recheckPeriodMs(strikes)).toISOString(),
+        strikes,
+        trigger: {
+          lang: worst.lang,
+          mean: Number(worst.mean.toFixed(3)),
+          mass: Number(worst.mass.toFixed(1)),
+        },
+        rechecked: {},
+      };
+      this.logger.info(
+        `[ModelScorecard] Cloud demotion: ${job}/${model} ` +
+        `(trigger ${worst.lang} mean ${worst.mean.toFixed(3)} mass ${worst.mass.toFixed(1)}, ` +
+        `strikes ${strikes}, recheck ${this._demotionSlot(job)[model].recheckAt})`
+      );
+      this._fireCloudDemotionChange(job, model);
+      return true;
+    }
+
+    if (qualifying.length === 0) return false;
+    if (!qualifying.every(q => q.mean >= reinstateBar)) return false;
+    this._demotionSlot(job)[model] = {
+      reinstatedAt: new Date().toISOString(),
+      strikes: rec.strikes || 1,
+    };
+    this.logger.info(
+      `[ModelScorecard] Cloud reinstatement: ${job}/${model} ` +
+      `(every measured cell ≥ ${reinstateBar.toFixed(3)}, strikes memory ${rec.strikes || 1})`
+    );
+    this._fireCloudDemotionChange(job, model);
+    return true;
+  }
+
+  /**
+   * @private Stamp a recheck-due language as re-audited this period. Runs
+   * AFTER _evaluateCloudDemotions: if the sample just reinstated the model,
+   * the active record is gone and this is a no-op.
+   */
+  _noteRecheckSample(job, model, lang) {
+    if (!this.isRecheckDue(job, model, lang)) return;
+    const rec = this._demotionRecord(job, model);
+    if (!rec.rechecked || typeof rec.rechecked !== 'object') rec.rechecked = {};
+    rec.rechecked[lang] = new Date().toISOString();
+  }
+
+  /** @private */
+  _demotionRecord(job, model) {
+    if (typeof job !== 'string' || !job || typeof model !== 'string' || !model) return null;
+    const own = (obj, key) => !!obj && Object.prototype.hasOwnProperty.call(obj, key);
+    const jobs = this._state.cloudDemotions;
+    return own(jobs, job) && own(jobs[job], model) ? jobs[job][model] : null;
+  }
+
+  /** @private Get-or-create the demotion map for a job (proto-safe, as _entry). */
+  _demotionSlot(job) {
+    const jobs = this._state.cloudDemotions;
+    if (!Object.prototype.hasOwnProperty.call(jobs, job)) jobs[job] = Object.create(null);
+    return jobs[job];
+  }
+
+  /** @private 7d × 2^(strikes−1), capped at 56d. */
+  _recheckPeriodMs(strikes) {
+    const s = Number.isFinite(strikes) && strikes >= 1 ? strikes : 1;
+    return Math.min(DEMOTION_RECHECK_BASE_MS * 2 ** (s - 1), DEMOTION_RECHECK_CAP_MS);
+  }
+
+  /** @private */
+  _fireCloudDemotionChange(job, model) {
+    if (typeof this.onCloudDemotionChange !== 'function') return;
+    try {
+      this.onCloudDemotionChange(job, model);
+    } catch (err) {
+      this.logger.warn(`[ModelScorecard] onCloudDemotionChange failed for ${job}/${model}: ${err.message}`);
+    }
+  }
+
   /** @private */
   _load() {
-    const fresh = { version: 1, jobs: {}, seats: {} };
+    const fresh = { version: 1, jobs: {}, seats: {}, cloudDemotions: {} };
     if (!this._storeFile) return fresh;
     try {
       const raw = fs.readFileSync(this._storeFile, 'utf8');
@@ -442,6 +668,8 @@ class ModelScorecard {
           version: 1,
           jobs: (parsed.jobs && typeof parsed.jobs === 'object') ? parsed.jobs : {},
           seats: (parsed.seats && typeof parsed.seats === 'object') ? parsed.seats : {},
+          cloudDemotions: (parsed.cloudDemotions && typeof parsed.cloudDemotions === 'object')
+            ? parsed.cloudDemotions : {},
         };
       }
     } catch (_err) {

--- a/src/lib/llm/router.js
+++ b/src/lib/llm/router.js
@@ -123,6 +123,13 @@ class LLMRouter {
     // CostTracker (optional, set post-construction)
     this.costTracker = null;
 
+    // #237: cloud quality veto (optional, set post-construction via
+    // setCloudQualityCheck — the costTracker pattern). (job, modelName) =>
+    // boolean; true sinks that model below all healthy peers in the job's
+    // cloud chain. Quality truth lives in ModelScorecard; the router only
+    // reads the verdict at its ONE generating function.
+    this._cloudQualityCheck = null;
+
     // JudgeQueue + language snapshot (optional, set post-construction —
     // Session 4). route() is the second LLM egress beside
     // RouterChatBridge.chat (the Talk thinking path routes here directly),
@@ -806,15 +813,51 @@ class LLMRouter {
    * @returns {Object} job → cloud-only provider-ID chain (local appended by caller)
    */
   _buildCloudJobChains(cloudIds, opts = {}) {
-    const textTiers = this._costTiers(this._eligibleCloudIds(cloudIds, isTextGeneration));
-    const toolTiers = this._costTiers(this._eligibleCloudIds(cloudIds, isToolCapable));
+    // Eligible sets computed ONCE (unknown-capability models log at most once).
+    const textEligible = this._eligibleCloudIds(cloudIds, isTextGeneration);
+    const toolEligible = this._eligibleCloudIds(cloudIds, isToolCapable);
     const out = {};
     for (const job of VALID_JOBS) {
       if (job === JOBS.CREDENTIALS) continue; // local-only, handled by caller
-      const tiers = (job === JOBS.TOOLS || job === JOBS.CODING) ? toolTiers : textTiers;
-      out[job] = this._cloudDepthChain(job, tiers, opts);
+      const eligible = (job === JOBS.TOOLS || job === JOBS.CODING) ? toolEligible : textEligible;
+      // #237 quality veto on the cost anchor, applied UPSTREAM of the depth
+      // policy: a demoted model loses its claim to its cost position, so for
+      // a 'cheapest' job the cheapest HEALTHY model becomes the leader; the
+      // demoted entries re-enter at the tail in their original cost order
+      // (reorder, never eliminate — tail service still earns them organic
+      // evidence toward reinstatement). Healthy models never swap on
+      // quality: ordering among them stays pure cost rank. With every
+      // eligible model demoted the healthy chain is empty and the emitted
+      // chain is exactly the un-vetoed one (never-go-dark).
+      const healthy = eligible.filter(id => !this._isDemotedId(job, id));
+      const chainMain = this._cloudDepthChain(job, this._costTiers(healthy), opts);
+      const chainAll = this._cloudDepthChain(job, this._costTiers(eligible), opts);
+      out[job] = [...new Set([...chainMain, ...chainAll])];
     }
     return out;
+  }
+
+  /**
+   * #237: whether a cloud provider's MODEL is demoted for a job. The
+   * scorecard keys on model names; the router filters provider IDs — the
+   * translation happens here, at the filter site, via the same
+   * providers.get(id).model lookup _cloudCapabilitiesOf performs. No check
+   * wired, no model name, or a throwing check all mean "healthy": a
+   * scorecard fault must never break chain building (fail-open).
+   * @private
+   * @param {string} job
+   * @param {string} id - Provider ID
+   * @returns {boolean}
+   */
+  _isDemotedId(job, id) {
+    if (typeof this._cloudQualityCheck !== 'function') return false;
+    const model = this.providers.get(id)?.model;
+    if (!model) return false;
+    try {
+      return !!this._cloudQualityCheck(job, model);
+    } catch (_err) {
+      return false;
+    }
   }
 
   /**
@@ -1085,7 +1128,8 @@ class LLMRouter {
       outputVerifier: this.outputVerifier.getStats(),
       roster: this.getRoster(),
       activePreset: this._activePreset,
-      routingMode: this._roster ? 'roster' : 'legacy'
+      routingMode: this._roster ? 'roster' : 'legacy',
+      cloudDemotions: this._describeCloudDemotions()
     };
   }
 
@@ -1156,6 +1200,76 @@ class LLMRouter {
         console.log(`[LLMRouter] Cloud capability classes (${presetName}): ${summary}`);
       }
     }
+  }
+
+  /**
+   * #237: wire the cloud quality veto (post-construction, the costTracker
+   * pattern). Production passes `(job, model) => scorecard.isDemoted(job,
+   * model)`. Takes effect on the next chain build; call
+   * refreshCloudOrdering() to rebuild an active preset roster immediately.
+   * @param {Function|null} fn - (job, modelName) => boolean
+   */
+  setCloudQualityCheck(fn) {
+    this._cloudQualityCheck = typeof fn === 'function' ? fn : null;
+  }
+
+  /**
+   * #237: re-resolve the active preset roster in place so demotion changes
+   * reach live routing. A custom roster (setRoster) is deliberately EXEMPT —
+   * deployer-explicit chains are human intent, the same exemption cockpit
+   * pins enjoy in NicheAssignment. Per-call allowCloud chains are built
+   * fresh per call and inherit the veto automatically.
+   * @param {string} [job] - The job whose demotion state changed (log context).
+   * @param {string} [model] - The model whose demotion state changed. When
+   *   given and NO cloud provider serves that model, the rebuild is skipped:
+   *   the scorecard computes demotions for any model meeting the condition
+   *   (local names included), but only cloud-served names can move a chain.
+   * @returns {boolean} whether a preset roster was rebuilt
+   */
+  refreshCloudOrdering(job, model) {
+    if (!this._activePreset || !this._roster) return false;
+    if (typeof model === 'string' && model) {
+      let cloudServed = false;
+      for (const [, provider] of this.providers) {
+        if (provider.type !== 'local' && provider.model === model) {
+          cloudServed = true;
+          break;
+        }
+      }
+      if (!cloudServed) return false;
+    }
+    this._roster = this._resolvePreset(this._activePreset);
+    const demoted = this._describeCloudDemotions();
+    const summary = Object.entries(demoted)
+      .map(([demotedJob, entries]) => `${demotedJob}=[${entries.map(e => e.id).join(',')}]`)
+      .join(' ');
+    console.log(
+      `[LLMRouter] Cloud ordering refreshed (preset ${this._activePreset}): ` +
+      (summary ? `demoted to tail ${summary}` : 'no active demotions')
+    );
+    return true;
+  }
+
+  /**
+   * #237 observability: per job, the cloud providers the quality veto is
+   * currently sinking to the tail. Detail (trigger, strikes, recheck) lives
+   * in ModelScorecard.getCloudDemotions() — quality truth keeps custody.
+   * @private
+   * @returns {Object<string, Array<{id: string, model: string|null}>>}
+   */
+  _describeCloudDemotions() {
+    const out = {};
+    if (typeof this._cloudQualityCheck !== 'function') return out;
+    for (const job of VALID_JOBS) {
+      if (job === JOBS.CREDENTIALS) continue;
+      const demoted = [];
+      for (const [id, provider] of this.providers) {
+        if (provider.type === 'local') continue;
+        if (this._isDemotedId(job, id)) demoted.push({ id, model: provider.model || null });
+      }
+      if (demoted.length > 0) out[job] = demoted;
+    }
+    return out;
   }
 
   /**

--- a/test/unit/llm/cloud-demotion.test.js
+++ b/test/unit/llm/cloud-demotion.test.js
@@ -1,0 +1,447 @@
+/**
+ * Cloud Chain Ordering from Judged Evidence (#237)
+ *
+ * The quality veto on the cost anchor: a cloud model with PROVEN quality
+ * problems for a job (one fixture-quantum of mass in a failing language
+ * cell, mean below the band) sinks below all healthy peers in that job's
+ * cloud chain and re-enters as tail fallback. Covers the ModelScorecard
+ * demotion state (band, mass floor, strikes, recheck cadence,
+ * persistence), the router's healthy/all partition upstream of the depth
+ * policy (tail re-entry, never-go-dark, custom-roster exemption), the
+ * scorecard↔router bridge, and LocalJudge's re-audition through the
+ * cold-cell chokepoint (budget gate untouched).
+ *
+ * Run: node test/unit/llm/cloud-demotion.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const ModelScorecard = require('../../../src/lib/llm/model-scorecard');
+const LLMRouter = require('../../../src/lib/llm/router');
+const LocalJudge = require('../../../src/lib/llm/local-judge');
+const JudgeQueue = require('../../../src/lib/llm/judge-queue');
+
+const silentLogger = { warn: () => {}, log: () => {}, info: () => {} };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeScorecard(opts = {}) {
+  return new ModelScorecard({ dataDir: null, logger: silentLogger, ...opts });
+}
+
+function fails(sc, job, model, lang, n) {
+  for (let i = 0; i < n; i++) sc.recordSample(job, model, lang, false);
+}
+
+function passes(sc, job, model, lang, n) {
+  for (let i = 0; i < n; i++) sc.recordSample(job, model, lang, true);
+}
+
+// Three cloud tiers + local, same setup shape as the cost-optimization
+// tests. The anthropic adapter profile declares completion+tools, so all
+// three are eligible for every job and ordering is pure cost rank.
+function makeRouter() {
+  return new LLMRouter({
+    providers: {
+      'ollama-local': { adapter: 'ollama', type: 'local', model: 'qwen3:8b', endpoint: 'http://localhost:11434' },
+      'cloud-heavy': { adapter: 'anthropic', type: 'api', model: 'model-heavy', costModel: { type: 'per_token', inputPer1M: 15, outputPer1M: 75 } },
+      'cloud-mid': { adapter: 'anthropic', type: 'api', model: 'model-mid', costModel: { type: 'per_token', inputPer1M: 3, outputPer1M: 15 } },
+      'cloud-cheap': { adapter: 'anthropic', type: 'api', model: 'model-cheap', costModel: { type: 'per_token', inputPer1M: 0.8, outputPer1M: 4 } },
+    },
+  });
+}
+
+// ============================================================
+// Scorecard: demote on threshold, mass floor, dead band
+// ============================================================
+
+test('demotion fires only when a failing cell carries one fixture-quantum of mass', () => {
+  const sc = makeScorecard();
+  fails(sc, 'writing', 'cloudy', 'DE', 11);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), false, '11 < mass floor — no demotion yet');
+  fails(sc, 'writing', 'cloudy', 'DE', 1);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true, '12 failures = mass 12, mean 0 — demoted');
+  const rec = sc.getCloudDemotions().writing.cloudy;
+  assert.strictEqual(rec.strikes, 1);
+  assert.strictEqual(rec.trigger.lang, 'DE');
+  assert.strictEqual(rec.trigger.mean, 0);
+  assert.ok(rec.recheckAt > rec.at, 'recheck scheduled after the demotion');
+});
+
+test('demotion is per-(job, model): the same model stays healthy for other jobs', () => {
+  const sc = makeScorecard();
+  fails(sc, 'writing', 'cloudy', 'DE', 12);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true);
+  assert.strictEqual(sc.isDemoted('thinking', 'cloudy'), false);
+  assert.strictEqual(sc.isDemoted('writing', 'other'), false);
+});
+
+test('dead band: a mean inside [floor−margin, floor+margin) moves nothing in either direction', () => {
+  const sc = makeScorecard();
+  // Healthy model at mean 0.5 over full mass: inside the band, no demotion.
+  passes(sc, 'writing', 'okayish', 'EN', 6);
+  fails(sc, 'writing', 'okayish', 'EN', 6);
+  assert.strictEqual(sc.isDemoted('writing', 'okayish'), false, 'band means status quo — healthy stays healthy');
+
+  // Demoted model recovering to mean 0.5: inside the band, stays demoted.
+  const sc2 = makeScorecard();
+  fails(sc2, 'writing', 'cloudy', 'EN', 12);
+  assert.strictEqual(sc2.isDemoted('writing', 'cloudy'), true);
+  passes(sc2, 'writing', 'cloudy', 'EN', 12);
+  assert.strictEqual(sc2.isDemoted('writing', 'cloudy'), true, 'band means status quo — demoted stays demoted');
+});
+
+test('an unmeasured (thin) language cell can neither trigger nor block', () => {
+  const sc = makeScorecard();
+  // Thin failing PT cell alone: no demotion.
+  fails(sc, 'writing', 'cloudy', 'PT', 2);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), false);
+  // DE carries the quantum: demotion.
+  fails(sc, 'writing', 'cloudy', 'DE', 12);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true);
+  // DE recovers past the upper edge; the thin PT cell must not block.
+  passes(sc, 'writing', 'cloudy', 'DE', 17); // 17/29 ≈ 0.586 ≥ 0.5833
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), false, 'thin PT cell cannot block reinstatement');
+});
+
+test('no qualifying cell at all means no reinstatement (no evidence is not recovery)', () => {
+  const sc = makeScorecard();
+  fails(sc, 'writing', 'cloudy', 'DE', 12);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true);
+  // Halve the cell below the mass floor (the ceiling does this in life);
+  // a sample elsewhere re-evaluates with no qualifying DE cell.
+  const de = sc.getPairings('writing').cloudy.DE;
+  de.a /= 2; de.b /= 2; // mass 6 < 12
+  sc.recordSample('writing', 'other', 'EN', true);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true, 'status quo holds without qualifying evidence');
+});
+
+// ============================================================
+// Scorecard: reinstatement, callback, strikes escalation
+// ============================================================
+
+test('reinstate when every qualifying cell clears floor+margin; callback fires both ways', () => {
+  const events = [];
+  const sc = makeScorecard();
+  sc.onCloudDemotionChange = (job, model) => events.push(`${job}/${model}/${sc.isDemoted(job, model) ? 'demoted' : 'reinstated'}`);
+  fails(sc, 'writing', 'cloudy', 'EN', 12);
+  passes(sc, 'writing', 'cloudy', 'EN', 17); // 17/29 ≈ 0.586
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), false);
+  assert.deepStrictEqual(events, ['writing/cloudy/demoted', 'writing/cloudy/reinstated']);
+  const memory = sc.getCloudDemotions().writing.cloudy;
+  assert.ok(memory.reinstatedAt, 'reinstatement leaves strike memory');
+  assert.strictEqual(memory.strikes, 1);
+});
+
+test('a throwing onCloudDemotionChange never breaks recordSample', () => {
+  const sc = makeScorecard();
+  sc.onCloudDemotionChange = () => { throw new Error('bridge exploded'); };
+  fails(sc, 'writing', 'cloudy', 'EN', 12);
+  assert.strictEqual(sc.isDemoted('writing', 'cloudy'), true, 'demotion recorded despite callback failure');
+});
+
+test('strikes escalate on re-demotion within the memory window, and reset after it', () => {
+  const sc = makeScorecard();
+  fails(sc, 'writing', 'cloudy', 'EN', 12);
+  const first = sc.getCloudDemotions().writing.cloudy;
+  assert.strictEqual(first.strikes, 1);
+  assert.ok(Math.abs((Date.parse(first.recheckAt) - Date.parse(first.at)) - 7 * DAY_MS) < 60000, 'first cool-off ≈ 7d');
+
+  passes(sc, 'writing', 'cloudy', 'EN', 17); // reinstated (17/29)
+  fails(sc, 'writing', 'cloudy', 'EN', 12); // 17/41 ≈ 0.415 — re-demoted immediately
+  const second = sc.getCloudDemotions().writing.cloudy;
+  assert.strictEqual(second.strikes, 2, 'consecutive failure escalates');
+  assert.ok(Math.abs((Date.parse(second.recheckAt) - Date.parse(second.at)) - 14 * DAY_MS) < 60000, 'second cool-off ≈ 14d');
+
+  passes(sc, 'writing', 'cloudy', 'EN', 17); // 34/58 ≈ 0.586 — reinstated again
+  // Age the reinstatement past the strike-memory window.
+  sc._state.cloudDemotions.writing.cloudy.reinstatedAt = new Date(Date.now() - 15 * DAY_MS).toISOString();
+  fails(sc, 'writing', 'cloudy', 'EN', 24); // 34/82 ≈ 0.415 — demoted anew
+  assert.strictEqual(sc.getCloudDemotions().writing.cloudy.strikes, 1, 'distant re-demotion starts over');
+});
+
+// ============================================================
+// Scorecard: recheck cadence and persistence
+// ============================================================
+
+test('isRecheckDue: false inside the cool-off, per-language once the cool-off elapses', () => {
+  const sc = makeScorecard();
+  fails(sc, 'writing', 'cloudy', 'EN', 12);
+  fails(sc, 'writing', 'cloudy', 'DE', 12);
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy', 'EN'), false, 'cool-off has not elapsed');
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy'), false);
+
+  sc._state.cloudDemotions.writing.cloudy.recheckAt = new Date(Date.now() - 1000).toISOString();
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy'), true);
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy', 'EN'), true);
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy', 'DE'), true);
+
+  // A landing sample (probe or organic) is EN's re-audition this period;
+  // DE remains due, and a healthy model is never due.
+  sc.recordSample('writing', 'cloudy', 'EN', false);
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy', 'EN'), false, 'EN consumed its recheck slot');
+  assert.strictEqual(sc.isRecheckDue('writing', 'cloudy', 'DE'), true, 'DE still due');
+  assert.strictEqual(sc.isRecheckDue('writing', 'healthy', 'EN'), false);
+});
+
+test('demotions and strike memory survive a persistence round-trip', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scorecard-demotion-'));
+  try {
+    const sc = new ModelScorecard({ dataDir: dir, logger: silentLogger });
+    fails(sc, 'writing', 'cloudy', 'DE', 12);
+    fails(sc, 'quick', 'flaky', 'EN', 12);
+    passes(sc, 'quick', 'flaky', 'EN', 17); // reinstated — memory persists too
+    sc.flush();
+
+    const reloaded = new ModelScorecard({ dataDir: dir, logger: silentLogger });
+    assert.strictEqual(reloaded.isDemoted('writing', 'cloudy'), true);
+    assert.strictEqual(reloaded.isDemoted('quick', 'flaky'), false);
+    const rec = reloaded.getCloudDemotions();
+    assert.strictEqual(rec.writing.cloudy.recheckAt, sc.getCloudDemotions().writing.cloudy.recheckAt);
+    assert.ok(rec.quick.flaky.reinstatedAt, 'strike memory round-trips');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ============================================================
+// Router: the veto in the ONE generating function
+// ============================================================
+
+test('no quality check wired → chains are byte-identical to pure cost order', () => {
+  const router = makeRouter();
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.writing, ['cloud-heavy', 'cloud-mid', 'cloud-cheap', 'ollama-local']);
+  assert.deepStrictEqual(roster.quick, ['cloud-cheap', 'ollama-local']);
+});
+
+test('cheapest-depth job: demoting the leader changes what "cheapest" means; demoted tails', () => {
+  const router = makeRouter();
+  const demoted = new Set(['quick:model-cheap']);
+  router.setCloudQualityCheck((job, model) => demoted.has(`${job}:${model}`));
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.quick, ['cloud-mid', 'cloud-cheap', 'ollama-local'],
+    'cheapest HEALTHY leads; demoted re-enters as tail before local');
+  assert.deepStrictEqual(roster.synthesis, ['cloud-cheap', 'ollama-local'],
+    'other jobs untouched — demotion is per-(job, model)');
+});
+
+test('synthesis sole-cheapest case: next-cheapest healthy leads, demoted tails, local still last', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job, model) => job === 'synthesis' && model === 'model-cheap');
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.synthesis, ['cloud-mid', 'cloud-cheap', 'ollama-local']);
+});
+
+test('depth job: demoted mid-tier re-enters at the tail; healthy models keep cost order', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job, model) => job === 'writing' && model === 'model-mid');
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.writing, ['cloud-heavy', 'cloud-cheap', 'cloud-mid', 'ollama-local']);
+});
+
+test('never-go-dark: with every eligible model demoted the chain is exactly the un-vetoed one', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job) => job === 'writing');
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.writing, ['cloud-heavy', 'cloud-mid', 'cloud-cheap', 'ollama-local']);
+});
+
+test('a demotion the depth policy never selected anyway is a no-op (no score-sorting)', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job, model) => job === 'synthesis' && model === 'model-heavy');
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.synthesis, ['cloud-cheap', 'ollama-local'],
+    'heavy was not in the cheapest chain; vetoing it changes nothing');
+});
+
+test('a throwing quality check fails open: chains keep pure cost order', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck(() => { throw new Error('scorecard fault'); });
+  const roster = router._resolvePreset('smart-mix');
+  assert.deepStrictEqual(roster.quick, ['cloud-cheap', 'ollama-local']);
+});
+
+test('cloud-fast (excludeHeavy) chains inherit the veto through the same generating function', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job, model) => model === 'model-cheap');
+  const roster = router._buildCloudFastRoster();
+  // Un-vetoed flat chain is [cheap, mid]; with cheap demoted, mid leads and
+  // cheap tails.
+  assert.deepStrictEqual(roster.quick, ['cloud-mid', 'cloud-cheap', 'ollama-local']);
+});
+
+// ============================================================
+// Router: refreshCloudOrdering, custom-roster exemption, stats
+// ============================================================
+
+test('refreshCloudOrdering rebuilds an active preset roster in place', () => {
+  const router = makeRouter();
+  const demoted = new Set();
+  router.setCloudQualityCheck((job, model) => demoted.has(`${job}:${model}`));
+  router.setPreset('smart-mix');
+  assert.strictEqual(router.getRoster().quick[0], 'cloud-cheap');
+
+  demoted.add('quick:model-cheap');
+  assert.strictEqual(router.refreshCloudOrdering(), true);
+  assert.deepStrictEqual(router.getRoster().quick, ['cloud-mid', 'cloud-cheap', 'ollama-local']);
+  assert.strictEqual(router.getPreset(), 'smart-mix', 'refresh does not change the active preset');
+});
+
+test('refreshCloudOrdering skips the rebuild when no cloud provider serves the model', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck(() => false);
+  router.setPreset('smart-mix');
+  assert.strictEqual(router.refreshCloudOrdering('quick', 'qwen3:8b'), false,
+    'a local-only model name cannot move any cloud chain');
+  assert.strictEqual(router.refreshCloudOrdering('quick', 'model-nobody-serves'), false);
+  assert.strictEqual(router.refreshCloudOrdering('quick', 'model-cheap'), true, 'cloud-served model rebuilds');
+  assert.strictEqual(router.refreshCloudOrdering(), true, 'no model given (boot refresh) always rebuilds');
+});
+
+test('custom roster (setRoster) is exempt: deployer-explicit chains outrank the mechanism', () => {
+  const router = makeRouter();
+  const demoted = new Set();
+  router.setCloudQualityCheck((job, model) => demoted.has(`${job}:${model}`));
+  router.setRoster({ writing: ['cloud-cheap', 'cloud-heavy'] });
+
+  demoted.add('writing:model-cheap');
+  assert.strictEqual(router.refreshCloudOrdering(), false, 'no preset active — nothing rebuilt');
+  assert.deepStrictEqual(router.getRoster().writing, ['cloud-cheap', 'cloud-heavy'],
+    'deployer-explicit chain untouched by a demotion');
+});
+
+test('getStats surfaces which providers the veto is currently sinking, per job', () => {
+  const router = makeRouter();
+  router.setCloudQualityCheck((job, model) => job === 'writing' && model === 'model-mid');
+  const stats = router.getStats();
+  assert.deepStrictEqual(stats.cloudDemotions.writing, [{ id: 'cloud-mid', model: 'model-mid' }]);
+  assert.strictEqual(stats.cloudDemotions.quick, undefined, 'healthy jobs are absent, not empty');
+});
+
+// ============================================================
+// The bridge: scorecard evidence moves live chains, both directions
+// ============================================================
+
+test('end-to-end: judged evidence demotes, the roster rebuilds; recovery reinstates it', () => {
+  const router = makeRouter();
+  const sc = makeScorecard();
+  // The webhook-server wiring, verbatim.
+  router.setCloudQualityCheck((job, model) => sc.isDemoted(job, model));
+  sc.onCloudDemotionChange = (job, model) => router.refreshCloudOrdering(job, model);
+  router.setPreset('smart-mix');
+  assert.strictEqual(router.getRoster().quick[0], 'cloud-cheap');
+
+  fails(sc, 'quick', 'model-cheap', 'DE', 12);
+  assert.deepStrictEqual(router.getRoster().quick, ['cloud-mid', 'cloud-cheap', 'ollama-local'],
+    'the demotion rebuilt the live roster without any manual refresh');
+
+  passes(sc, 'quick', 'model-cheap', 'DE', 17); // 17/29 ≈ 0.586 — reinstated
+  assert.deepStrictEqual(router.getRoster().quick, ['cloud-cheap', 'ollama-local'],
+    'reinstatement restored pure cost order');
+});
+
+// ============================================================
+// LocalJudge: re-audition through the cold-cell chokepoint
+// ============================================================
+
+const JUDGE = { name: 'judge:8b', paramSize: 8, digest: 'sha256:j1' };
+const WRITING_FIXTURE = { jobs: { writing: { EN: ['write EN'], DE: ['schreibe DE'], PT: ['escreve PT'] } } };
+
+function makeCloudJudge({ scorecard, budgetEnforcer, cloudCand }) {
+  return new LocalJudge({
+    judgeQueue: new JudgeQueue({ dataDir: null, logger: silentLogger }),
+    scorecard,
+    selectJudgeModel: () => JUDGE,
+    localChat: async () => ({ content: '{"pass": true}' }),
+    localCandidates: () => [],
+    cloudCandidates: () => [cloudCand.cand],
+    resolveTrust: () => 'cloud-ok',
+    budgetEnforcer,
+    fixture: WRITING_FIXTURE,
+    maxCloudProbesPerCycle: 10,
+    maxLocalProbesPerCycle: 0,
+    logger: silentLogger,
+  });
+}
+
+function makeCloudCand(model) {
+  const calls = { chat: 0 };
+  return {
+    calls,
+    cand: {
+      id: 'cloud-x',
+      model,
+      chat: async () => {
+        calls.chat++;
+        return { content: 'cloud text', _cost: 0.004, _tokens: 50 };
+      },
+    },
+  };
+}
+
+asyncTest('a recheck-due demoted pairing is probe-eligible despite warmth — once per language per period', async () => {
+  const scorecard = makeScorecard();
+  // Warm AND demoted in every fixture language (mass 12 ≥ coldMassFloor 5).
+  for (const lang of ['EN', 'DE', 'PT']) fails(scorecard, 'writing', 'claude-x', lang, 12);
+  scorecard._state.cloudDemotions.writing['claude-x'].recheckAt = new Date(Date.now() - 1000).toISOString();
+
+  const cloudCand = makeCloudCand('claude-x');
+  let gateChecks = 0;
+  const budgetEnforcer = {
+    canSpendProactive: () => { gateChecks++; return { allowed: true }; },
+    recordProactiveSpend: () => {},
+  };
+  const judge = makeCloudJudge({ scorecard, budgetEnforcer, cloudCand });
+
+  const out = await judge.runIdleCycle();
+  assert.strictEqual(cloudCand.calls.chat, 3, 'one re-audition generation per fixture language');
+  assert.strictEqual(out.cloudProbes, 3);
+  assert.strictEqual(gateChecks, 3, 'every re-audition generation passed the proactive gate first');
+
+  // The verdicts consumed each language's recheck slot; the next cycle is
+  // back to warm-cell silence until the cool-off elapses again.
+  const again = await judge.runIdleCycle();
+  assert.strictEqual(cloudCand.calls.chat, 3, 'no further probes this period');
+  assert.strictEqual(again.cloudProbes, 0);
+  assert.strictEqual(scorecard.isDemoted('writing', 'claude-x'), true, 'three failing-history cells stay demoted');
+});
+
+asyncTest('recheck probes stay inside the proactive budget gate (gate closed → no generation)', async () => {
+  const scorecard = makeScorecard();
+  fails(scorecard, 'writing', 'claude-x', 'EN', 12);
+  scorecard._state.cloudDemotions.writing['claude-x'].recheckAt = new Date(Date.now() - 1000).toISOString();
+
+  const cloudCand = makeCloudCand('claude-x');
+  const budgetEnforcer = {
+    canSpendProactive: () => ({ allowed: false, reason: 'proactive_budget_exceeded' }),
+    recordProactiveSpend: () => {},
+  };
+  const judge = makeCloudJudge({ scorecard, budgetEnforcer, cloudCand });
+  const out = await judge.runIdleCycle();
+  assert.strictEqual(cloudCand.calls.chat, 0, 'the budget gate outranks the recheck');
+  assert.strictEqual(out.cloudProbes, 0);
+});
+
+asyncTest('a scorecard without (or with a throwing) isRecheckDue keeps today\'s warm-skip, no crash', async () => {
+  const scorecard = makeScorecard();
+  for (const lang of ['EN', 'DE', 'PT']) {
+    for (let i = 0; i < 5; i++) scorecard.recordSample('writing', 'claude-x', lang, true, { synthetic: true });
+  }
+  scorecard.isRecheckDue = () => { throw new Error('older scorecard'); };
+
+  const cloudCand = makeCloudCand('claude-x');
+  const budgetEnforcer = { canSpendProactive: () => ({ allowed: true }), recordProactiveSpend: () => {} };
+  const judge = makeCloudJudge({ scorecard, budgetEnforcer, cloudCand });
+  const out = await judge.runIdleCycle();
+  assert.strictEqual(cloudCand.calls.chat, 0, 'warm cells attract no probe when recheck cannot be established');
+  assert.strictEqual(out.cloudProbes, 0);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -1666,6 +1666,21 @@ async function initialize() {
       });
       console.log('[INIT] ModelScorecard ready (maturation loop)');
 
+      // #237: cloud chain ordering from judged evidence. Quality truth and
+      // hysteresis live in the scorecard; chain ordering lives in the
+      // router's ONE generating function — the bridge is one injected read
+      // each way. The scorecard loaded persisted demotions in its
+      // constructor, so the refresh makes any active preset roster correct
+      // from the first chain.
+      if (llmRouter) {
+        llmRouter.setCloudQualityCheck((job, model) => modelScorecard.isDemoted(job, model));
+        modelScorecard.onCloudDemotionChange = (job, model) => llmRouter.refreshCloudOrdering(job, model);
+        llmRouter.refreshCloudOrdering();
+        console.log('[INIT] Cloud quality veto wired (ModelScorecard demotions -> LLMRouter chain ordering)');
+      } else {
+        console.log('[INIT] Cloud quality veto NOT wired (LLMRouter absent — chains keep pure cost order)');
+      }
+
       // Judged-job sample retention (Session 4). The queue is the ONLY
       // place raw response content persists, on local disk under data/,
       // bounded and judge-then-delete — content never enters Nextcloud.


### PR DESCRIPTION
Implements `briefings/Moltagent-237-CloudChainOrdering-Spec.md` (design verified against `next` @ afe0172). Closes #237 on live verification (see gate below).

## The mechanism

Not a reordering algorithm — a **quality veto on the cost anchor**. The cost-ranked eligible list stays exactly as it is; a cloud model with *proven* quality problems for a (job) loses its claim to its cost position, sinks below all healthy peers, and re-enters as tail fallback. Two healthy models never swap on quality; price never enters the trigger; no quality promotion exists.

Three existing single homes stay the single homes:
- **ModelScorecard** — quality truth AND hysteresis state (seats + demotions).
- **`_buildCloudJobChains`** — the veto is applied there once, UPSTREAM of the depth policy, and inherited by every caller (presets, cloud-fast, per-call `allowCloud`). For a `'cheapest'` job the demotion changes *what cheapest means*; the depth-policy code is untouched, which handles synthesis's single-entry chain by construction.
- **LocalJudge's cold-cell chokepoint** — re-audition of a demoted model is one OR-condition (null-safe), one probe per fixture language per cool-off period, budget/trust gates untouched.

## Thresholds (in the system's own units)

| | |
|---|---|
| Mass floor | 12 — one fixture-quantum in a single (job, model, language) cell |
| Demote | ∃ measured lang: mass ≥ 12 AND mean < floor − margin (≈ 0.417) |
| Reinstate | every qualifying cell mean ≥ floor + margin (≈ 0.583); ≥ 1 qualifying cell required |
| Dead band | [0.417, 0.583) changes nothing — the incumbent state holds (#232 discipline, cloud regime) |
| Cool-off | 7d × 2^(strikes−1), capped 56d; re-demotion within 14d of reinstatement escalates strikes |

## Guarantees pinned by tests (26 new, full unit suite 232/232)

- Reorder, never eliminate: demoted entries tail in original cost order (organic tail traffic earns reinstatement evidence).
- Never-go-dark: all-demoted ⇒ chain is exactly the un-vetoed one.
- Custom rosters (`setRoster`) exempt — deployer-explicit chains are human intent.
- Fail-open bridge: no check wired / throwing check ⇒ pure cost order; older scorecard without `isRecheckDue` ⇒ today's warm-skip.
- Recheck probes pass the proactive budget gate per generation, as before.
- Demotions and strike memory survive a persistence round-trip.
- Rebuild guard: a demotion change on a model no cloud provider serves (scorecard records for local names are inert by design) skips the roster rebuild.

## Reviewer pass (applied)

Independent review verdict PASS; two findings folded in: `refreshCloudOrdering(job, model)` early-outs when the model maps to no cloud provider (local-model band flaps no longer trigger pointless full preset rebuilds), and corrupt persisted cells with a non-finite mean neither trigger nor block a demotion.

## Verification gate

Layer 1 (tests) green. Layer 2 (production, spec §10): after deploy, capture either (a) a real demotion journal line + the `refreshCloudOrdering` roster line, or (b) the seeded-store variant (one sample below threshold, one live `recordSample` pushing it over). #237 closes on that `[VERIFIED: ...]` capture, not on merge.

Net src ≈ +190 — acknowledged against LESS CODE and accepted per spec §8: no parallel structure exists to delete; the alternative (a second scoring table or per-caller ordering) is the code this design avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)