### PR TITLE
fix(llm): fence golden-set probe idle lane out of the boot run() cache write (#260)

### DIFF
--- a/src/lib/llm/golden-set-probe.js
+++ b/src/lib/llm/golden-set-probe.js
@@ -96,6 +96,13 @@ class GoldenSetProbe {
     // idle lane can drain the models run()'s early exit skipped without
     // re-deriving the list (#260). getUnmeasuredCandidates() defaults to it.
     this._lastCandidates = [];
+
+    // True only while run()'s measurement loop + final cache save are in flight.
+    // The idle lane (getUnmeasuredCandidates) no-ops while set, so a nighttime
+    // restart's fire-and-forget boot run() and the heartbeat idle pulse never
+    // interleave their cache writes (#260). run() knows the full skip set only
+    // once it has finished anyway, so waiting costs nothing.
+    this._running = false;
   }
 
   /**
@@ -131,6 +138,12 @@ class GoldenSetProbe {
       this.logger.warn('[GoldenSetProbe] Missing classifyFn or fixture; skipping probe.');
       return this.select(list);
     }
+
+    // Fence the idle lane out until this measurement pass has persisted its
+    // result (#260). Cleared before the single return below; the only awaited
+    // call past this point (_measureCandidate) catches its own errors, so the
+    // flag always clears.
+    this._running = true;
 
     const diskCache = this._loadCache();
     let cacheChanged = false;
@@ -212,6 +225,7 @@ class GoldenSetProbe {
         `models classify ${weak.join('/') || 'one or more languages'} poorly.`
       );
     }
+    this._running = false;
     return result;
   }
 
@@ -346,6 +360,9 @@ class GoldenSetProbe {
    * @returns {Array} unmeasured candidates, input order (smallest-first) preserved.
    */
   getUnmeasuredCandidates(candidates) {
+    // While the boot run() is still measuring, the skip set isn't final and its
+    // cache save is pending — don't let the idle lane act on a moving target (#260).
+    if (this._running) return [];
     const source = Array.isArray(candidates) ? candidates : this._lastCandidates;
     const list = (source || []).filter(c => c && typeof c.name === 'string');
     if (list.length === 0) return [];

--- a/test/unit/llm/golden-set-probe.test.js
+++ b/test/unit/llm/golden-set-probe.test.js
@@ -668,6 +668,41 @@ asyncTest('TC-EXIT-004: measureOne() does not cache an incomplete (cold-Ollama) 
   }
 });
 
+asyncTest('TC-EXIT-005: idle lane is fenced out while a boot run() is in flight', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const candidates = [
+      { name: 'small', paramSize: 2, digest: 's1' },
+      { name: 'big', paramSize: 30, digest: 'b1' }
+    ];
+    // Gate the classify call on a promise we control, so run() is provably
+    // mid-measurement when we probe the idle-lane accessor.
+    let release;
+    const gate = new Promise(res => { release = res; });
+    let gateUsed = false;
+    const probe = new GoldenSetProbe({
+      classifyFn: async (model, message, lang) => {
+        if (!gateUsed) { gateUsed = true; await gate; }
+        return perfectClassifyFn(fixture)(model, message, lang);
+      },
+      fixture,
+      cacheDir,
+      logger: silentLogger
+    });
+    const running = probe.run(candidates);
+    // Yield so run() reaches its first (gated) classify call.
+    await Promise.resolve();
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates(candidates), [], 'idle lane must no-op while run() is measuring');
+    release();
+    await running;
+    // After run() completes the fence lifts and the skipped candidate surfaces.
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['big']);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
 // Summary
 setTimeout(() => {
   summary();


### PR DESCRIPTION
Follow-up to #261 (merged as `3b490b6`), addressing the one substantive finding from the post-implementation review.

## The race

The idle-lane migration in #261 has a narrow write race on a **nighttime restart**: the heartbeat's outside-active-hours branch can fire while the fire-and-forget boot `probe.run()` is still measuring. `getUnmeasuredCandidates()` returns candidates as soon as `run()` sets `_lastCandidates` (top of the method), so `measureOne()`'s independent load-modify-save can interleave with `run()`'s final cache save and drop the idle measurement.

Low severity and self-healing (the dropped candidate is re-measured the next idle pulse, and the seat is recomputed on the next boot regardless) — but a real interleaving, and the `measureOne` comment overstated the guarantee since `run()`'s own final persist is a snapshot overwrite, not load-modify-save.

## Fix

An in-flight fence: `run()` sets `_running` for the span of its measurement loop + final save, and `getUnmeasuredCandidates()` no-ops while it is set. `run()` only knows the full early-exit skip set once it has finished anyway, so the idle lane loses nothing by waiting one pulse. The only awaited call past the fence (`_measureCandidate`) catches its own errors, so the flag always clears (no try/finally needed, no stuck-flag path).

4 lines of logic + a comment; no re-indent.

## Test

`TC-EXIT-005` gates a classify call on a controlled promise to hold `run()` provably mid-measurement, asserts the idle lane sees an empty set until `run()` completes, then confirms the skipped candidate surfaces. golden-set-probe 21→22; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
