### PR TITLE
fix(llm): golden-set probe stops competing with serving on large rosters (#260)

### DIFF
--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -150,6 +150,15 @@ class HeartbeatManager {
     // NicheAssignment (optional, Layer 3): /api/ps snapshot + replan each
     // pulse. A thunk, not an instance — it is constructed asynchronously
     // (after ModelScout discovery), possibly after this manager.
+    // GoldenSetProbe (optional, #260): a thunk, like getNicheAssignment — the
+    // probe is constructed inside the async ModelScout discovery block, after
+    // this manager. The idle branch drains one unmeasured classification
+    // candidate per pulse so calibration converges in downtime instead of
+    // competing with serving at boot.
+    this.getGoldenSetProbe = typeof config.getGoldenSetProbe === 'function'
+      ? config.getGoldenSetProbe
+      : null;
+
     this.getNicheAssignment = typeof config.getNicheAssignment === 'function'
       ? config.getNicheAssignment
       : null;
@@ -593,6 +602,34 @@ class HeartbeatManager {
             results.errors.push({ component: 'localJudge', error: err.message });
           }
         }
+
+        // GoldenSetProbe idle lane (#260): the boot probe measures only up to
+        // its early-exit winner; the candidates it skipped (and any whose boot
+        // measurement was incomplete) are drained here, one per idle pulse, so
+        // classification calibration never competes with serving at boot. This
+        // is informational only — it warms the probe's cache for the next
+        // boot's early exit and the maturation loop's seedFromProbe; it never
+        // reseats (that is the probe's boot select() and the maturation loop's
+        // authority). One candidate per pulse keeps a cold load off the GPU
+        // during the same window the judge grades in.
+        const probe = this.getGoldenSetProbe ? this.getGoldenSetProbe() : null;
+        if (probe && typeof probe.getUnmeasuredCandidates === 'function') {
+          try {
+            const unmeasured = probe.getUnmeasuredCandidates();
+            if (unmeasured.length > 0) {
+              const r = await probe.measureOne(unmeasured[0]);
+              if (r && r.measured) {
+                console.log(`[Heartbeat] Probe idle measurement: ${r.name} (${Object.entries(r.scores || {}).map(([l, s]) => `${l} ${s}`).join(' ')}); ${unmeasured.length - 1} candidate(s) remain`);
+              } else {
+                console.log(`[Heartbeat] Probe idle measurement: ${r?.name || unmeasured[0].name} incomplete (${r?.reason || 'unknown'}); will retry next idle pulse`);
+              }
+            }
+          } catch (err) {
+            console.warn('[Heartbeat] Probe idle measurement error:', err.message);
+            results.errors.push({ component: 'goldenSetProbe', error: err.message });
+          }
+        }
+
         this.state.lastRun = new Date();
         // Restore status to ready even during quiet hours (prevents status going stale)
         await this.statusIndicator?.setStatus('ready', { force: true });

--- a/src/lib/llm/golden-set-probe.js
+++ b/src/lib/llm/golden-set-probe.js
@@ -91,6 +91,11 @@ class GoldenSetProbe {
     // bar by at least one fixture example's worth of accuracy, or the incumbent
     // itself drops below the bar.
     this._incumbent = null;
+
+    // The candidate list from the most recent run(), retained so the heartbeat
+    // idle lane can drain the models run()'s early exit skipped without
+    // re-deriving the list (#260). getUnmeasuredCandidates() defaults to it.
+    this._lastCandidates = [];
   }
 
   /**
@@ -118,6 +123,7 @@ class GoldenSetProbe {
    */
   async run(candidates) {
     const list = Array.isArray(candidates) ? candidates.filter(c => c && typeof c.name === 'string') : [];
+    this._lastCandidates = list;
     if (list.length === 0) {
       return this.select(list);
     }
@@ -136,54 +142,48 @@ class GoldenSetProbe {
       this._incumbent = diskCache[SELECTION_KEY].model;
     }
 
+    // Early exit (#260): candidates are smallest-first, and no model larger
+    // than the smallest passer can win the seat (smallest-passer preference).
+    // Once a passer is measured — and the incumbent's scores are in hand for
+    // the hysteresis defense — the rest of the list is pure cost (a cold 30B+
+    // load on a large roster) and is deferred to the heartbeat idle lane via
+    // getUnmeasuredCandidates()/measureOne() rather than loaded at boot. When
+    // the incumbent is smaller than the first passer it is already measured by
+    // the time we reach the passer; when it is larger, the loop runs on (a
+    // warm cache hit in the common case) until the incumbent is measured, then
+    // stops. Larger-than-both candidates are never touched.
+    const incumbentInList = !!this._incumbent && list.some(c => c.name === this._incumbent);
+    let passerSeen = false;
+    let incumbentSettled = !incumbentInList;
+
     for (const candidate of list) {
       const key = this._cacheKey(candidate);
+      if (candidate.name === this._incumbent) incumbentSettled = true;
+
       const cached = diskCache[key];
       if (cached && cached.scores) {
         this._scores[key] = cached.scores;
-        continue;
-      }
-
-      const scores = {};
-      let complete = true;
-      for (const [lang, items] of Object.entries(this.fixture.languages)) {
-        const examples = Array.isArray(items) ? items : [];
-        let correct = 0;
-        let errored = 0;
-        for (const item of examples) {
-          try {
-            // Sequential by design: one Ollama model can't usefully serve
-            // concurrent classify calls at boot.
-            const predicted = await this.classifyFn(candidate.name, item.message, lang);
-            if (predicted && predicted.gate === item.gate &&
-                (item.domain === null || predicted.domain === item.domain)) {
-              correct++;
-            }
-          } catch (err) {
-            errored++;
-            this.logger.warn(`[GoldenSetProbe] classifyFn failed for ${candidate.name}/${lang}#${item.id}: ${err.message}`);
-          }
-        }
-        // Any classify error means this language was not fully measured — a
-        // distorted (deflated) accuracy, typically because Ollama is cold or
-        // down at boot (MEMORY #124: qwen3:8b cold-start can exceed 60s). A
-        // deflated score must NOT be cached as authoritative, or the digest+
-        // version key would hit forever and the probe would serve poisoned
-        // zeros until someone deletes the cache file by hand.
-        if (errored > 0) complete = false;
-        scores[lang] = examples.length > 0 ? correct / examples.length : 0;
-      }
-
-      if (complete) {
-        diskCache[key] = { scores, at: new Date().toISOString() };
-        this._scores[key] = scores;
-        cacheChanged = true;
       } else {
-        // Incomplete measurement: neither persist nor trust it. Leaving it out
-        // of _scores means select() treats this model as unmeasured (not a
-        // passer, not a poisoned failer), and the next boot retries it.
-        this.logger.warn(`[GoldenSetProbe] ${candidate.name}: measurement incomplete (Ollama cold/unavailable?); not caching, will retry next boot.`);
+        const { scores, complete } = await this._measureCandidate(candidate);
+        if (complete) {
+          diskCache[key] = { scores, at: new Date().toISOString() };
+          this._scores[key] = scores;
+          cacheChanged = true;
+        } else {
+          // Incomplete measurement (Ollama cold/unavailable): neither persist
+          // nor trust it. Left out of _scores, select() treats this model as
+          // unmeasured (not a passer, not a poisoned failer). It is NOT retried
+          // inline next boot — that retries into the same contention (#260) —
+          // but drained by the heartbeat idle lane instead.
+          this.logger.warn(`[GoldenSetProbe] ${candidate.name}: measurement incomplete (Ollama cold/unavailable?); not caching, deferring to the heartbeat idle lane.`);
+        }
       }
+
+      // Stop as soon as selection is fully determined: a passer is in hand and
+      // the incumbent (if any) has been measured for its seat defense. Nothing
+      // further down the smallest-first list can change select()'s outcome.
+      if (this._passesAllScores(this._scores[key] || {})) passerSeen = true;
+      if (passerSeen && incumbentSettled) break;
     }
 
     const result = this.select(list);
@@ -246,7 +246,7 @@ class GoldenSetProbe {
       const key = this._cacheKey(candidate);
       const scores = this._scores[key] || {};
       const langScores = languages.map(lang => (Number.isFinite(scores[lang]) ? scores[lang] : 0));
-      const passesAll = languages.length > 0 && langScores.every(s => s >= threshold);
+      const passesAll = this._passesAllScores(scores);
       const minScore = langScores.length > 0 ? Math.min(...langScores) : 0;
       return { candidate, scores, passesAll, minScore };
     });
@@ -334,9 +334,116 @@ class GoldenSetProbe {
     return counts;
   }
 
+  /**
+   * The subset of `candidates` with no complete cached score: those run()'s
+   * early exit never reached, plus any whose boot measurement was incomplete
+   * (Ollama cold). The heartbeat idle lane drains this one candidate per pulse
+   * so calibration converges in downtime instead of competing with serving at
+   * boot (#260). Consults the on-disk cache, not just this run's in-memory
+   * _scores, so a candidate measured on a prior boot is not re-measured.
+   * @param {Array<{name: string, digest?: string}>} [candidates] defaults to
+   *   the most recent run()'s list.
+   * @returns {Array} unmeasured candidates, input order (smallest-first) preserved.
+   */
+  getUnmeasuredCandidates(candidates) {
+    const source = Array.isArray(candidates) ? candidates : this._lastCandidates;
+    const list = (source || []).filter(c => c && typeof c.name === 'string');
+    if (list.length === 0) return [];
+    const diskCache = this._loadCache();
+    return list.filter(c => {
+      const key = this._cacheKey(c);
+      if (this._scores[key]) return false;
+      const cached = diskCache[key];
+      return !(cached && cached.scores);
+    });
+  }
+
+  /**
+   * Measure a single candidate (all languages) and persist a complete result —
+   * the same measurement run() does per candidate, but seat-neutral: it never
+   * calls select() or moves the ground-truth override. It only warms the cache
+   * so a later boot's early-exit check has a hit and the maturation loop's
+   * seedFromProbe sees a richer measurement set (#260). The heartbeat idle lane
+   * calls this one candidate per pulse. An incomplete measurement is not cached
+   * and stays in getUnmeasuredCandidates() for the next idle pulse to retry.
+   * @param {{name: string, digest?: string}} candidate
+   * @returns {Promise<{name: string|null, measured: boolean, complete: boolean, scores: Object|null, reason?: string}>}
+   */
+  async measureOne(candidate) {
+    if (!candidate || typeof candidate.name !== 'string') {
+      return { name: null, measured: false, complete: false, scores: null, reason: 'invalid candidate' };
+    }
+    if (!this.classifyFn || !this.fixture || !this.fixture.languages) {
+      return { name: candidate.name, measured: false, complete: false, scores: null, reason: 'no classifyFn/fixture' };
+    }
+    const { scores, complete } = await this._measureCandidate(candidate);
+    if (!complete) {
+      return { name: candidate.name, measured: false, complete: false, scores, reason: 'incomplete' };
+    }
+    // Load-modify-save so a concurrent seat write (SELECTION_KEY) or another
+    // candidate's cached score is preserved — this runs long after run()'s save.
+    const diskCache = this._loadCache();
+    diskCache[this._cacheKey(candidate)] = { scores, at: new Date().toISOString() };
+    this._saveCache(diskCache);
+    this._scores[this._cacheKey(candidate)] = scores;
+    return { name: candidate.name, measured: true, complete: true, scores };
+  }
+
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------
+
+  /**
+   * @private
+   * Replay every fixture example for one candidate through classifyFn and score
+   * per language. Sequential by design: one Ollama model can't usefully serve
+   * concurrent classify calls at boot. `complete` is false if ANY classify call
+   * errored — the language was not fully measured, so its accuracy is deflated
+   * (typically Ollama cold; MEMORY #124: qwen3:8b cold-start can exceed 60s) and
+   * MUST NOT be cached as authoritative, or the digest+version key would hit
+   * forever and the probe would serve poisoned zeros until the cache is deleted
+   * by hand. Shared by run() (boot) and measureOne() (idle lane).
+   * @param {{name: string}} candidate
+   * @returns {Promise<{scores: Object<string, number>, complete: boolean}>}
+   */
+  async _measureCandidate(candidate) {
+    const scores = {};
+    let complete = true;
+    for (const [lang, items] of Object.entries(this.fixture.languages)) {
+      const examples = Array.isArray(items) ? items : [];
+      let correct = 0;
+      let errored = 0;
+      for (const item of examples) {
+        try {
+          const predicted = await this.classifyFn(candidate.name, item.message, lang);
+          if (predicted && predicted.gate === item.gate &&
+              (item.domain === null || predicted.domain === item.domain)) {
+            correct++;
+          }
+        } catch (err) {
+          errored++;
+          this.logger.warn(`[GoldenSetProbe] classifyFn failed for ${candidate.name}/${lang}#${item.id}: ${err.message}`);
+        }
+      }
+      if (errored > 0) complete = false;
+      scores[lang] = examples.length > 0 ? correct / examples.length : 0;
+    }
+    return { scores, complete };
+  }
+
+  /**
+   * @private
+   * Whether a per-language score map clears the threshold in EVERY fixture
+   * language. A missing/non-finite language counts as 0 (unmeasured is not a
+   * pass). Empty fixture → never passes. The single definition of "passes",
+   * shared by run()'s early-exit check and select().
+   */
+  _passesAllScores(scores) {
+    const languages = Object.keys((this.fixture && this.fixture.languages) || {});
+    if (languages.length === 0) return false;
+    const threshold = this._threshold();
+    return languages.every(lang => (Number.isFinite(scores[lang]) ? scores[lang] : 0) >= threshold);
+  }
 
   /** @private */
   _threshold() {

--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -71,6 +71,22 @@ const CONTEXT_FLOOR = Object.freeze({
  */
 const JUDGE_CONTEXT_FLOOR = 8192;
 
+/**
+ * Parameter-size ceiling (in billions) for golden-set classification
+ * candidates (#260). Classification is a latency job with a 12-example/language
+ * fixture; a model larger than this is already far past what the task demands,
+ * and loading a 30B+ code-specialist just to measure it evicts the serving
+ * model on a single-GPU box and can starve a live request for minutes. A 34B
+ * seat is never the right classification pick, so walking to it must be
+ * structurally impossible, not merely unlikely. 14 is generous — well above
+ * qwen3:8b, the reference box's classification winner. Models above the ceiling
+ * stay available for every other job (thinking/writing/tools) through the
+ * regular roster; only the probe's candidate walk is bounded. Cloud models
+ * never pass through here, so the ceiling does not touch them.
+ * @type {number}
+ */
+const CLASSIFICATION_PARAM_CEILING = 14;
+
 class ModelScout {
   /**
    * @param {Object} config
@@ -212,9 +228,10 @@ class ModelScout {
    */
   getClassificationCandidates() {
     if (!this._discovered || this._discovered.length === 0) return [];
-    return this._discovered
+    const textGen = this._discovered
       .filter(m => this._isTextGen(m))
-      .sort((a, b) => this._compareSize(a, b))
+      .sort((a, b) => this._compareSize(a, b));
+    return this._paramCeilinged(textGen, CLASSIFICATION_PARAM_CEILING)
       .map(m => ({ name: m.name, paramSize: m.paramSize, digest: m.digest || null }));
   }
 
@@ -393,6 +410,24 @@ class ModelScout {
   }
 
   /**
+   * Apply a parameter-size ceiling (in billions) to an already-sorted model
+   * list (#260). A model whose sensed paramSize exceeds the ceiling is excluded
+   * — UNLESS excluding would empty the list, in which case the ungated list is
+   * returned (never-go-dark: a box of only large models still needs a
+   * classification candidate). A null paramSize PASSES the gate: unknown size
+   * is not evidence of largeness (sense-don't-predict), mirroring _contextGated.
+   * No ceiling (falsy) is an identity pass-through.
+   * @param {Array} sorted - models pre-sorted by the caller's prior
+   * @param {number} [ceiling] - billions of parameters
+   * @returns {Array}
+   */
+  _paramCeilinged(sorted, ceiling) {
+    if (!ceiling) return sorted;
+    const gated = sorted.filter(m => m.paramSize === null || m.paramSize <= ceiling);
+    return gated.length > 0 ? gated : sorted;
+  }
+
+  /**
    * Extract model family from Ollama model metadata.
    * @param {Object} model - Raw Ollama model object
    * @returns {string}
@@ -432,4 +467,4 @@ class ModelScout {
   }
 }
 
-module.exports = { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR, JUDGE_CONTEXT_FLOOR };
+module.exports = { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR, JUDGE_CONTEXT_FLOOR, CLASSIFICATION_PARAM_CEILING };

--- a/test/unit/llm/golden-set-probe.test.js
+++ b/test/unit/llm/golden-set-probe.test.js
@@ -533,6 +533,141 @@ asyncTest('TC-HYST-005: a least-bad (non-passing) pick is not seated as incumben
   }
 });
 
+// ============================================================
+// Early exit + idle-lane migration (#260): run() stops at the first passer
+// (plus a larger incumbent, for the hysteresis defense) and defers the rest
+// to getUnmeasuredCandidates()/measureOne().
+// ============================================================
+
+console.log('\n--- Early exit + idle lane (#260) ---\n');
+
+// Wraps a classifyFn and records every model name it is asked to classify —
+// lets a test assert which candidates run() actually loaded.
+function trackingClassifyFn(inner, seen) {
+  return async (model, message, lang) => {
+    seen.add(model);
+    return inner(model, message, lang);
+  };
+}
+
+asyncTest('TC-EXIT-001: run() stops at the smallest passer — larger candidates are never measured', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const seen = new Set();
+    const probe = new GoldenSetProbe({
+      classifyFn: trackingClassifyFn(perfectClassifyFn(fixture), seen),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'mid', paramSize: 8, digest: 'm1' },
+      { name: 'big', paramSize: 30, digest: 'b1' }
+    ]);
+    assert.strictEqual(result.model, 'small');
+    assert.strictEqual(result.passed, true);
+    assert.deepStrictEqual([...seen], ['small'], 'only the smallest passer is measured; mid/big are deferred');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-EXIT-002: run() still measures a LARGER incumbent so hysteresis can defend the seat', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const seen = new Set();
+    // small passes at the bar (0.75) but not by margin; big (incumbent) is perfect.
+    const probe = new GoldenSetProbe({
+      classifyFn: trackingClassifyFn(accuracyClassifyFn(fixture, { small: 3, big: 4, huge: 4 }), seen),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    probe._incumbent = 'big';
+    const result = await probe.run([
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 8, digest: 'b1' },
+      { name: 'huge', paramSize: 30, digest: 'h1' }
+    ]);
+    // Seat defense needs the incumbent's scores, so 'big' IS measured even
+    // though a smaller passer preceded it; 'huge' (larger than both) is not.
+    assert.ok(seen.has('small') && seen.has('big'), 'small and the larger incumbent big are both measured');
+    assert.ok(!seen.has('huge'), 'nothing larger than the incumbent is measured');
+    assert.strictEqual(result.model, 'big', 'incumbent holds — small did not clear bar+margin');
+    assert.strictEqual(result.reason, 'incumbent holds seat');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-EXIT-003: getUnmeasuredCandidates() lists the skipped candidates; measureOne() drains one', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const seen = new Set();
+    const candidates = [
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'mid', paramSize: 8, digest: 'm1' },
+      { name: 'big', paramSize: 30, digest: 'b1' }
+    ];
+    const probe = new GoldenSetProbe({
+      classifyFn: trackingClassifyFn(perfectClassifyFn(fixture), seen),
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    await probe.run(candidates);
+
+    // The two the early exit skipped are unmeasured (defaults to run()'s list).
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['mid', 'big']);
+
+    const r = await probe.measureOne({ name: 'mid', paramSize: 8, digest: 'm1' });
+    assert.strictEqual(r.measured, true);
+    assert.strictEqual(r.complete, true);
+    assert.strictEqual(r.scores.EN, 1);
+    // measureOne is seat-neutral — it must not touch the selection state.
+    const persisted = JSON.parse(fs.readFileSync(path.join(cacheDir, 'golden-set-probe.json'), 'utf8'));
+    assert.strictEqual(persisted.__selection__.model, 'small', 'measureOne must not reseat');
+
+    // mid is now measured; only big remains unmeasured.
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['big']);
+
+    // A fresh probe over the same cacheDir sees the persisted measurements on disk.
+    const probe2 = new GoldenSetProbe({ classifyFn: perfectClassifyFn(fixture), fixture, cacheDir, logger: silentLogger });
+    assert.deepStrictEqual(probe2.getUnmeasuredCandidates(candidates).map(c => c.name), ['big'], 'disk cache, not just in-memory, gates re-measurement');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-EXIT-004: measureOne() does not cache an incomplete (cold-Ollama) measurement', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const probe = new GoldenSetProbe({
+      classifyFn: async () => { throw new Error('Ollama request timed out'); },
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const r = await probe.measureOne({ name: 'cold', paramSize: 8, digest: 'c1' });
+    assert.strictEqual(r.measured, false);
+    assert.strictEqual(r.complete, false);
+    assert.strictEqual(r.reason, 'incomplete');
+    // Not persisted → still unmeasured, so the next idle pulse retries it.
+    assert.deepStrictEqual(
+      probe.getUnmeasuredCandidates([{ name: 'cold', paramSize: 8, digest: 'c1' }]).map(c => c.name),
+      ['cold']
+    );
+    assert.strictEqual(fs.existsSync(path.join(cacheDir, 'golden-set-probe.json')), false, 'no cache file written for an incomplete measurement');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
 // Summary
 setTimeout(() => {
   summary();

--- a/test/unit/providers/model-scout.test.js
+++ b/test/unit/providers/model-scout.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
-const { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR } = require('../../../src/lib/providers/model-scout');
+const { ModelScout, PRIOR_STRENGTH, CONTEXT_FLOOR, CLASSIFICATION_PARAM_CEILING } = require('../../../src/lib/providers/model-scout');
 
 // A realistic mixed pool: two tool-capable chat models of different sizes, a
 // small text-only chat model, an embedding model, and a vision model.
@@ -376,6 +376,57 @@ scenario('getModelInfo() returns the sensed descriptor by exact name; rosterFor(
     scout.generateLocalRoster();
     const writing = scout.rosterFor('writing');
     assert.ok(writing.length > 0 && writing[0] === 'qwen3:8b', 'largest-first chain for writing');
+  });
+});
+
+// -- getClassificationCandidates() applies the paramSize ceiling (#260) --
+
+// A pool with a code-specialist far above the classification ceiling, a text
+// model of unknown size (no parameter_size, unparseable name), and two small
+// text models. The probe should never be handed the 34B model.
+const CEILING_TAGS = [
+  { name: 'codellama:34b', model: 'codellama:34b', size: 19000000000, details: { family: 'llama', parameter_size: '34B', format: 'gguf' } },
+  { name: 'mystery-tune', model: 'mystery-tune', size: 6000000000, details: { family: 'llama', format: 'gguf' } },
+  { name: 'qwen2.5:3b', model: 'qwen2.5:3b', size: 2000000000, details: { family: 'qwen2', parameter_size: '3.1B', format: 'gguf' } },
+  { name: 'gemma2:2b', model: 'gemma2:2b', size: 1600000000, details: { family: 'gemma2', parameter_size: '2.6B', format: 'gguf' } }
+];
+const CEILING_SHOW = {
+  'codellama:34b': { capabilities: ['completion'], model_info: { 'llama.context_length': 16384 } },
+  'mystery-tune': { capabilities: ['completion'], model_info: { 'llama.context_length': 8192 } },
+  'qwen2.5:3b': { capabilities: ['completion', 'tools'], model_info: { 'qwen2.context_length': 32768 } },
+  'gemma2:2b': { capabilities: ['completion'], model_info: { 'gemma2.context_length': 8192 } }
+};
+
+scenario('getClassificationCandidates() excludes models above the paramSize ceiling; null size passes', async () => {
+  await withMock(mockFetch(CEILING_TAGS, CEILING_SHOW), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const names = scout.getClassificationCandidates().map(c => c.name);
+    assert.ok(!names.includes('codellama:34b'), `34B model must be excluded (ceiling ${CLASSIFICATION_PARAM_CEILING}B): got ${names.join(',')}`);
+    // Unknown size is not evidence of largeness — it passes (sense-don't-predict).
+    assert.ok(names.includes('mystery-tune'), 'null-paramSize model must pass the ceiling');
+    // Smallest-first ordering is preserved among the survivors (a null
+    // paramSize sorts as 0, i.e. first — unchanged _compareSize behavior).
+    assert.deepStrictEqual(names, ['mystery-tune', 'gemma2:2b', 'qwen2.5:3b']);
+  });
+});
+
+scenario('getClassificationCandidates() never goes dark — an all-large pool falls back ungated', async () => {
+  const bigTags = [
+    { name: 'codellama:34b', model: 'codellama:34b', size: 19000000000, details: { family: 'llama', parameter_size: '34B', format: 'gguf' } },
+    { name: 'qwen3:30b', model: 'qwen3:30b', size: 18000000000, details: { family: 'qwen3', parameter_size: '30B', format: 'gguf' } }
+  ];
+  const bigShow = {
+    'codellama:34b': { capabilities: ['completion'], model_info: { 'llama.context_length': 16384 } },
+    'qwen3:30b': { capabilities: ['completion'], model_info: { 'qwen3.context_length': 40960 } }
+  };
+  await withMock(mockFetch(bigTags, bigShow), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const names = scout.getClassificationCandidates().map(c => c.name);
+    // Every model is above the ceiling, but returning [] would leave the probe
+    // with nothing to measure — fall back to the ungated (smallest-first) list.
+    assert.deepStrictEqual(names, ['qwen3:30b', 'codellama:34b']);
   });
 });
 

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -525,6 +525,7 @@ let modelScorecard = null; // Maturation loop: per-(job, model, language) scores
 let judgeQueue = null; // Session 4: bounded judge-then-delete retention of judged-job samples
 let localJudge = null; // Session 4: heartbeat-idle grader for writing/thinking
 let nicheAssignment = null; // Session 5 (Layer 3): carrying-capacity plan over the winners
+let goldenSetProbe = null; // #260: retained so the heartbeat idle lane drains the candidates run()'s early exit skipped
 
 // Residency-signal sink for every local Ollama adapter (both families).
 // Late-bound: no-ops until NicheAssignment is constructed after discovery,
@@ -2183,6 +2184,10 @@ async function initialize() {
               cacheDir: path.join(__dirname, 'data'),
               logger: console,
             });
+            // Retain the instance so the heartbeat idle lane can drain the
+            // candidates run()'s early exit skipped (#260). Same probe, same
+            // cache; the thunk into HeartbeatManager mirrors getNicheAssignment.
+            goldenSetProbe = probe;
             const clsCandidates = modelScout.getClassificationCandidates();
             probe.run(clsCandidates)
               .then(async sel => {
@@ -2646,6 +2651,10 @@ async function initialize() {
         // ModelScout discovery, possibly after this manager. The sink keeps
         // timing capture alive across heartbeat roster rebuilds.
         getNicheAssignment: () => nicheAssignment,
+        // #260: same thunk pattern — the golden-set probe is constructed inside
+        // the async ModelScout discovery block, after this manager. The idle
+        // lane drains its unmeasured candidates one per pulse.
+        getGoldenSetProbe: () => goldenSetProbe,
         onOllamaTimings: ollamaTimingsSink,
         dailyBriefing,
         reviewUser: appConfig.cockpit?.adminUser || appConfig.knowledge?.adminUser || '',


### PR DESCRIPTION
Closes #260.

## Problem

On a large roster (18 Ollama models, incl. 30B+, single GPU) the boot-time golden-set probe walks the full smallest-first candidate list, loading every model to measure classification accuracy. That evicts the serving model, starves live requests for minutes, and — because incomplete measurements are (correctly) not cached — retries the same storm every restart. It's the same category of background self-measurement the JudgeQueue already confines to the heartbeat idle window; the probe did it as boot-time bulk instead.

## Fix (three independently-correct changes)

**A. Early exit in `run()`** — candidates are smallest-first and no model larger than the smallest passer can win the seat, so the loop stops once a passer is in hand. It runs on only far enough to also measure a *larger* incumbent when one exists, so the #232 hysteresis seat-defense still has the incumbent's scores; nothing larger than both is ever loaded. On a healthy box the probe collapses to measuring one model. Per-candidate measurement is extracted to `_measureCandidate()` (shared with the idle lane) and the pass check unified into `_passesAllScores()`.

**B. Idle-lane migration** — `getUnmeasuredCandidates()` reports the candidates the early exit skipped or that measured incomplete; `measureOne()` measures one, **seat-neutral** (never selects or reseats), warming the cache for the next boot's early exit and the maturation loop's `seedFromProbe`. The heartbeat's outside-active-hours branch drains one candidate per pulse, alongside the local judge. The probe instance travels via a `getGoldenSetProbe()` thunk — the same pattern as `getNicheAssignment`. Deletes the boot storm and the retry-on-incomplete loop together.

**C. Classification candidacy ceiling** — a `paramSize` ceiling (14B, well above the reference box's qwen3:8b winner) excludes oversized code-specialists from `getClassificationCandidates()` via `_paramCeilinged()`, mirroring the existing `_contextGated()` (null size passes; never-go-dark on an all-large pool). A 34B classification seat is now structurally impossible, not merely unlikely. Models above the ceiling stay available for every other job through the regular roster.

> Note: `paramSize` in this codebase is **billions** (8 for 8B), so the ceiling is `14`, not the `14e9` the briefing suggested (the briefing assumed raw parameter counts).

## What this does NOT change

No Ollama-level scheduler, no pre-warm, no tool-capability-probe change, no maturation-loop/scorecard change. The idle-lane measurement feeds the probe's cache, not the scorecard directly.

## Tests

- `golden-set-probe` 17→21: early exit stops at smallest passer; larger incumbent still measured (hysteresis preserved); `getUnmeasuredCandidates`/`measureOne` drain + disk-cache gating; incomplete measurement not cached.
- `model-scout` 23→25: ceiling excludes oversized, null size passes, never-go-dark falls back ungated.
- Heartbeat suites green; lint 0 errors.

## Verification Gate — status

Code-level verified (tests/lint/syntax). **Live Prime boot-log + idle-lane + NC MCP verification is a post-merge deploy step** (Prime runs `/opt/moltagent` on `next`; the fix live-gates after merge, matching the project's established live-gating pattern). The 18-model contention itself reproduces only on the beta deployer's box, not on Prime — Prime verification confirms correctness, the beta deployer's next pull is the field test.

Also posted the requested adjacent observation on #232 (n=1/0.000 first-seat window in the maturation loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
