### PR TITLE
feat(wikisteward): compost mover + durable state + link/root guards (#245 #246 #255 #256)

### DIFF
--- a/src/lib/maintenance/wiki-steward.js
+++ b/src/lib/maintenance/wiki-steward.js
@@ -70,8 +70,29 @@
  * @version 0.1.0
  */
 
+const fs = require('fs');
+const path = require('path');
+
 // Section identity has exactly one derivation, owned by the client (#51 generator).
 const { deriveSection } = require('../integrations/collectives-client');
+
+// The Archive section is a Level-1 section, sibling to People/Projects/etc.
+// A composted page moves here (#245); its identity survives in NC versioning
+// and the Archive copy — there is no delete path.
+const ARCHIVE_SECTION = 'Archive';
+
+// The human veto window between marking a page compost_ready (which fires the
+// KnowledgeBoard card) and the mover physically archiving it (#245).
+const COMPOST_HOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Pulses stay bounded: at most this many pages move to Archive per visit (#245).
+const MAX_MOVES_PER_VISIT = 3;
+
+// Persisted steward state (#246): visit timestamps and the per-cluster lens
+// ring. Both are behavior-relevant across restarts — losing _lastVisit makes
+// every cluster read maximally neglected; losing the ring breaks the
+// three-lens rotation invariant at the restart boundary.
+const STATE_FILENAME = 'wiki-steward-state.json';
 
 /**
  * @typedef {Object} PageRef
@@ -206,6 +227,18 @@ class WikiSteward {
     /** @type {Map<string, number>} */
     this._zeroPageStreak = new Map();
 
+    // Durable steward state (#246). _lastVisit and _lensIndexByCluster survive
+    // restarts via one debounced JSON under data/ (the model-scorecard pattern:
+    // atomic tmp+rename, loaded at construction, corrupt/missing starts fresh).
+    // _zeroPageStreak stays ephemeral by design — it is a diagnostic, and a
+    // fresh start after a restart is the correct behavior for a streak counter.
+    this.dataDir = this.config.dataDir === null
+      ? null
+      : (this.config.dataDir || path.resolve(process.cwd(), 'data'));
+    this._stateFile = this.dataDir ? path.join(this.dataDir, STATE_FILENAME) : null;
+    this._saveTimer = null;
+    this._loadState();
+
     // Level 0 landing page throttling.
     /** @type {number} */
     this._lastIndexRefresh = 0;
@@ -213,6 +246,87 @@ class WikiSteward {
     this._indexRefreshIntervalMs = Number.isFinite(this.config.indexRefreshIntervalMs)
       ? this.config.indexRefreshIntervalMs
       : 6 * 60 * 60 * 1000; // 6h default
+  }
+
+  // ---------------------------------------------------------------------------
+  // DURABLE STATE (#246) — modeled on model-scorecard.js load/save shape
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Load persisted _lastVisit and lens rings at construction. A missing or
+   * corrupt file starts fresh — the prior in-memory behavior, so a bad file is
+   * never worse than no persistence at all.
+   * @private
+   */
+  _loadState() {
+    if (!this._stateFile) return;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this._stateFile, 'utf8'));
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      if (parsed.lastVisit && typeof parsed.lastVisit === 'object') {
+        for (const [cluster, ts] of Object.entries(parsed.lastVisit)) {
+          if (Number.isFinite(ts)) this._lastVisit.set(cluster, ts);
+        }
+      }
+      if (parsed.lensIndex && typeof parsed.lensIndex === 'object') {
+        for (const [cluster, idx] of Object.entries(parsed.lensIndex)) {
+          if (Number.isInteger(idx) && idx >= 0) {
+            this._lensIndexByCluster.set(cluster, idx % this._stewards.length);
+          }
+        }
+      }
+      this.logger.info(
+        `[WikiSteward] State loaded: ${this._lastVisit.size} visit stamps, ` +
+        `${this._lensIndexByCluster.size} lens rings.`
+      );
+    } catch (_err) {
+      // Missing file or corrupt JSON — start fresh (the pre-persistence amnesia).
+    }
+  }
+
+  /**
+   * Coalesce state writes: a tend marks the state dirty and a short unref'd
+   * timer flushes it, so a burst of tends costs one disk write and a crash
+   * loses at most a second of visit/lens bookkeeping.
+   * @private
+   */
+  _scheduleSave() {
+    if (!this._stateFile || this._saveTimer) return;
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null;
+      this._persistState();
+    }, 1000);
+    if (typeof this._saveTimer.unref === 'function') this._saveTimer.unref();
+  }
+
+  /** @private */
+  _persistState() {
+    if (!this._stateFile) return;
+    try {
+      if (!fs.existsSync(this.dataDir)) fs.mkdirSync(this.dataDir, { recursive: true });
+      const state = {
+        version: 1,
+        lastVisit: Object.fromEntries(this._lastVisit),
+        lensIndex: Object.fromEntries(this._lensIndexByCluster),
+      };
+      const tmp = this._stateFile + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
+      fs.renameSync(tmp, this._stateFile);
+    } catch (err) {
+      this.logger.warn(`[WikiSteward] Failed to persist state: ${err.message}`);
+    }
+  }
+
+  /**
+   * Flush any pending debounced write now. Idempotent — safe to call on a
+   * double shutdown. Wire into the process shutdown drain.
+   */
+  flush() {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+    }
+    this._persistState();
   }
 
   // ---------------------------------------------------------------------------
