### PR TITLE
chore(policy): one reader for the write class; delete the policy that lies (#217)

### DIFF
--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -2,6 +2,7 @@
 
 const { classifyConfirmationReply } = require('../shared/confirmation-classifier');
 const { PendingActionStore } = require('../pending-action-store');
+const { REQUIRES_APPROVAL } = require('../../security/guards/tool-guard');
 
 /**
  * GuardrailEnforcer - Runtime Guardrail Enforcement
@@ -86,36 +87,31 @@ const KEYWORD_FALLBACK_MAP = {
 const MATCH_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const SEMANTIC_TIMEOUT_MS = 30000; // 30s — classification needs headroom
 
-// Severity classification for ToolGuard APPROVAL_REQUIRED tools
+// Severity classification for ToolGuard APPROVAL_REQUIRED tools. Every name is a
+// registered tool: seven that no tool registered (send_email, execute_shell, …)
+// were removed — they classified nothing.
 const HIGH_SEVERITY_TOOLS = new Set([
-  'send_email', 'send_message_external', 'webhook_call',
-  'execute_shell', 'run_command',
-  'notification_send', 'external_api_call',
   'file_share', 'deck_share_board',
   'calendar_cancel_meeting',
 ]);
 
 const TOOL_APPROVAL_LABELS = {
-  deck_delete_card:     'Delete Deck card',
-  file_delete:          'Delete file',
-  delete_file:          'Delete file',
-  delete_files:         'Delete files',
-  delete_folder:        'Delete folder',
-  file_move:            'Move file',
-  modify_calendar:      'Modify calendar',
-  delete_calendar_event:'Delete calendar event',
-  modify_contacts:      'Modify contacts',
-  send_email:           'Send email',
-  webhook_call:         'Call webhook',
-  execute_shell:        'Execute shell command',
-  run_command:          'Run command',
-  notification_send:    'Send notification',
-  external_api_call:    'External API call',
-  file_share:           'Share file',
-  deck_share_board:     'Share board',
-  access_new_credential:'Access credential',
-  wiki_delete:          'Delete wiki page',
-  calendar_cancel_meeting:  'Cancel meeting',
+  deck_delete_card:        'Delete Deck card',
+  deck_delete_board:       'Delete Deck board',
+  deck_delete_stack:       'Delete Deck stack',
+  deck_setup_workflow:     'Set up Deck workflow',
+  deck_share_board:        'Share board',
+  file_delete:             'Delete file',
+  file_move:               'Move file',
+  file_write:              'Write file',
+  file_share:              'Share file',
+  calendar_create_event:   'Create calendar event',
+  calendar_update_event:   'Update calendar event',
+  calendar_delete_event:   'Delete calendar event',
+  calendar_cancel_meeting: 'Cancel meeting',
+  wiki_write:              'Write wiki page',
+  wiki_delete:             'Delete wiki page',
+  mail_send:               'Send email',
 };
 
 // #107: the approval prompt renders the arguments the tool actually registered.
@@ -147,6 +143,33 @@ const PENDING_ACTION_TYPE = 'offered-work';
 // Talk surface (U+1F510, "closed lock with key"). Any other component emitting
 // this codepoint in a chat response is staging a fake ceremony — see #81.
 const HITL_PROMPT_MARKER = '\u{1F510}';
+
+/**
+ * The write class: every tool that changes something outside this process —
+ * deletes, shares, sends, or writes. The one place in the codebase that answers
+ * "what is write-class?".
+ *
+ * Policy still has three writer homes (#217): ToolGuard.REQUIRES_APPROVAL for
+ * hardcoded gating, HIGH_SEVERITY_TOOLS for the severity split, and
+ * SENSITIVE_TOOLS for the Cockpit-governed GATE guardrails. Their union is the
+ * write class, and consolidating the homes is Wave 3 work with F1 retirement.
+ * Until then: two writers, ONE reader. A caller that needs the write class calls
+ * this. A caller that re-derives it from the underlying sets becomes the third
+ * derivation site, and the three drift apart the way they already have.
+ *
+ * SENSITIVE_TOOLS matters here and is easy to miss: mail_send, wiki_write and
+ * file_write live only there, so a union of the other two sets silently excludes
+ * email — the exact tool #81's hallucinated ceremony was staged around.
+ *
+ * @returns {Set<string>} tool names, deduplicated
+ */
+function getWriteClassTools() {
+  return new Set([
+    ...REQUIRES_APPROVAL,
+    ...HIGH_SEVERITY_TOOLS,
+    ...SENSITIVE_TOOLS,
+  ]);
+}
 
 class GuardrailEnforcer {
   /**
@@ -1218,4 +1241,11 @@ class GuardrailEnforcer {
   }
 }
 
-module.exports = { GuardrailEnforcer, HIGH_SEVERITY_TOOLS, TOOL_APPROVAL_LABELS, HITL_PROMPT_MARKER };
+module.exports = {
+  GuardrailEnforcer,
+  HIGH_SEVERITY_TOOLS,
+  SENSITIVE_TOOLS,
+  TOOL_APPROVAL_LABELS,
+  HITL_PROMPT_MARKER,
+  getWriteClassTools,
+};

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -337,6 +337,17 @@ class ToolRegistry {
    *   (a cross-cutting helper such as web_search), not a domain of its own.
    * @param {Object} [toolDef.metadata]
    */
+  /**
+   * `writes: true` declares that a tool changes something outside this process —
+   * it deletes, shares, sends, or overwrites. It is the tool's own statement about
+   * itself, independent of any gating policy, and that independence is the point:
+   * the write-class pin cross-checks these declarations against
+   * GuardrailEnforcer.getWriteClassTools(), so a destructive tool registered
+   * without a policy entry fails the suite instead of shipping ungated.
+   *
+   * @param {Object} toolDef
+   * @param {boolean} [toolDef.writes] - true when the tool mutates external state
+   */
   register(toolDef) {
     if (!toolDef.name || !toolDef.handler) {
       throw new Error('Tool definition requires name and handler');
@@ -1041,6 +1052,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_board',
+      writes: true,
       domains: ['deck'],
       description: 'Permanently delete a Deck board and all its stacks and cards. This is irreversible and requires confirmation.',
       parameters: {
@@ -1156,6 +1168,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_stack',
+      writes: true,
       domains: ['deck'],
       description: 'Permanently delete a stack (column) and all its cards from a Deck board. This is irreversible and requires confirmation.',
       parameters: {
@@ -1293,6 +1306,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_card',
+      writes: true,
       domains: ['deck'],
       description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to delete a card on a shared board.',
       parameters: {
@@ -1627,6 +1641,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_share_board',
+      writes: true,
       domains: ['deck'],
       description: 'Share a board you own with another user or group. Requires confirmation.',
       parameters: {
@@ -1855,6 +1870,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_setup_workflow',
+      writes: true,
       domains: ['deck'],
       description: 'Create a new board with a set of named stacks (columns), optionally seed it with cards in the first stack, and optionally share it with a user. Use when asked to set up a workflow or project board with a defined column structure. Requires confirmation.',
       parameters: {
@@ -2031,6 +2047,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_create_event',
+      writes: true,
       domains: ['calendar'],
       description: 'Create a calendar event. Optionally checks availability first (set check_availability: true). Supports attendees with automatic invitation emails. Use duration_minutes OR end to set the event length (default: 60 minutes).',
       parameters: {
@@ -2167,6 +2184,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_update_event',
+      writes: true,
       domains: ['calendar'],
       description: 'Update an existing calendar event. Use to reschedule, rename, change duration, add attendees, or modify any event property.',
       parameters: {
@@ -2275,6 +2293,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_delete_event',
+      writes: true,
       domains: ['calendar'],
       description: 'Delete a calendar event.',
       parameters: {
@@ -2355,6 +2374,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_cancel_meeting',
+      writes: true,
       domains: ['calendar'],
       description: 'Cancel a scheduled meeting and send cancellation notices to all attendees.',
       parameters: {
@@ -2599,6 +2619,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_write',
+      writes: true,
       domains: ['file'],
       description: 'Write content to a file in your Nextcloud workspace. Creates the file if it doesn\'t exist, overwrites if it does.',
       parameters: {
@@ -2686,6 +2707,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_move',
+      writes: true,
       domains: ['file'],
       description: 'Move or rename a file within Nextcloud.',
       parameters: {
@@ -2732,6 +2754,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_delete',
+      writes: true,
       domains: ['file'],
       description: 'Delete a file or folder. Requires confirmation.',
       parameters: {
@@ -2776,6 +2799,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_share',
+      writes: true,
       domains: ['file'],
       description: 'Share a file or folder with a user. Uses NC\'s native sharing. Requires confirmation.',
       parameters: {
@@ -3048,6 +3072,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_write',
+      writes: true,
       domains: ['wiki'],
       description: 'Create or update a page in the Moltagent Knowledge wiki. Content can include YAML frontmatter between --- delimiters. To ADD to an existing page rather than replace it, call wiki_read first, then wiki_write with the merged content.',
       parameters: {
@@ -3361,6 +3386,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_delete',
+      writes: true,
       domains: ['wiki'],
       description: 'Delete (trash) a page from the Moltagent Knowledge wiki. This action cannot be undone.',
       parameters: {
@@ -3993,6 +4019,7 @@ class ToolRegistry {
     if (emailHandler) {
       this.register({
         name: 'mail_send',
+        writes: true,
         domains: ['email'],
         description: 'Send an email. REQUIRES human approval before execution. Provide recipient, subject, and body. The email will be sent via SMTP from the configured Moltagent email account.',
         parameters: {

--- a/src/security/guards/tool-guard.js
+++ b/src/security/guards/tool-guard.js
@@ -11,6 +11,14 @@
 'use strict';
 
 // Hardcoded operation categories (never modifiable at runtime)
+//
+// FORBIDDEN and REQUIRES_APPROVAL have opposite relationships to the registry.
+// FORBIDDEN names operations that must NEVER become tools — it is a denylist,
+// and every name in it is expected to be unregistered forever. REQUIRES_APPROVAL
+// names tools that DO exist and must be gated. A name in REQUIRES_APPROVAL that
+// no tool registers gates nothing; it is a map that lies about the territory.
+// The write-class pin (test/unit/security/write-class-policy.test.js) enforces
+// that asymmetry so the two lists cannot drift back together.
 const FORBIDDEN = [
   // Self-modification (prevents "soul-evil" attacks)
   'modify_system_prompt', 'modify_soul', 'replace_instructions',
@@ -27,29 +35,22 @@ const FORBIDDEN = [
   'access_other_session', 'export_credentials',
 ];
 
-// NOTE(#217): gating policy has two homes (this list + GuardrailEnforcer.SENSITIVE_TOOLS);
-// single-home consolidation tracked for F1 retirement.
+// NOTE(#217): gating policy still has two WRITER homes (this list +
+// GuardrailEnforcer's HIGH_SEVERITY_TOOLS / SENSITIVE_TOOLS). Full single-home
+// consolidation lands in Wave 3 with F1 retirement. In the meantime there is
+// exactly one READER: GuardrailEnforcer.getWriteClassTools(), which computes the
+// union. Nothing else may re-derive "what is write-class?" from these lists.
+//
+// Every name here must be a registered tool. Fourteen names that no tool ever
+// registered (send_email, execute_shell, delete_folder, modify_calendar, …) were
+// removed: they gated nothing and made this list unreadable as policy. Guarding a
+// tool that does not exist belongs in FORBIDDEN, not here.
 const REQUIRES_APPROVAL = [
-  // External communication
-  'send_email', 'send_message_external', 'webhook_call',
-
   // Destructive file operations
-  'delete_file', 'delete_files', 'delete_folder', 'file_delete',
+  'file_delete',
 
-  // Calendar/contact modification
-  'modify_calendar', 'delete_calendar_event', 'calendar_delete_event', 'modify_contacts',
-
-  // Calendar scheduling (sends external invitations/cancellations)
-  'calendar_cancel_meeting',
-
-  // System-level operations
-  'execute_shell', 'run_command',
-
-  // Credential access
-  'access_new_credential',
-
-  // External API calls
-  'external_api_call',
+  // Calendar modification (sends external invitations/cancellations)
+  'calendar_delete_event', 'calendar_cancel_meeting',
 
   // Destructive deck operations
   'deck_delete_card',
@@ -68,10 +69,8 @@ const REQUIRES_APPROVAL = [
   // Sensitive file operations (sharing data)
   'file_share',
 
-  // Phase 2: External communication
-  // mail_send — handled by SOUL.md instruction (LLM must confirm with user before calling)
-  // wiki_write — moved to GuardrailEnforcer SENSITIVE_TOOLS (Cockpit-governed, not hardcoded)
-  'notification_send',    // Pushing notifications — prevent spam
+  // mail_send — Cockpit-governed via GuardrailEnforcer SENSITIVE_TOOLS
+  // wiki_write, file_write, file_move — likewise
 ];
 
 const LOCAL_LLM_ONLY = [
@@ -271,3 +270,5 @@ class ToolGuard {
 
 module.exports = ToolGuard;
 module.exports.ToolGuard = ToolGuard;
+module.exports.FORBIDDEN = FORBIDDEN;
+module.exports.REQUIRES_APPROVAL = REQUIRES_APPROVAL;

--- a/test/unit/agent/guardrail-enforcer.test.js
+++ b/test/unit/agent/guardrail-enforcer.test.js
@@ -1129,11 +1129,11 @@ async function runTests() {
       pollIntervalMs: 50
     });
 
-    // Even with "send the email" in history, HIGH tools always ask HITL
+    // Even with an explicit request in history, HIGH tools always ask HITL
     const history = [
-      { role: 'user', content: 'send the email now' }
+      { role: 'user', content: 'share the Personal board with ada' }
     ];
-    const result = await enforcer.checkApproval('send_email', { to: 'a@b.com' }, 'room1', history);
+    const result = await enforcer.checkApproval('deck_share_board', { board: 'Personal', participant: 'ada' }, 'room1', history);
     assert.strictEqual(result.allowed, true);
     // Verify it actually sent a HITL message (not short-circuited)
     assert.strictEqual(queue._getSent().length, 1);
@@ -1187,13 +1187,13 @@ async function runTests() {
 
   // --- _classifySeverity ---
 
+  // HIGH severity is the sharing/broadcasting class: an action whose effect leaves
+  // the box and reaches someone else. Every name is a registered tool (#217).
   test('TC-APPROVE-008: _classifySeverity returns HIGH for high-severity tools', () => {
     const enforcer = makeEnforcer({});
-    assert.strictEqual(enforcer._classifySeverity('send_email'), 'HIGH');
-    assert.strictEqual(enforcer._classifySeverity('execute_shell'), 'HIGH');
-    assert.strictEqual(enforcer._classifySeverity('webhook_call'), 'HIGH');
-    assert.strictEqual(enforcer._classifySeverity('external_api_call'), 'HIGH');
+    assert.strictEqual(enforcer._classifySeverity('file_share'), 'HIGH');
     assert.strictEqual(enforcer._classifySeverity('deck_share_board'), 'HIGH');
+    assert.strictEqual(enforcer._classifySeverity('calendar_cancel_meeting'), 'HIGH');
   });
 
   test('TC-APPROVE-009: _classifySeverity returns MEDIUM for deck_delete_card', () => {
@@ -1290,8 +1290,8 @@ async function runTests() {
       pollIntervalMs: 50
     });
 
-    await enforcer.checkApproval('send_email', { to: 'a@b.com' }, 'room1',
-      [{ role: 'user', content: 'send the email now' }]);
+    await enforcer.checkApproval('deck_share_board', { board: 'Personal', participant: 'ada' }, 'room1',
+      [{ role: 'user', content: 'share the board with ada' }]);
     assert.strictEqual(downgradeCalls, 0);
   });
 

--- a/test/unit/guards/tool-guard.test.js
+++ b/test/unit/guards/tool-guard.test.js
@@ -22,6 +22,7 @@
 const assert = require('assert');
 const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
 const ToolGuard = require('../../../src/security/guards/tool-guard');
+const { REQUIRES_APPROVAL } = require('../../../src/security/guards/tool-guard');
 
 console.log('\n=== ToolGuard Tests ===\n');
 
@@ -191,112 +192,41 @@ test('TC-TG-023: FORBIDDEN - access_other_session', () => {
 // APPROVAL_REQUIRED Tests (blocked with prompt)
 // -----------------------------------------------------------------------------
 
-test('TC-TG-030: APPROVAL_REQUIRED - send_email', () => {
+// Every gated name must be a tool that exists (#217 cleanup). Fourteen tests here
+// asserted that send_email, execute_shell, delete_folder … require approval —
+// none of them were ever registered tools, so the assertions proved nothing about
+// the running system. The policy list itself is now the table.
+
+test('TC-TG-030: every REQUIRES_APPROVAL tool evaluates to APPROVAL_REQUIRED', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send_email');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(result.requiresAction, 'await_approval');
-  assert.ok(result.approvalPrompt !== null);
-  assert.ok(result.approvalPrompt.includes('send_email'));
-  assert.ok(result.reason.includes('approval'));
+  for (const tool of REQUIRES_APPROVAL) {
+    const result = guard.evaluate(tool);
+    assert.strictEqual(result.allowed, false, `${tool} should be blocked`);
+    assert.strictEqual(result.level, 'APPROVAL_REQUIRED', `${tool} level`);
+    assert.strictEqual(result.requiresAction, 'await_approval', `${tool} action`);
+    assert.ok(result.approvalPrompt, `${tool} prompt`);
+    assert.ok(result.approvalPrompt.includes(tool), `${tool} named in prompt`);
+    assert.ok(result.reason.includes('approval'), `${tool} reason`);
+  }
 });
 
-test('TC-TG-031: APPROVAL_REQUIRED - delete_file', () => {
+test('TC-TG-031: an operation absent from every list is allowed', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('delete_file');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(result.requiresAction, 'await_approval');
-  assert.ok(result.approvalPrompt !== null);
-});
-
-test('TC-TG-032: APPROVAL_REQUIRED - execute_shell', () => {
-  const guard = new ToolGuard();
+  // execute_shell used to sit in REQUIRES_APPROVAL guarding a tool nobody wrote.
+  // With the entry gone it evaluates as an unknown operation. That is the point of
+  // the write-class pin: if someone ever registers it, the pin fails the build
+  // until it is gated. FORBIDDEN, not REQUIRES_APPROVAL, is where never-build-this
+  // belongs — and the FORBIDDEN entries below still hold.
   const result = guard.evaluate('execute_shell');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(result.requiresAction, 'await_approval');
-  assert.ok(result.approvalPrompt !== null);
+  assert.strictEqual(result.level, 'ALLOWED');
 });
 
-test('TC-TG-033: APPROVAL_REQUIRED - webhook_call', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('webhook_call');
+test('TC-TG-032: additionalApproval extends the gate at construction', () => {
+  const guard = new ToolGuard({ additionalApproval: ['custom_op'] });
+  const result = guard.evaluate('custom_op');
   assert.strictEqual(result.allowed, false);
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(result.requiresAction, 'await_approval');
-  assert.ok(result.approvalPrompt !== null);
-});
-
-test('TC-TG-034: APPROVAL_REQUIRED - send_message_external', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('send_message_external');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-035: APPROVAL_REQUIRED - delete_files', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('delete_files');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-036: APPROVAL_REQUIRED - delete_folder', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('delete_folder');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-037: APPROVAL_REQUIRED - modify_calendar', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('modify_calendar');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-038: APPROVAL_REQUIRED - delete_calendar_event', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('delete_calendar_event');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-038b: APPROVAL_REQUIRED - calendar_delete_event (executor name)', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('calendar_delete_event');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-039: APPROVAL_REQUIRED - modify_contacts', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('modify_contacts');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-040: APPROVAL_REQUIRED - run_command', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('run_command');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-041: APPROVAL_REQUIRED - access_new_credential', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('access_new_credential');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
-});
-
-test('TC-TG-042: APPROVAL_REQUIRED - external_api_call', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('external_api_call');
-  assert.strictEqual(result.allowed, false);
-  assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
+  assert.ok(result.approvalPrompt.includes('custom_op'));
 });
 
 test('TC-TG-043: APPROVAL_REQUIRED - deck_delete_card', () => {
@@ -443,39 +373,39 @@ test('TC-TG-067: ALLOWED - random_operation', () => {
 // Fuzzy Matching Tests
 // -----------------------------------------------------------------------------
 
-test('TC-TG-070: Fuzzy match - Send Email (title case)', () => {
+test('TC-TG-070: Fuzzy match - Deck Delete Card (title case)', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('Send Email');
+  const result = guard.evaluate('Deck Delete Card');
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.strictEqual(result.allowed, false);
 });
 
-test('TC-TG-071: Fuzzy match - send-email (hyphenated)', () => {
+test('TC-TG-071: Fuzzy match - deck-delete-card (hyphenated)', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send-email');
+  const result = guard.evaluate('deck-delete-card');
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.strictEqual(result.allowed, false);
 });
 
-test('TC-TG-072: Fuzzy match - SEND_EMAIL (uppercase)', () => {
+test('TC-TG-072: Fuzzy match - WIKI_DELETE (uppercase)', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('SEND_EMAIL');
+  const result = guard.evaluate('WIKI_DELETE');
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.strictEqual(result.allowed, false);
 });
 
-test('TC-TG-073: Fuzzy match - send email (space separated)', () => {
+test('TC-TG-073: Fuzzy match - file delete (space separated)', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send email');
+  const result = guard.evaluate('file delete');
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.strictEqual(result.allowed, false);
 });
 
-test('TC-TG-074: Fuzzy match - Delete File (various cases)', () => {
+test('TC-TG-074: Fuzzy match - File Delete (various cases)', () => {
   const guard = new ToolGuard();
-  assert.strictEqual(guard.evaluate('Delete File').level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(guard.evaluate('delete-file').level, 'APPROVAL_REQUIRED');
-  assert.strictEqual(guard.evaluate('DELETE_FILE').level, 'APPROVAL_REQUIRED');
+  assert.strictEqual(guard.evaluate('File Delete').level, 'APPROVAL_REQUIRED');
+  assert.strictEqual(guard.evaluate('file-delete').level, 'APPROVAL_REQUIRED');
+  assert.strictEqual(guard.evaluate('FILE_DELETE').level, 'APPROVAL_REQUIRED');
 });
 
 test('TC-TG-075: Fuzzy match - Process Credential', () => {
@@ -504,30 +434,30 @@ test('TC-TG-077: Fuzzy match - Mixed separators', () => {
 // -----------------------------------------------------------------------------
 
 test('TC-TG-080: Context target included in approval prompt', () => {
-  const guard = new ToolGuard();
-  const result = guard.evaluate('send_email', { target: 'boss@company.com' });
+  const guard = new ToolGuard({ additionalApproval: ['mail_send'] });
+  const result = guard.evaluate('mail_send', { target: 'boss@company.com' });
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.ok(result.approvalPrompt.includes('boss@company.com'));
   assert.ok(result.approvalPrompt.includes('target:'));
 });
 
-test('TC-TG-081: Context target included for delete_file', () => {
+test('TC-TG-081: Context target included for file_delete', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('delete_file', { target: '/important/file.txt' });
+  const result = guard.evaluate('file_delete', { target: '/important/file.txt' });
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.ok(result.approvalPrompt.includes('/important/file.txt'));
 });
 
 test('TC-TG-082: Context with no target does not include target', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send_email', {});
+  const result = guard.evaluate('deck_delete_card', {});
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.ok(!result.approvalPrompt.includes('target:'));
 });
 
 test('TC-TG-083: Context with additional fields only uses target', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('webhook_call', {
+  const result = guard.evaluate('deck_share_board', {
     target: 'https://example.com/hook',
     user: 'alice',
     data: 'sensitive'
@@ -539,16 +469,16 @@ test('TC-TG-083: Context with additional fields only uses target', () => {
 
 test('TC-TG-084: Approval prompt contains action instructions', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send_email');
+  const result = guard.evaluate('deck_delete_card');
   assert.ok(result.approvalPrompt.includes('approve'));
   assert.ok(result.approvalPrompt.includes('deny'));
 });
 
 test('TC-TG-085: Approval prompt format is consistent', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('execute_shell', { target: 'rm -rf /' });
+  const result = guard.evaluate('wiki_delete', { target: 'People/Ada' });
   assert.ok(result.approvalPrompt.startsWith('⚠️ Moltagent wants to:'));
-  assert.ok(result.approvalPrompt.includes('execute_shell'));
+  assert.ok(result.approvalPrompt.includes('wiki_delete'));
 });
 
 // -----------------------------------------------------------------------------
@@ -618,9 +548,9 @@ test('TC-TG-097: getAllLists forbidden includes expected operations', () => {
 test('TC-TG-098: getAllLists approval includes expected operations', () => {
   const guard = new ToolGuard();
   const lists = guard.getAllLists();
-  assert.ok(lists.approval.includes('send_email'));
-  assert.ok(lists.approval.includes('delete_file'));
-  assert.ok(lists.approval.includes('execute_shell'));
+  assert.ok(lists.approval.includes('deck_delete_card'));
+  assert.ok(lists.approval.includes('file_delete'));
+  assert.ok(lists.approval.includes('wiki_delete'));
 });
 
 test('TC-TG-099: getAllLists local includes expected operations', () => {
@@ -736,15 +666,15 @@ test('TC-TG-127: Very long operation name', () => {
 
 test('TC-TG-128: Context without target field works', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send_email', { user: 'alice', other: 'data' });
+  const result = guard.evaluate('deck_delete_card', { user: 'alice', other: 'data' });
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
   assert.ok(!result.approvalPrompt.includes('target:'));
 });
 
 test('TC-TG-129: Null context handled same as empty context', () => {
   const guard = new ToolGuard();
-  const result1 = guard.evaluate('send_email', null);
-  const result2 = guard.evaluate('send_email', {});
+  const result1 = guard.evaluate('deck_delete_card', null);
+  const result2 = guard.evaluate('deck_delete_card', {});
   assert.strictEqual(result1.level, result2.level);
   assert.strictEqual(result1.allowed, result2.allowed);
 });
@@ -767,8 +697,8 @@ test('TC-TG-131: FORBIDDEN takes priority over custom LOCAL', () => {
 });
 
 test('TC-TG-132: APPROVAL takes priority over custom LOCAL', () => {
-  const guard = new ToolGuard({ additionalLocal: ['send_email'] });
-  const result = guard.evaluate('send_email');
+  const guard = new ToolGuard({ additionalLocal: ['deck_delete_card'] });
+  const result = guard.evaluate('deck_delete_card');
   // Should still be APPROVAL_REQUIRED
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED');
 });
@@ -856,7 +786,7 @@ test('TC-TG-150: FORBIDDEN result has correct structure', () => {
 
 test('TC-TG-151: APPROVAL_REQUIRED result has correct structure', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('send_email');
+  const result = guard.evaluate('deck_delete_card');
   assert.strictEqual(typeof result.allowed, 'boolean');
   assert.strictEqual(typeof result.reason, 'string');
   assert.strictEqual(typeof result.level, 'string');

--- a/test/unit/security/guards/tool-guard-phase2.test.js
+++ b/test/unit/security/guards/tool-guard-phase2.test.js
@@ -39,15 +39,17 @@ test('mail_send is allowed (HITL handled by SOUL.md instruction, not guard)', ()
   assert.strictEqual(result.level, 'ALLOWED', 'Should be ALLOWED level');
 });
 
-test('notification_send requires approval', () => {
+// notification_send named a tool nobody registered (#217). The gate it was meant to
+// demonstrate is exercised on a real one: deck_share_board pushes data to another user.
+test('deck_share_board requires approval', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('notification_send');
+  const result = guard.evaluate('deck_share_board');
 
-  assert.strictEqual(result.allowed, false, 'notification_send should require approval');
+  assert.strictEqual(result.allowed, false, 'deck_share_board should require approval');
   assert.strictEqual(result.level, 'APPROVAL_REQUIRED', 'Should be APPROVAL_REQUIRED level');
   assert.strictEqual(result.requiresAction, 'await_approval', 'Should require await_approval action');
   assert.ok(result.approvalPrompt, 'Should provide approval prompt');
-  assert.ok(result.approvalPrompt.includes('notification_send'), 'Prompt should mention operation name');
+  assert.ok(result.approvalPrompt.includes('deck_share_board'), 'Prompt should mention operation name');
 });
 
 test('web_search is allowed (not in restricted lists)', () => {
@@ -89,12 +91,12 @@ test('wiki_search is allowed (not in restricted lists)', () => {
 });
 
 // Additional tests to verify the guard is working correctly
-test('Approval prompt includes operation name for notification_send', () => {
+test('Approval prompt includes operation name for deck_share_board', () => {
   const guard = new ToolGuard();
-  const result = guard.evaluate('notification_send', { target: 'user123' });
+  const result = guard.evaluate('deck_share_board', { target: 'user123' });
 
   assert.ok(result.approvalPrompt, 'Should have approval prompt');
-  assert.ok(result.approvalPrompt.includes('notification_send'), 'Prompt should mention operation');
+  assert.ok(result.approvalPrompt.includes('deck_share_board'), 'Prompt should mention operation');
   assert.ok(result.approvalPrompt.includes('user123'), 'Prompt should mention target when provided');
 });
 

--- a/test/unit/security/interceptor.test.js
+++ b/test/unit/security/interceptor.test.js
@@ -215,11 +215,12 @@ asyncTest('TC-SI-025: Strict mode blocks REVIEW content', async () => {
 // beforeExecute — APPROVAL_REQUIRED cases
 // -----------------------------------------------------------------------------
 
-asyncTest('TC-SI-030: send_email requires approval', async () => {
+// send_email was never a registered tool (#217). The interceptor's approval flow is
+// the thing under test; deck_delete_card is a real gated tool that exercises it.
+asyncTest('TC-SI-030: deck_delete_card requires approval', async () => {
   const si = createInterceptor();
-  const result = await si.beforeExecute('send_email', {
-    to: 'boss@company.com',
-    subject: 'Report',
+  const result = await si.beforeExecute('deck_delete_card', {
+    card: 'Q3 Planning',
   }, defaultCtx);
 
   assert.strictEqual(result.proceed, false);
@@ -233,14 +234,14 @@ asyncTest('TC-SI-031: Approved operation proceeds on re-check', async () => {
   const ctx = { roomToken: 'room1', userId: 'alice' };
 
   // First call — needs approval
-  const result1 = await si.beforeExecute('send_email', { to: 'boss@company.com' }, ctx);
+  const result1 = await si.beforeExecute('deck_delete_card', { card: 'Q3 Planning' }, ctx);
   assert.strictEqual(result1.decision, 'APPROVAL_REQUIRED');
 
   // Grant approval
-  si.handleApproval(ctx, 'send_email', { to: 'boss@company.com' }, true);
+  si.handleApproval(ctx, 'deck_delete_card', { card: 'Q3 Planning' }, true);
 
   // Second call — should proceed
-  const result2 = await si.beforeExecute('send_email', { to: 'boss@company.com' }, ctx);
+  const result2 = await si.beforeExecute('deck_delete_card', { card: 'Q3 Planning' }, ctx);
   assert.strictEqual(result2.proceed, true);
   assert.strictEqual(result2.decision, 'ALLOW');
 });

--- a/test/unit/security/write-class-policy.test.js
+++ b/test/unit/security/write-class-policy.test.js
@@ -1,0 +1,149 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * Write-class policy pin — the structural guard against a map that lies.
+ *
+ * Architecture Brief:
+ * - Problem: gating policy lived in three hand-maintained sets. Fourteen of the
+ *   twenty-four names in them were tools that no code ever registered, so the
+ *   policy read as protection while protecting nothing. The reverse gap is worse:
+ *   a destructive tool registered with no policy entry ships ungated, silently.
+ * - Pattern: two independent declarations that must agree. Policy says which tools
+ *   need approval; each tool's own `writes: true` says whether it mutates the
+ *   world. Neither is derived from the other, so the pin has teeth.
+ * - Key Dependencies: ToolRegistry (declarations), GuardrailEnforcer +
+ *   ToolGuard (policy).
+ * - Data Flow: fully-populated registry × getWriteClassTools() → set equality.
+ *
+ * Related: #217 (policy has three writer homes, one reader; Wave 3 consolidates).
+ *
+ * Run: node test/unit/security/write-class-policy.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const { ToolRegistry } = require('../../../src/lib/agent/tool-registry');
+const {
+  getWriteClassTools, HIGH_SEVERITY_TOOLS, SENSITIVE_TOOLS, TOOL_APPROVAL_LABELS
+} = require('../../../src/lib/agent/guardrail-enforcer');
+const { FORBIDDEN, REQUIRES_APPROVAL } = require('../../../src/security/guards/tool-guard');
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+/**
+ * Every tool the codebase *can* register. ToolRegistry registers a tool only when
+ * its client exists (see `_registerDeckTools`: `if (!deck) return`), so a registry
+ * built without clients has zero tools and would make every assertion below pass
+ * vacuously. Proxy mocks make each client truthy.
+ *
+ * "Can register" is the right frame, not "does register on this box". mail_send
+ * appears only when emailHandler is wired, so a deployment without email
+ * configured registers 59 tools rather than 60 — and policy is still right to name
+ * mail_send. Drop a client from this list and the tools it owns silently leave the
+ * pin's reach; the populated-registry assertion below is the tripwire for that.
+ */
+function fullRegistry() {
+  const mock = new Proxy({}, { get: () => () => {} });
+  return new ToolRegistry({
+    deckClient: mock, calDAVClient: mock, systemTagsClient: mock, ncRequestManager: mock,
+    ncFilesClient: mock, ncSearchClient: mock, textExtractor: mock, collectivesClient: mock,
+    learningLog: mock, searxngClient: mock, webReader: mock, contactsClient: mock,
+    memorySearcher: mock, searchAdapters: mock, emailHandler: mock, resilientWriter: mock,
+    newsClient: mock, entityExtractor: mock, meetingComposer: mock, rsvpTracker: mock,
+    logger: silentLogger
+  });
+}
+
+const registry = fullRegistry();
+const registered = new Set(registry.tools.keys());
+const declaredWrites = new Set(
+  [...registry.tools.values()].filter(t => t.writes === true).map(t => t.name)
+);
+
+console.log('Write-Class Policy Pin\n');
+
+// Guard the guard: if the mocks stop populating the registry, every assertion
+// below becomes vacuously true. Fail loudly instead.
+test('the registry under test is actually populated', () => {
+  assert.ok(registered.size > 50, `expected a full registry, got ${registered.size} tools`);
+  assert.ok(declaredWrites.size > 0, 'no tool declares writes: true');
+});
+
+// ── Direction 1: policy ⊆ registered — no map that lies ─────────
+
+test('every REQUIRES_APPROVAL name is a registered tool', () => {
+  const ghosts = REQUIRES_APPROVAL.filter(t => !registered.has(t));
+  assert.deepStrictEqual(ghosts, [],
+    `REQUIRES_APPROVAL gates tools that do not exist: ${ghosts.join(', ')}. ` +
+    'A name here gates nothing unless a tool registers it. To guard an operation ' +
+    'that must never become a tool, put it in FORBIDDEN.');
+});
+
+test('every HIGH_SEVERITY_TOOLS name is a registered tool', () => {
+  const ghosts = [...HIGH_SEVERITY_TOOLS].filter(t => !registered.has(t));
+  assert.deepStrictEqual(ghosts, [], `HIGH_SEVERITY_TOOLS names non-tools: ${ghosts.join(', ')}`);
+});
+
+test('every SENSITIVE_TOOLS name is a registered tool', () => {
+  const ghosts = [...SENSITIVE_TOOLS].filter(t => !registered.has(t));
+  assert.deepStrictEqual(ghosts, [], `SENSITIVE_TOOLS names non-tools: ${ghosts.join(', ')}`);
+});
+
+test('every TOOL_APPROVAL_LABELS key is a registered tool', () => {
+  const ghosts = Object.keys(TOOL_APPROVAL_LABELS).filter(t => !registered.has(t));
+  assert.deepStrictEqual(ghosts, [], `TOOL_APPROVAL_LABELS labels non-tools: ${ghosts.join(', ')}`);
+});
+
+// ── Direction 2: registered ∩ destructive ⊆ policy — no ungated tool ──
+//
+// `writes: true` is the tool's own declaration, made at its registration site and
+// owing nothing to the policy sets. That is what lets it catch the dangerous drift.
+
+test('every tool declaring writes: true is in the write class', () => {
+  const writeClass = getWriteClassTools();
+  const ungated = [...declaredWrites].filter(t => !writeClass.has(t)).sort();
+  assert.deepStrictEqual(ungated, [],
+    `these tools mutate external state but no policy gates them: ${ungated.join(', ')}. ` +
+    'Add each to ToolGuard.REQUIRES_APPROVAL (hardcoded gate) or ' +
+    'GuardrailEnforcer.SENSITIVE_TOOLS (Cockpit GATE guardrail).');
+});
+
+test('every write-class tool declares writes: true', () => {
+  const undeclared = [...getWriteClassTools()].filter(t => !declaredWrites.has(t)).sort();
+  assert.deepStrictEqual(undeclared, [],
+    `policy gates these tools, but they do not declare writes: true: ${undeclared.join(', ')}`);
+});
+
+// ── The union is what the reader returns ────────────────────────
+
+test('getWriteClassTools is exactly the union of the three writer homes', () => {
+  const expected = new Set([...REQUIRES_APPROVAL, ...HIGH_SEVERITY_TOOLS, ...SENSITIVE_TOOLS]);
+  assert.deepStrictEqual([...getWriteClassTools()].sort(), [...expected].sort());
+});
+
+test('the write class covers the tools that leave the box', () => {
+  const writeClass = getWriteClassTools();
+  // mail_send lives only in SENSITIVE_TOOLS. A two-set union silently drops it,
+  // and with it the #81 symptom: the model narrating an email ceremony instead of
+  // sending. Naming it here means that regression cannot land quietly.
+  for (const tool of ['mail_send', 'wiki_write', 'file_write', 'deck_delete_card', 'wiki_delete']) {
+    assert.ok(writeClass.has(tool), `${tool} must be write-class`);
+  }
+});
+
+// ── FORBIDDEN is the opposite relationship ──────────────────────
+
+test('FORBIDDEN names operations that must never be registered as tools', () => {
+  const leaked = FORBIDDEN.filter(op => registered.has(op));
+  assert.deepStrictEqual(leaked, [],
+    `FORBIDDEN is a denylist; these leaked in as real tools: ${leaked.join(', ')}`);
+});
+
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);


### PR DESCRIPTION
**Advances #217 · Prerequisite for PR B (#81 commit 2)**

## What was wrong

Gating policy named 24 tools. **Fourteen of them do not exist.**

| name | homes | registered? |
|---|---|---|
| `send_email`, `send_message_external`, `webhook_call`, `execute_shell`, `run_command`, `notification_send`, `external_api_call` | `REQUIRES_APPROVAL` + `HIGH_SEVERITY_TOOLS` + labels | ❌ |
| `delete_file`, `delete_files`, `delete_folder`, `modify_calendar`, `delete_calendar_event`, `modify_contacts`, `access_new_credential` | `REQUIRES_APPROVAL` + labels | ❌ |

No code ever registered a tool by those names. The policy read as protection and protected nothing; anyone counting entries would have put the destructive surface at roughly twice its real size. The real write class is **16 tools**.

## Two changes, both structural

### One reader

Full #217 consolidation stays in Wave 3 with F1 retirement — pulling it forward spreads the change across the trust boundary. The interim keeps the writer homes and introduces exactly one reader:

```js
// guardrail-enforcer.js — the one place that answers "what is write-class?"
function getWriteClassTools() {
  return new Set([...REQUIRES_APPROVAL, ...HIGH_SEVERITY_TOOLS, ...SENSITIVE_TOOLS]);
}
```

**The union is three sets, not two.** `mail_send`, `wiki_write` and `file_write` live only in `SENSITIVE_TOOLS` (Cockpit-GATE governed). `HIGH_SEVERITY ∪ REQUIRES_APPROVAL` — the source #81's body names — silently excludes email, which is the tool #81's hallucinated ceremony is staged around. PR B must call this function rather than become a third derivation site.

### A pin, not a cleanup

Deleting dead entries once invites them back. So tools now declare `writes: true` **at their registration site** — the tool's own statement that it mutates external state, owing nothing to the policy sets. That independence is what gives the pin teeth:

```
policy ⊆ registered                 → no map that lies
registered ∧ writes ⊆ write-class   → no destructive tool ships ungated
```

The second direction is the one that matters, and it answers the objection that `execute_shell` was a useful tripwire for a tool nobody has written yet. **It never was.** That entry would have gated a future `execute_shell` only if its author happened to reuse the exact name. The pin catches any destructive tool, whatever it is called — provided the author declares `writes: true`, which is the one assumption left standing and is visible at the registration site rather than buried in a policy file.

Operations that must *never* become tools belong in `FORBIDDEN` (`modify_soul`, `export_credentials`, …), which is untouched and has the inverse semantics: every name in it is expected to stay unregistered forever. The pin asserts that too, so the two lists cannot drift back together.

## Tests

Fourteen assertions proved that non-existent tools require approval — the same lie, in test form. They are replaced by a table over the real `REQUIRES_APPROVAL` list, plus a mechanism test that uses `additionalApproval` so the guard's *behavior* is still covered without pretending a tool exists. Mechanism tests elsewhere (interceptor, phase 2, fuzzy matching, approval-prompt context) were re-pointed at real gated tools.

One test now asserts that `execute_shell` evaluates to `ALLOWED`, with a comment explaining why that is correct and where the protection actually lives. It is the sort of line that looks alarming in isolation, so it is worth reading its comment during review.

## Verification

**The pin was mutation-tested in both directions** — a pin that has never failed proves nothing:

- Added `'execute_shell'` back to `REQUIRES_APPROVAL` → `every REQUIRES_APPROVAL name is a registered tool` **FAILS**: *"REQUIRES_APPROVAL gates tools that do not exist: execute_shell."*
- Registered a `nuke_everything` tool with `writes: true` and no policy entry → `every tool declaring writes: true is in the write class` **FAILS**: *"these tools mutate external state but no policy gates them: nuke_everything."*
- Both green again on revert.

**Live on Prime against real clients** (a `NCRequestManager` bound to production Nextcloud, plus real `DeckClient` / `CalDAVClient` / `NCFilesClient` / `CollectivesClient` — Proxy mocks in the pin could mask a registration that depends on real client shape):

```
real registry tools: 60
tools declaring writes:true: 16
write-class names with no registered tool: NONE
registered writers with no policy: NONE

ToolGuard.evaluate:
  deck_delete_card → APPROVAL_REQUIRED     wiki_delete  → APPROVAL_REQUIRED
  file_delete      → APPROVAL_REQUIRED     file_share   → APPROVAL_REQUIRED
  deck_share_board → APPROVAL_REQUIRED

Cockpit-GATE tools (SENSITIVE_TOOLS governs, ToolGuard must not hardcode-gate):
  mail_send  → ToolGuard=ALLOWED  sensitive=true  writeClass=true
  wiki_write → ToolGuard=ALLOWED  sensitive=true  writeClass=true
  file_write → ToolGuard=ALLOWED  sensitive=true  writeClass=true

deleted ghost names:  execute_shell / send_email / delete_folder → ALLOWED, registered=false
FORBIDDEN still holds: modify_soul → FORBIDDEN   export_credentials → FORBIDDEN
```

A gotcha the pin now documents: `mail_send` registers **only when `emailHandler` is wired**, so a box without email configured registers 59 tools, not 60 — and policy is still right to name it. The pin therefore asserts against the registry the codebase *can* build, not the one a given deployment does, and carries a populated-registry tripwire so it can never pass vacuously.

235/235 unit + 6/6 integration test files pass; lint 0 errors.

## What this does not fix

A destructive tool registered **without** `writes: true` still slips both directions. Nothing structural catches that — it is the residual assumption, moved from a policy file nobody reads to the registration site, where the author is already thinking about what the tool does. Full consolidation (#217, Wave 3) removes it by deriving policy from the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)