@@ -357,8 +471,11 @@ class WikiSteward {
       this.logger.warn(`[WikiSteward] observations.resolve failed: ${err.message}`);
     }
 
-    // Step 9: record visit timestamp
+    // Step 9: record visit timestamp, then persist visit + lens state (#246).
+    // Both the lens ring (step 2) and _lastVisit changed this tend; one
+    // debounced write coalesces them.
     this._lastVisit.set(cluster.name, Date.now());
+    this._scheduleSave();
 
     const result = {
       steward: stewardType,
@@ -555,8 +672,22 @@ class WikiSteward {
       const pageList = Array.isArray(allPages) ? allPages : [];
       const clusterName = cluster.name;
 
-      const landingPage = pageList.find(p => p.parentId === 0);
-      const landingPageId = landingPage?.id;
+      // Root-count assertion (#256): the fractal index has exactly one root
+      // page (the Level 0 landing page). A stray at root corrupts section
+      // derivation and landing-page identity — the failure class Phase 5's
+      // root-create suppression closed. This promotes that one-time manual
+      // snapshot to a standing per-tend check, riding the listPages read we
+      // already made. Observes only; humans act on the named strays.
+      const rootPages = pageList.filter(p => p.parentId === 0);
+      if (rootPages.length !== 1) {
+        this.logger.warn(
+          `[WikiSteward] root page count assertion: expected 1 landing page ` +
+          `(parentId=0), found ${rootPages.length}: ` +
+          rootPages.map(p => `"${p.title}"`).join(', ')
+        );
+      }
+      const landingPageId = rootPages[0]?.id;
+
       clusterPages = pageList.filter(p => deriveSection(p, landingPageId) === clusterName);
     } catch (err) {
       this.logger.warn(`[WikiSteward] Failed to list pages for cluster "${cluster.name}": ${err.message}`);
@@ -990,6 +1121,12 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       pagesModified: 0,
       linksAdded: 0,
       observationsResolved: 0,
+      // Link-integrity counters (#255). gapsLogged: targets that resolved to no
+      // page (GAP recorded, no link written). deadLinksWritten: links written
+      // despite an unresolved target — 0 by construction today; > 0 is the
+      // regression signal if the gap branch is ever bypassed.
+      gapsLogged: 0,
+      deadLinksWritten: 0,
       // (type, page) pairs the executors actually acted on. tend() resolves
       // exactly these — visiting is not resolving (G2, #161 class).
       resolutions: [],
@@ -1095,7 +1232,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           const handle = resolve(m.page, 'missing link');
           if (!handle) continue;
           try {
-            const added = await this._addWikilink(handle, m.shouldLinkTo, m.relationship, neighborhood);
+            const added = await this._addWikilink(handle, m.shouldLinkTo, m.relationship, neighborhood, results);
             if (added) {
               results.linksAdded++;
               results.pagesModified++;
@@ -1114,7 +1251,7 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           if (!handle) continue;
           for (const target of o.suggestedConnections || []) {
             try {
-              const added = await this._addWikilink(handle, target, 'related', neighborhood);
+              const added = await this._addWikilink(handle, target, 'related', neighborhood, results);
               if (added) {
                 results.linksAdded++;
                 results.pagesModified++;
@@ -1142,6 +1279,17 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           } catch (err) {
             this.logger.warn(`[WikiSteward:connection] _flagDuplicate failed: ${err.message}`);
           }
+        }
+        // Link-integrity line (#255): one journal line per connection tend at
+        // the link chokepoint. The connection lens is the only path that writes
+        // wikilinks, so this is the tend-cycle summary for link integrity.
+        // dead_links_written > 0 means the gap branch was bypassed — a WARN.
+        {
+          const linkLine =
+            `[WikiSteward:connection] links: gaps_logged=${results.gapsLogged} ` +
+            `dead_links_written=${results.deadLinksWritten}`;
+          if (results.deadLinksWritten > 0) this.logger.warn(linkLine);
+          else this.logger.info(linkLine);
         }
         break;
       }
@@ -1191,6 +1339,45 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
           } catch (err) {
             this.logger.warn(`[WikiSteward:memory] _embedPage("${e.page}") failed: ${err.message}`);
           }
+        }
+
+        // Fourth memory intervention: the compost MOVER (#245). Unlike the
+        // three above, its candidates come from the neighborhood's own
+        // frontmatter, not the LLM assessment — a page's compost lifecycle is
+        // structural bookkeeping (a flag and a date), not a judgement, so no
+        // model call is involved. A page moves to Archive/ when ALL hold:
+        // compost_ready, marked 7+ days ago (the human veto window — the
+        // KnowledgeBoard card already fired at marking time), not already
+        // archived, not structural, not pinned (compost: never lives in
+        // structuralTitles). Capped per visit so pulses stay bounded.
+        let moved = 0;
+        const nowMs = Date.now();
+        for (const page of neighborhood?.pages || []) {
+          if (moved >= MAX_MOVES_PER_VISIT) break;
+          const fm = page.frontmatter || {};
+          if (fm.compost_ready !== true) continue;
+          if (fm.archived === true) continue;
+          if (structuralTitles.has(page.title)) continue;
+          const markedAt = Date.parse(fm.compost_marked_at);
+          if (!Number.isFinite(markedAt) || (nowMs - markedAt) < COMPOST_HOLD_MS) continue;
+          const handle = resolve(page.title, 'archive move');
+          if (!handle) continue;
+          try {
+            const archived = await this._moveToArchive(handle);
+            if (archived) {
+              moved++;
+              // The source section lost a page — drive the Level 1 refresh.
+              results.pagesModified++;
+            }
+          } catch (err) {
+            this.logger.warn(`[WikiSteward:memory] _moveToArchive("${page.title}") failed: ${err.message}`);
+          }
+        }
+        if (moved > 0) {
+          this.logger.info(
+            `[WikiSteward:memory] compost mover: ${moved} page(s) archived this visit ` +
+            `(cap ${MAX_MOVES_PER_VISIT}).`
+          );
         }
         break;
       }
@@ -1397,13 +1584,21 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
    * @param {string} relationship
    * @param {Neighborhood} [neighborhood] - Assessed neighborhood; provides
    *   the local title index and the cluster for the GAP observation.
+   * @param {{gapsLogged: number, deadLinksWritten: number}} [tally] - Optional
+   *   link-integrity counters (#255) incremented in place at the two structural
+   *   branches: the gap branch and the write site.
    * @returns {Promise<boolean>} true if the wikilink was added.
    */
-  async _addWikilink(handle, target, relationship, neighborhood) {
+  async _addWikilink(handle, target, relationship, neighborhood, tally) {
     if (!handle?.path || !target) return false;
 
     const canonicalTarget = await this._resolveLinkTarget(target, neighborhood);
-    if (!canonicalTarget) {
+    // Computed once, read independently at the gap branch and the write site.
+    // The dead-link counter reads this fact at the write — so if the gap
+    // early-return below is ever removed, an unresolved write is still counted.
+    const resolved = !!canonicalTarget;
+    if (!resolved) {
+      if (tally) tally.gapsLogged++;
       this.observations.notice({
         type: 'gap',
         cluster: neighborhood?.cluster,
@@ -1450,6 +1645,11 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
       // Append a new Related section
       newBody = `${body.trimEnd()}\n\n## Related\n${relLine}`;
     }
+
+    // Regression sensor (#255): a resolved target reaches here today; an
+    // unresolved one only can if the gap branch above is bypassed. Count it at
+    // the write, independently of that branch.
+    if (tally && !resolved) tally.deadLinksWritten++;
 
     await this.collectivesClient.writePageWithFrontmatterAtPath(handle.path, result.frontmatter, newBody);
     this.logger.info(`[WikiSteward:connection] Added [[${target}]] to "${handle.title}" (${relationship})`);
@@ -1607,8 +1807,9 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
 
   /**
    * Memory lens: flag a page for composting.
-   * Sets compost_ready=true and related metadata. The actual page move
-   * is done by the Sleep Cycle — this only marks the frontmatter.
+   * Sets compost_ready=true and related metadata. The actual page move to
+   * Archive/ is done by _moveToArchive on a later visit, once the 7-day human
+   * veto window has passed (#245) — this only marks the frontmatter.
    *
    * Honors the `compost: never` frontmatter pin: structural/index pages
    * carry it because their access_count stays at 0 by design (probes target
@@ -1653,6 +1854,82 @@ OUTPUT FORMAT (STRICT): Your entire response must be a single JSON object. The f
         this.logger.warn(`[WikiSteward] KnowledgeBoard stale card for "${handle.title}" failed: ${err.message}`);
       }
     }
+    return true;
+  }
+
+  /**
+   * Memory lens: physically move a composted page to the Archive/ section
+   * (#245). Called by the mover once compost_ready has aged past the 7-day
+   * veto window. Collectives has no re-parent primitive, so the move is
+   * create-in-Archive then trash-original: the page is never absent from the
+   * wiki at any instant, and NC versioning plus the Archive copy are the only
+   * undo. No delete path exists here.
+   *
+   * @param {{id: string|number, title: string, path: string}} handle - Handle
+   *   from the assessed neighborhood (identity custody, G3).
+   * @returns {Promise<boolean>} true if the page was archived.
+   */
+  async _moveToArchive(handle) {
+    if (!handle?.path || handle.id == null) return false;
+
+    // Read the FULL body — the neighborhood carries only a truncated preview,
+    // and archiving must not write a clipped page.
+    const full = await this.collectivesClient.readPageWithFrontmatterAtPath(handle.path);
+    if (!full) return false;
+
+    // Defense in depth: never archive a pinned page, even if it slipped the
+    // structural filter. Same pin _markForComposting honors.
+    if (full.frontmatter && full.frontmatter.compost === 'never') {
+      this.logger.info(`[WikiSteward:memory] Skipping archive of "${handle.title}" — pinned (compost: never)`);
+      return false;
+    }
+
+    const collectiveId = this.collectiveId || await this.collectivesClient.resolveCollective();
+    const archiveSection = await this.collectivesClient.ensureSection(collectiveId, ARCHIVE_SECTION);
+    if (!archiveSection?.id) {
+      this.logger.warn(`[WikiSteward:memory] Archive of "${handle.title}" aborted — no Archive section`);
+      return false;
+    }
+
+    const leafTitle = String(handle.title).split('/').pop();
+    const created = await this.collectivesClient.createPage(collectiveId, archiveSection.id, leafTitle);
+
+    const newPath = (created && (created.fileName || created.filePath))
+      ? this.collectivesClient._buildPagePath(created)
+      : null;
+    if (!newPath) {
+      // The created page carries no resolvable path. Trash the stub so it can't
+      // collide with a future retry, and leave the original untouched — content
+      // is never lost, the move simply doesn't happen this visit.
+      if (created && created.id != null) {
+        try { await this.collectivesClient.trashPage(collectiveId, created.id); } catch { /* best effort */ }
+      }
+      this.logger.warn(`[WikiSteward:memory] Archive of "${handle.title}" aborted — created page has no resolvable path`);
+      return false;
+    }
+
+    // Collectives appends a "(N)" suffix when the Archive section already holds
+    // this leaf title (a distinct same-named page, or a stub from an interrupted
+    // move). We do NOT assume the existing page is this page's copy — that
+    // assumption trashes an original whose content was never archived. We write
+    // this page's body into whatever page was just created, suffixed or not: the
+    // body is always preserved, and a duplicate title is the worst case.
+    // Duplicates are recoverable; lost content is not.
+    //
+    // Pin the archived copy compost: never so the stewards treat it as inert:
+    // it is skipped by the mover (archived) and by every lens (compost: never
+    // lands it in the structural set), keeping Archive/ out of the tend churn.
+    const fm = {
+      ...full.frontmatter,
+      archived: true,
+      archived_at: new Date().toISOString(),
+      compost: 'never',
+    };
+    await this.collectivesClient.writePageWithFrontmatterAtPath(newPath, fm, full.body || '');
+    // Original trashed last — the Archive copy exists before the origin is gone.
+    await this.collectivesClient.trashPage(collectiveId, handle.id);
+
+    this.logger.info(`[WikiSteward:memory] Archived "${handle.title}" → ${ARCHIVE_SECTION}/ (original trashed)`);
     return true;
   }
 

--- a/test/unit/maintenance/wiki-steward-compost-mover.test.js
+++ b/test/unit/maintenance/wiki-steward-compost-mover.test.js
@@ -1,0 +1,347 @@
+'use strict';
+
+/**
+ * WikiSteward — compost mover (#245), durable state (#246), and the two
+ * link/root guards (#255, #256).
+ *
+ * Custom test runner (test/asyncTest/summary/exitWithCode + assert), not
+ * jest/mocha. Self-contained inline mocks; does not touch mock-factories.js.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+const { WikiSteward } = require('../../../src/lib/maintenance/wiki-steward');
+const { ObservationLog } = require('../../../src/lib/maintenance/observation-log');
+
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+
+// A logger that records every line so guard assertions can inspect them.
+function makeSpyLogger() {
+  const lines = { info: [], warn: [], error: [], debug: [] };
+  return {
+    debug: (m) => lines.debug.push(m),
+    info: (m) => lines.info.push(m),
+    warn: (m) => lines.warn.push(m),
+    error: (m) => lines.error.push(m),
+    _lines: lines,
+    _all: () => [...lines.info, ...lines.warn, ...lines.error, ...lines.debug],
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgoISO = (n) => new Date(Date.now() - n * DAY_MS).toISOString();
+
+// Mock CollectivesClient with the move primitives the mover flows through.
+function makeMoverClient({ pagesByPath = {}, suffixCollision = false } = {}) {
+  const created = [];
+  const trashed = [];
+  const written = {};
+  let nextId = 5000;
+  return {
+    _created: created,
+    _trashed: trashed,
+    _written: written,
+    resolveCollective: async () => 10,
+    ensureSection: async (_cid, name) => ({ id: 999, title: name, parentId: 1 }),
+    createPage: async (_cid, parentId, title) => {
+      const t = suffixCollision ? `${title} (2)` : title;
+      const page = { id: ++nextId, title: t, parentId, filePath: 'Archive', fileName: `${t}.md` };
+      created.push(page);
+      return page;
+    },
+    _buildPagePath: (p) => (p.fileName
+      ? (p.filePath ? `${p.filePath}/${p.fileName}` : p.fileName)
+      : `${p.title}.md`),
+    trashPage: async (_cid, id) => { trashed.push(id); },
+    readPageWithFrontmatterAtPath: async (p) => (pagesByPath[p] ? { ...pagesByPath[p] } : null),
+    writePageWithFrontmatterAtPath: async (p, fm, body) => { written[p] = { frontmatter: fm, body }; return p; },
+  };
+}
+
+function makeDeps(overrides = {}) {
+  return {
+    collectivesClient: makeMoverClient(),
+    knowledgeGraph: { getEntity: () => null, relatedTo: () => [] },
+    vectorStore: { getMetadata: () => null, upsert: () => {}, count: () => 0 },
+    embeddingClient: { embed: async () => [0.1] },
+    llmRouter: { route: async () => ({ result: '{}' }) },
+    observationLog: new ObservationLog({ logger: silentLogger }),
+    logger: silentLogger,
+    config: { dataDir: null }, // in-memory: no state file in most tests
+    ...overrides,
+  };
+}
+
+// Build a neighborhood page carrying frontmatter, plus register its full body
+// on the client so _moveToArchive's re-read succeeds.
+function makePage(client, title, frontmatter, { section = 'People', body = `# ${title}\n\nbody` } = {}) {
+  const p = `${section}/${title}.md`;
+  client._pagesByPath = client._pagesByPath || {};
+  // Wire the read map used by readPageWithFrontmatterAtPath.
+  const readMap = client.__readMap || (client.__readMap = {});
+  readMap[p] = { frontmatter: { ...frontmatter }, body, path: p };
+  const origRead = client.readPageWithFrontmatterAtPath;
+  client.readPageWithFrontmatterAtPath = async (path_) => (readMap[path_] ? { ...readMap[path_] } : origRead(path_));
+  return { id: `id-${title}`, title, path: p, section, frontmatter: { ...frontmatter }, bodyPreview: body.slice(0, 20), wikilinks: [], graphConnections: [], hasEmbedding: true };
+}
+
+function neighborhoodOf(pages, cluster = 'People') {
+  return { cluster, sections: new Set([cluster]), pages };
+}
+
+const EMPTY_MEMORY_ASSESSMENT = { strengthen: [], compost: [], embed: [] };
+
+// ---------------------------------------------------------------------------
+// A. COMPOST MOVER (#245)
+// ---------------------------------------------------------------------------
+
+asyncTest('mover: an eligible page moves to Archive/, stamped archived, original trashed', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Old Contact', { compost_ready: true, compost_marked_at: daysAgoISO(8) });
+  const res = await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+
+  assert.strictEqual(client._created.length, 1, 'one Archive page created');
+  assert.strictEqual(client._created[0].parentId, 999, 'created under Archive section');
+  const wroteTo = Object.keys(client._written)[0];
+  assert.ok(/^Archive\//.test(wroteTo), 'written under Archive/');
+  assert.strictEqual(client._written[wroteTo].frontmatter.archived, true, 'archived:true stamped');
+  assert.ok(client._written[wroteTo].frontmatter.archived_at, 'archived_at stamped');
+  assert.strictEqual(client._written[wroteTo].frontmatter.compost, 'never', 'archived copy pinned inert');
+  assert.ok(client._trashed.includes('id-Old Contact'), 'original trashed');
+  assert.strictEqual(res.pagesModified, 1, 'pagesModified bumped for Level 1 refresh');
+});
+
+asyncTest('mover: full body is preserved (not the truncated preview)', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const longBody = '# Title\n\n' + 'x'.repeat(2000);
+  const page = makePage(client, 'Long Page', { compost_ready: true, compost_marked_at: daysAgoISO(10) }, { body: longBody });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  const wroteTo = Object.keys(client._written)[0];
+  assert.strictEqual(client._written[wroteTo].body, longBody, 'full body written to Archive copy');
+});
+
+// Eligibility matrix — each condition individually BLOCKS the move.
+asyncTest('mover blocked: compost_ready absent', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Not Ready', { compost_marked_at: daysAgoISO(30) });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'no move without compost_ready');
+});
+
+asyncTest('mover blocked: marked less than 7 days ago (veto window)', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Too Fresh', { compost_ready: true, compost_marked_at: daysAgoISO(3) });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'no move inside the 7-day veto window');
+});
+
+asyncTest('mover blocked: already archived', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Already Gone', { compost_ready: true, compost_marked_at: daysAgoISO(30), archived: true });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'no re-move of an archived page');
+});
+
+asyncTest('mover blocked: structural page (type: section)', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'People', { type: 'section', compost_ready: true, compost_marked_at: daysAgoISO(30) });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'structural page never moved');
+});
+
+asyncTest('mover blocked: pinned (compost: never)', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Pinned', { compost: 'never', compost_ready: true, compost_marked_at: daysAgoISO(30) });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'pinned page never moved');
+});
+
+asyncTest('mover blocked: compost_marked_at malformed', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Bad Date', { compost_ready: true, compost_marked_at: 'not-a-date' });
+  await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf([page]));
+  assert.strictEqual(client._created.length, 0, 'unparseable marked_at blocks the move');
+});
+
+asyncTest('mover: cap of 3 moves per visit', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const pages = [];
+  for (let i = 0; i < 5; i++) {
+    pages.push(makePage(client, `Stale ${i}`, { compost_ready: true, compost_marked_at: daysAgoISO(30) }));
+  }
+  const res = await steward._intervene('memory', EMPTY_MEMORY_ASSESSMENT, neighborhoodOf(pages));
+  assert.strictEqual(client._created.length, 3, 'exactly 3 moved, cap enforced');
+  assert.strictEqual(res.pagesModified, 3);
+  assert.strictEqual(client._trashed.length, 3, 'exactly 3 originals trashed');
+});
+
+asyncTest('_moveToArchive: leaf-title collision preserves content at the suffixed path', async () => {
+  // A distinct same-named page already lives in Archive, so createPage returns
+  // a "(2)" title. Content MUST be written (never trashed uncopied) — the
+  // regression the reviewer caught: a blind trash-both loses the body.
+  const client = makeMoverClient({ suffixCollision: true });
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const body = '# Dup Page\n\nunique content that must survive';
+  const page = makePage(client, 'Dup Page', { compost_ready: true, compost_marked_at: daysAgoISO(9) }, { body });
+  const ok = await steward._moveToArchive({ id: page.id, title: page.title, path: page.path });
+  assert.strictEqual(ok, true, 'move reported complete');
+  const wroteTo = Object.keys(client._written)[0];
+  assert.ok(/Dup Page \(2\)/.test(wroteTo), 'written to the suffixed Archive path');
+  assert.strictEqual(client._written[wroteTo].body, body, 'body preserved, not lost');
+  assert.ok(client._trashed.includes('id-Dup Page'), 'original trashed only after content is written');
+});
+
+asyncTest('_moveToArchive: created page with no resolvable path trashes the stub, keeps original', async () => {
+  const client = makeMoverClient();
+  // createPage returns a page lacking fileName/filePath — an unbuildable path.
+  client.createPage = async () => ({ id: 7777, title: 'Stubby' });
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Stubby', { compost_ready: true, compost_marked_at: daysAgoISO(9) });
+  const ok = await steward._moveToArchive({ id: page.id, title: page.title, path: page.path });
+  assert.strictEqual(ok, false, 'move aborted');
+  assert.ok(client._trashed.includes(7777), 'empty stub trashed so it cannot collide on retry');
+  assert.ok(!client._trashed.includes('id-Stubby'), 'original left in place — content preserved');
+  assert.strictEqual(Object.keys(client._written).length, 0, 'no write when path unresolvable');
+});
+
+asyncTest('_moveToArchive: defense-in-depth honors compost: never even off the loop', async () => {
+  const client = makeMoverClient();
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const page = makePage(client, 'Pinned Direct', { compost: 'never' });
+  const ok = await steward._moveToArchive({ id: page.id, title: page.title, path: page.path });
+  assert.strictEqual(ok, false, 'pinned page refused');
+  assert.strictEqual(client._created.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// B. DURABLE STATE (#246)
+// ---------------------------------------------------------------------------
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-steward-state-'));
+}
+
+asyncTest('persistence: _lastVisit and lens rings round-trip across a restart', async () => {
+  const dir = tmpDir();
+  const s1 = new WikiSteward(makeDeps({ config: { dataDir: dir } }));
+  s1._lastVisit.set('People', 1720000000000);
+  s1._nextSteward('People'); // advance lens ring: 0 -> 1
+  s1._nextSteward('Projects'); // 0 -> 1
+  s1.flush();
+
+  const stateFile = path.join(dir, 'wiki-steward-state.json');
+  assert.ok(fs.existsSync(stateFile), 'state file written on flush');
+
+  const s2 = new WikiSteward(makeDeps({ config: { dataDir: dir } }));
+  assert.strictEqual(s2._lastVisit.get('People'), 1720000000000, '_lastVisit restored');
+  assert.strictEqual(s2._lensIndexByCluster.get('People'), 1, 'People lens ring restored');
+  assert.strictEqual(s2._lensIndexByCluster.get('Projects'), 1, 'Projects lens ring restored');
+  // Continuity: ring is at index 1, so the next lens is 'connection' (returns
+  // then advances), NOT a reset to 'knowledge' (index 0).
+  assert.strictEqual(s2._nextSteward('People'), 'connection', 'rotation continues rather than resetting');
+});
+
+asyncTest('persistence: corrupt state file starts fresh, no throw', async () => {
+  const dir = tmpDir();
+  fs.writeFileSync(path.join(dir, 'wiki-steward-state.json'), '{ this is not json', 'utf8');
+  let steward;
+  assert.doesNotThrow(() => { steward = new WikiSteward(makeDeps({ config: { dataDir: dir } })); });
+  assert.strictEqual(steward._lastVisit.size, 0, 'fresh _lastVisit');
+  assert.strictEqual(steward._lensIndexByCluster.size, 0, 'fresh lens rings');
+});
+
+asyncTest('persistence: dataDir null is in-memory (no file, flush is a no-op)', async () => {
+  const steward = new WikiSteward(makeDeps({ config: { dataDir: null } }));
+  steward._lastVisit.set('People', 123);
+  assert.doesNotThrow(() => steward.flush());
+  assert.strictEqual(steward._stateFile, null, 'no state file path when dataDir null');
+});
+
+asyncTest('persistence: flush is idempotent (double shutdown safe)', async () => {
+  const dir = tmpDir();
+  const steward = new WikiSteward(makeDeps({ config: { dataDir: dir } }));
+  steward._lastVisit.set('People', 999);
+  steward.flush();
+  assert.doesNotThrow(() => steward.flush(), 'second flush is safe');
+});
+
+// ---------------------------------------------------------------------------
+// C1. LINK-INTEGRITY COUNTER (#255)
+// ---------------------------------------------------------------------------
+
+asyncTest('#255: gap branch increments gaps_logged, no dead link written', async () => {
+  const client = makeMoverClient();
+  // No resolvable target: findPageByTitle absent, neighborhood has no such title.
+  client.findPageByTitle = async () => null;
+  client.readPageContent = async () => '';
+  client.writePageContent = async () => {};
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const tally = { gapsLogged: 0, deadLinksWritten: 0 };
+  const handle = { title: 'Source', path: 'People/Source.md' };
+  const added = await steward._addWikilink(handle, 'Ghost Entity', 'related', neighborhoodOf([]), tally);
+  assert.strictEqual(added, false, 'no link written to a non-existent target');
+  assert.strictEqual(tally.gapsLogged, 1, 'gaps_logged incremented');
+  assert.strictEqual(tally.deadLinksWritten, 0, 'no dead link written (healthy signature)');
+});
+
+asyncTest('#255: resolved target writes a link, dead_links_written stays 0', async () => {
+  const client = makeMoverClient();
+  const targetPage = makePage(client, 'Target', {});
+  const sourcePath = 'People/Source.md';
+  client.__readMap[sourcePath] = { frontmatter: {}, body: '# Source\n', path: sourcePath };
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client }));
+  const tally = { gapsLogged: 0, deadLinksWritten: 0 };
+  const handle = { title: 'Source', path: sourcePath };
+  const added = await steward._addWikilink(handle, 'Target', 'related', neighborhoodOf([targetPage]), tally);
+  assert.strictEqual(added, true, 'link written to a resolvable target');
+  assert.strictEqual(tally.gapsLogged, 0);
+  assert.strictEqual(tally.deadLinksWritten, 0, 'dead_links_written is 0 for a resolved write');
+});
+
+// ---------------------------------------------------------------------------
+// C2. ROOT-COUNT ASSERTION (#256)
+// ---------------------------------------------------------------------------
+
+asyncTest('#256: two root pages trigger a WARN naming the strays', async () => {
+  const spy = makeSpyLogger();
+  const client = makeMoverClient();
+  client.listPages = async () => ([
+    { id: 1, title: 'Landing', parentId: 0 },
+    { id: 2, title: 'Stray Root', parentId: 0 },
+    { id: 3, title: 'People', parentId: 1 },
+  ]);
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client, logger: spy }));
+  steward.collectiveId = 10;
+  await steward._readNeighborhood({ name: 'People' });
+  const warn = spy._lines.warn.find(l => /root page count assertion/.test(l));
+  assert.ok(warn, 'root-count WARN emitted');
+  assert.ok(/found 2/.test(warn), 'reports the count');
+  assert.ok(/"Landing"/.test(warn) && /"Stray Root"/.test(warn), 'names the stray pages');
+});
+
+asyncTest('#256: exactly one root page emits no WARN', async () => {
+  const spy = makeSpyLogger();
+  const client = makeMoverClient();
+  client.listPages = async () => ([
+    { id: 1, title: 'Landing', parentId: 0 },
+    { id: 3, title: 'People', parentId: 1 },
+  ]);
+  const steward = new WikiSteward(makeDeps({ collectivesClient: client, logger: spy }));
+  steward.collectiveId = 10;
+  await steward._readNeighborhood({ name: 'People' });
+  assert.ok(!spy._lines.warn.some(l => /root page count assertion/.test(l)), 'no WARN when exactly one root');
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -3059,6 +3059,13 @@ async function shutdown(signal) {
     console.log('[SHUTDOWN] Audit logs flushed');
   }
 
+  // Flush WikiSteward durable state (visit stamps + lens rings, #246) so the
+  // next boot resumes rotation instead of treating every cluster as neglected.
+  if (heartbeatManager && heartbeatManager.wikiSteward && heartbeatManager.wikiSteward.flush) {
+    heartbeatManager.wikiSteward.flush();
+    console.log('[SHUTDOWN] WikiSteward state flushed');
+  }
+
   // Drain Talk queue before discarding credentials
   if (talkQueue) {
     await talkQueue.shutdown();


### PR DESCRIPTION
Implements #245, #246, and files+implements the two PR #250 premortem guards (#255, #256). All four flow through existing WikiSteward chokepoints — no new scheduler, no new structural check. Net: one memory-lens sub-loop, one executor, one persistence block, two guard lines.

## #245 — Compost mover (the decomposer, not a Sleep Cycle)
A fourth Memory-lens intervention in `_intervene`. Its candidates come from the neighborhood's own frontmatter (a flag and a date — lifecycle bookkeeping, not an LLM judgement), not `assessment.compost`. A page moves to `Archive/` when ALL hold: `compost_ready`, `compost_marked_at` 7+ days old (the human veto window; the KnowledgeBoard card already fired at marking time), not already `archived`, not structural, not pinned (`compost: never`). Capped at 3 moves/visit.

`_moveToArchive`: Collectives has no re-parent primitive, so the move is create-in-`Archive` (via the existing `ensureSection`/`createPage`) then trash-original — the page is never absent at any instant; NC versioning plus the Archive copy are the only undo, no delete path. On a leaf-title collision the body is always written to the suffixed page rather than discarded (a duplicate title is the worst case, never lost content). Archived copies are pinned `compost: never` so `Archive/` stays out of tend churn.

## #246 — Durable steward state
`_lastVisit` and the per-cluster lens ring persist to `data/wiki-steward-state.json`, modeled on `model-scorecard.js` (atomic tmp+rename, debounced `unref()`'d write, loaded at construction, corrupt/missing starts fresh). `flush()` wired into the shutdown drain. `_zeroPageStreak` stays ephemeral by design (a diagnostic streak correctly resets on restart).

## #255 — Link-integrity counter
`gaps_logged` / `dead_links_written` threaded into `_addWikilink`, logged once per connection tend. `dead_links_written` is 0 by construction today; the counter sits at the write site independent of the gap early-return, so a future bypass of the gap branch increments it — the standing regression signal (WARN when > 0).

## #256 — Root-count assertion
`_readNeighborhood` asserts exactly one root page (`parentId == 0`) per tend, riding the `listPages` read it already makes, and WARNs naming the strays when violated. Observes only; humans act.

## Tests
20 new unit tests (mover eligibility matrix with each condition individually blocking, cap-3, structural/pinned exemptions, collision content-preservation, unresolvable-path stub handling, persistence round-trip incl. corrupt-file fresh start, link counter, root-count WARN). Full suite: **233/233 test files green**, lint 0 errors.

Adversarially reviewed; the reviewer caught a content-loss risk in an earlier collision branch (blind trash-both) — fixed to always preserve the body, with two regression tests added.

## Verification — Layer 1 done; Layer 2 (production) pending post-merge deploy
Layer 2 rides the post-merge deploy of `next`. Procedure to capture and close the four issues:
- **Mover:** backdate `compost_marked_at` to 8 days ago on ONE disposable page (`Compost Fixture (delete me)`), `compost_ready: true`. Observe the next Memory-lens visit: intervention line, page under `Archive/` with `archived: true`, absent from prior section, moves-this-visit ≤ 3. (Backdated fixture; no KnowledgeBoard card exists because the card fires at organic marking time.) Trash the fixture after capture.
- **Persistence:** restart the service once; journal shows the state file loaded; first post-restart tend does not treat all clusters as maximally neglected; lens rings continue rotation (cite ring position pre/post).
- **Guards:** one organic tend's `links: gaps_logged=N dead_links_written=0` line; the root-count line (count=1, no WARN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
