### PR TITLE
feat(agent): a gate=action turn that changed nothing cannot claim it did (#81 commit 2)

### DIFF
--- a/src/lib/agent/action-guard.js
+++ b/src/lib/agent/action-guard.js
@@ -20,8 +20,24 @@ const { HITL_PROMPT_MARKER } = require('./guardrail-enforcer');
  * A response staging the marker is *always* illegitimate — at any gate. A
  * confirmation follow-up ("lösch den dritten") classifies as gate=confirmation,
  * not gate=action, so a gate-conditional check would miss it; the marker check
- * must therefore be unconditional. The "no tool call on an action turn" signal
- * stays gate-conditional and lives in the caller.
+ * must therefore be unconditional. The "no mutating tool call on an action
+ * turn" signal stays gate-conditional and lives in the caller.
+ *
+ * This module also owns the honesty floor's text (#81 commit 2). The invariant
+ * both halves serve:
+ *
+ *   A gate=action turn that invoked no mutating tool must not deliver a
+ *   success claim to the user.
+ *
+ * The re-prompt (Layer 1) gives the model one chance to do the work it was
+ * asked to do; the trailer (Layer 2) makes the turn honest whether or not it
+ * takes that chance. Both key on what the turn *did* — its invoked tool names,
+ * measured against each tool's own ToolRegistry mutation declaration — never on
+ * what it said. Approval (the write class, #266) is a strictly smaller question:
+ * deck_create_card mutates and needs no consent.
+ * Reading the model's sentences to decide whether the model acted is the
+ * same category error as reading conversation history to decide whether the user
+ * authorised something, which #264 removed.
  *
  * @module agent/action-guard
  */
@@ -63,4 +79,64 @@ const ACTION_REPROMPT_DIRECTIVE =
   'If you can perform the action, call the appropriate tool now. If you cannot, explain what prevented you. ' +
   'Do not describe a result the tool has not returned.';
 
-module.exports = { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE };
+/**
+ * The honesty floor's text, per language.
+ *
+ * This is output templating on a code-owned surface — the same class as the
+ * enforcer's approval prompt — not language handling. No prose is read and no
+ * language is detected here: the key is the Cockpit language already travelling
+ * with the turn on the classification verdict. Unknown languages fall back to EN
+ * rather than guessing.
+ *
+ * The text states a fact about what the turn did, and claims nothing about why.
+ * It sits beneath the model's narration, so a specific refusal ("I couldn't find
+ * that card") keeps its place as the useful sentence and this only adds the part
+ * the model may have omitted or contradicted.
+ */
+const NO_ACTION_TRAILER = {
+  EN: '⚠️ No action was executed — nothing was created, changed, or deleted.',
+  DE: '⚠️ Es wurde keine Aktion ausgeführt — nichts wurde erstellt, geändert oder gelöscht.',
+  PT: '⚠️ Nenhuma ação foi executada — nada foi criado, alterado ou eliminado.',
+};
+
+/**
+ * Normalise a Cockpit language tag to a trailer key.
+ *
+ * Accepts the shapes the verdict actually carries: 'DE', 'de', 'DE+EN' (the
+ * bilingual persona setting), null. Anything not templated falls back to EN.
+ *
+ * @param {string|null|undefined} language
+ * @returns {'EN'|'DE'|'PT'}
+ */
+function _trailerKey(language) {
+  const key = String(language || 'EN').toUpperCase().split('+')[0].trim();
+  return Object.prototype.hasOwnProperty.call(NO_ACTION_TRAILER, key) ? key : 'EN';
+}
+
+/**
+ * The honesty floor (#81 commit 2, Layer 2).
+ *
+ * A gate=action turn that invoked no mutating tool did not act, whatever its
+ * prose says. Rather than inspect that prose — the ProvenanceAnnotator's
+ * groundedRatio scores a fabricated claim as "grounded" whenever it echoes the
+ * user's own nouns, see #267 — the floor appends a code-owned statement of what
+ * the turn actually did.
+ *
+ * Appended, never substituted: replacing the narration would destroy a
+ * legitimate specific refusal, and the trailer's job is to add a true sentence,
+ * not to remove a useful one.
+ *
+ * @param {string|null|undefined} language - Cockpit language from the verdict
+ * @returns {string}
+ */
+function buildNoActionTrailer(language) {
+  return NO_ACTION_TRAILER[_trailerKey(language)];
+}
+
+module.exports = {
+  stagesApprovalCeremony,
+  stripApprovalMarker,
+  buildNoActionTrailer,
+  ACTION_REPROMPT_DIRECTIVE,
+  NO_ACTION_TRAILER,
+};

--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { extractArtifact } = require('./artifact-extractor');
-const { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
+const { stagesApprovalCeremony, stripApprovalMarker, buildNoActionTrailer, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
 
 /**
  * AgentLoop - The Nervous System
@@ -71,6 +71,9 @@ class AgentLoop {
    * @param {string} roomToken - NC Talk room token
    * @param {Object} [options]
    * @param {number} [options.messageId]
+   * @param {string} [options.gate] - Classification gate; 'action' arms the mutation guard
+   * @param {string} [options.language] - Cockpit language from the verdict ('EN'|'DE'|'PT'|'DE+EN'…),
+   *   used only to pick the honesty trailer's template. Unset falls back to EN.
    * @returns {Promise<string>} The agent's final text response
    */
   async process(message, roomToken, options = {}) {
@@ -157,6 +160,32 @@ class AgentLoop {
     const toolResultIndices = [];  // indices into messages[] of tool results
     const failedCallIds = new Set();  // tool_call_ids that returned errors
     let actionGuardFired = false;  // once-per-turn re-prompt for tool-less action responses
+
+    // #81 commit 2: the names of tools this turn actually invoked, accumulated
+    // across iterations. toolResultIndices holds message indices, not names, and
+    // iterationToolsCalled resets each iteration — neither can answer "did this
+    // turn change anything?". A name lands here only where the tool is really
+    // handed to _executeWithGuards, so the consecutive-failure skip path (which
+    // pushes to iterationToolsCalled for a tool that never ran) cannot fake a
+    // mutation. A DENIED or timed-out call does land here, and must: the guard
+    // polices narration-instead-of-invocation, and a refused ceremony is a real
+    // invocation with a real answer.
+    //
+    // The question is MUTATION, not approval. The write class (#266) is the set
+    // of tools that need a human's consent — deletes, shares, sends. It is a
+    // strict subset of the tools that change the world: deck_create_card mutates
+    // and needs no consent. Keying the guard on the write class would append
+    // "no action was executed" beneath a successfully created card, which is
+    // #81's harm inverted. Each tool declares `mutates` or `readOnly` at its
+    // registration site, and the write-class pin asserts write-class ⊆ mutates.
+    const toolsInvokedThisTurn = new Set();
+    const invokedMutatingTool = () => [...toolsInvokedThisTurn].some(name =>
+      // A registry that cannot answer is treated as "it mutated", so the guard
+      // stays silent rather than printing a false "nothing happened". Unknown
+      // names (a fuzzy alias, a SkillForge tool) answer the same way inside
+      // ToolRegistry.isMutating, for the same reason.
+      typeof this.toolRegistry?.isMutating !== 'function' || this.toolRegistry.isMutating(name)
+    );
 
     while (iteration < maxIter) {
       iteration++;
@@ -245,6 +274,12 @@ class AgentLoop {
             continue;
           }
 
+          // The turn invoked this tool. Recorded before the result is known:
+          // a denial, a timeout, or a handler error are all outcomes of a real
+          // invocation, and the guard asks whether the tool was called — not
+          // whether it succeeded.
+          toolsInvokedThisTurn.add(toolCall.name);
+
           const toolResult = await this._executeWithGuards(toolCall, roomToken);
 
           // Track tool failures (don't count errors toward maxIterations)
@@ -324,16 +359,29 @@ class AgentLoop {
       // Action-hallucination guard: when the classifier said this turn is an
       // action but the LLM produced text without doing the work, re-prompt
       // once before letting the response reach the user. The check is
-      // structural (gate + tool-call history + HITL marker) — language-free.
+      // structural (gate + invoked tool names + HITL marker) — language-free.
       //
       // Two structural signals trigger the re-prompt:
-      //   (a) Zero tool calls this turn — the original PR #68 case.
+      //   (a) No MUTATING tool call this turn. Zero-tool-calls was the
+      //       original PR #68 proxy for this, and it was too weak: on
+      //       2026-07-09 a gate=action turn called deck_list_cards, then ended
+      //       by asking "Delete it?" in prose. A read had run, so the old
+      //       condition was false, and no marker was emitted, so (b) was false
+      //       too. The turn talked about a deletion it never invoked. Mutation
+      //       is each tool's own declaration at its registration site, read via
+      //       ToolRegistry.isMutating() — never the approval policy, which
+      //       covers a strictly smaller set (see the note above the Set).
       //   (b) The response renders the HITL prompt marker (\u{1F510}) that
       //       the GuardrailEnforcer reserves for its Talk surface. If the
       //       agent emits that codepoint, it is staging a fake approval
-      //       ceremony instead of calling the destructive tool (#81). This
-      //       fires even when read-only tools were called (e.g. list-then-
-      //       narrate-approval).
+      //       ceremony instead of calling the destructive tool (#81).
+      //
+      // A read-only tool call no longer satisfies "this turn did the work",
+      // which means an honest not-found refusal ("I couldn't find that card")
+      // trips (a) as well — it is structurally identical to the prose offer,
+      // and telling them apart would mean reading prose. That is accepted: the
+      // model restates the refusal on its second pass, the bound below stops
+      // there, and the user's answer is unchanged.
       //
       // Bounded to one re-prompt per turn via actionGuardFired so legitimate
       // text-only refusals on the second pass ("I can't because…") are not
@@ -342,11 +390,11 @@ class AgentLoop {
       // Marker staging is illegitimate at ANY gate — the 🔐 codepoint belongs to
       // GuardrailEnforcer's Talk surface, never a model response. A confirmation
       // follow-up ("lösch den dritten") classifies as gate=confirmation, so gating
-      // this on action would miss the #85 leak. The no-tool-call signal stays
-      // gate=action (a knowledge turn legitimately produces no tool call).
+      // this on action would miss the #85 leak. The write-class signal stays
+      // gate=action (a knowledge turn legitimately performs no write).
       const responseStagesApproval = stagesApprovalCeremony(response.content);
-      const actionWithoutToolCall = options.gate === 'action' && toolResultIndices.length === 0;
-      if (!actionGuardFired && (actionWithoutToolCall || responseStagesApproval)) {
+      const actionWithoutMutation = options.gate === 'action' && !invokedMutatingTool();
+      if (!actionGuardFired && (actionWithoutMutation || responseStagesApproval)) {
         actionGuardFired = true;
         maxIter = Math.max(maxIter, iteration + 1);
 
@@ -361,7 +409,7 @@ class AgentLoop {
 
         const reason = responseStagesApproval
           ? 'response staged HITL marker without destructive tool call'
-          : 'zero tool calls (gate=action)';
+          : `no mutating tool call (gate=action, invoked=[${[...toolsInvokedThisTurn].join(', ')}])`;
         this.logger.warn(`[AgentLoop] Action-hallucination guard fired at iteration ${iteration} — re-prompting (${reason})`);
         // Maturation loop: the guard firing is a structural failure of the
         // (tools, model) pairing — an action turn that didn't act.
@@ -425,6 +473,37 @@ class AgentLoop {
     if (stagesApprovalCeremony(lastResponse)) {
       this.logger.warn('[AgentLoop] HITL marker survived the re-prompt — stripping from final response (model staged ceremony twice)');
       lastResponse = stripApprovalMarker(lastResponse);
+    }
+
+    // 5. Honesty floor (#81 commit 2, Layer 2). The re-prompt above is bounded to
+    // one attempt, and on 2026-07-09 a model spent that attempt producing a more
+    // confident falsehood ("Ich habe die Karte gelöscht — die Tool-Bestätigung
+    // liegt vor", zero tool calls). One re-prompt is a request, not a guarantee.
+    //
+    // So the turn's honesty is made structural rather than hoped for: a
+    // gate=action turn that invoked no write-class tool did not act, and says so
+    // in a code-owned sentence beneath whatever the model wrote. The trailer
+    // appends and never replaces — substituting it would delete a legitimate
+    // specific refusal ("I couldn't find that card"), the most useful sentence in
+    // such a turn, in favour of a generic one.
+    //
+    // The trigger reads the turn's invoked tool names, never its prose. The
+    // ProvenanceAnnotator's groundedRatio was the tempting alternative and is not
+    // consulted: it scores a fabricated claim as grounded whenever the claim
+    // echoes the user's own nouns (#267).
+    //
+    // This is also a diagnostic. A read-only request misclassified as
+    // gate=action will visibly carry the trailer under an informational answer.
+    // That is a classifier-quality signal surfacing in production, not a defect
+    // here, and no heuristic suppresses it — the journal line below carries the
+    // gate and the invoked tool names so a recurring false fire is attributable
+    // to the classification, which is where the fix belongs.
+    if (options.gate === 'action' && !invokedMutatingTool() && lastResponse) {
+      this.logger.warn(
+        `[AgentLoop] Honesty trailer appended: gate=action mutatingCall=none ` +
+        `invoked=[${[...toolsInvokedThisTurn].join(', ')}] guardFired=${actionGuardFired} language=${options.language || 'unset'}`
+      );
+      lastResponse = `${lastResponse}\n\n${buildNoActionTrailer(options.language)}`;
     }
 
     const elapsed = Date.now() - startTime;

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -338,21 +338,55 @@ class ToolRegistry {
    * @param {Object} [toolDef.metadata]
    */
   /**
-   * `writes: true` declares that a tool changes something outside this process —
-   * it deletes, shares, sends, or overwrites. It is the tool's own statement about
-   * itself, independent of any gating policy, and that independence is the point:
-   * the write-class pin cross-checks these declarations against
-   * GuardrailEnforcer.getWriteClassTools(), so a destructive tool registered
-   * without a policy entry fails the suite instead of shipping ungated.
+   * Every tool declares exactly one of `readOnly: true` or `mutates: true`, and
+   * the write-class pin asserts that partition is total. Two questions get asked
+   * about a tool, and conflating them was a real bug (#81 commit 2):
+   *
+   * - **`mutates`** — *does calling this change the world?* Creating a card
+   *   mutates. Listing cards does not. This is what the action-hallucination
+   *   guard reads: a gate=action turn that invoked no mutating tool did not act,
+   *   whatever its prose says.
+   * - **`writes`** — *does calling this need approval?* A strictly smaller set
+   *   (#266's write class: deletes, shares, sends, overwrites). `deck_create_card`
+   *   mutates and needs no approval; the two sets are not the same, and keying
+   *   the guard on `writes` made it deny successful card creations.
+   *
+   * Both are the tool's own statement about itself, independent of any policy
+   * table, and that independence is what gives the pin teeth: it cross-checks
+   * `writes` against `GuardrailEnforcer.getWriteClassTools()` and requires
+   * `write-class ⊆ mutates`, so neither an ungated destructive tool nor a
+   * gated-but-undeclared one can ship.
    *
    * @param {Object} toolDef
-   * @param {boolean} [toolDef.writes] - true when the tool mutates external state
+   * @param {boolean} [toolDef.mutates] - true when calling the tool changes external state
+   * @param {boolean} [toolDef.readOnly] - true when calling the tool changes nothing
+   * @param {boolean} [toolDef.writes] - true when the tool additionally requires approval
    */
   register(toolDef) {
     if (!toolDef.name || !toolDef.handler) {
       throw new Error('Tool definition requires name and handler');
     }
     this.tools.set(toolDef.name, toolDef);
+  }
+
+  /**
+   * Does invoking this tool change state outside the process?
+   *
+   * Undeclared and unknown tools answer **true**. The caller (the action guard)
+   * uses this to decide whether a turn may have acted, and the only unsafe answer
+   * is a false "nothing happened" printed under a real mutation. So the default
+   * fails toward silence: a dynamically registered tool (SkillForge) that never
+   * declared itself is assumed to have acted, and the guard stays quiet.
+   *
+   * @param {string} name - Tool name (resolved)
+   * @returns {boolean}
+   */
+  isMutating(name) {
+    const tool = this.tools.get(name);
+    if (!tool) return true;              // unknown: assume it acted
+    if (tool.mutates === true) return true;
+    if (tool.readOnly === true) return false;
+    return true;                         // undeclared: assume it acted
   }
 
   /**
@@ -688,6 +722,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_cards',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all cards on a board, grouped by stack. Defaults to the task board. Use the board parameter to query other boards (e.g. "Cockpit", "Moltagent Cockpit"). Omit the stack parameter to search all stacks (preferred default).',
       parameters: {
@@ -783,6 +818,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_move_card',
+      mutates: true,
       domains: ['deck'],
       description: 'Move a card to a different stack. Use this when asked to close, finish, start, or queue a task. The card can be identified by title (partial match) or ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
@@ -848,6 +884,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_create_card',
+      mutates: true,
       domains: ['deck', 'news'],
       description: 'Create a new card (task) on a board. ALWAYS include a description with relevant context from the conversation — findings, results, next steps, or details discussed. If the user asks to save findings or results to a card, include that content in the description field. Cards are created in the Inbox stack by default.',
       parameters: {
@@ -922,6 +959,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_boards',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all Deck boards accessible to you (owned and shared). Returns board names, IDs, and ownership info.',
       parameters: { type: 'object', properties: {}, required: [] },
@@ -943,6 +981,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_get_board',
+      readOnly: true,
       domains: ['deck'],
       description: 'Get details of a specific Deck board including its stacks, labels, and sharing settings. Accepts board name (partial match) or ID.',
       parameters: {
@@ -975,6 +1014,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_create_board',
+      mutates: true,
       domains: ['deck'],
       description: 'Create a new Deck board. You will own this board.',
       parameters: {
@@ -1003,6 +1043,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_rename_board',
+      mutates: true,
       domains: ['deck'],
       description: 'Rename an existing Deck board.',
       parameters: {
@@ -1028,6 +1069,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_archive_board',
+      mutates: true,
       domains: ['deck'],
       description: 'Archive a Deck board. Archived boards are hidden from the default view but not deleted.',
       parameters: {
@@ -1052,6 +1094,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_board',
+      mutates: true,
       writes: true,
       domains: ['deck'],
       description: 'Permanently delete a Deck board and all its stacks and cards. This is irreversible and requires confirmation.',
@@ -1079,6 +1122,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_stacks',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all stacks (columns) in a Deck board with card counts. Accepts board name (partial match) or ID.',
       parameters: {
@@ -1108,6 +1152,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_create_stack',
+      mutates: true,
       domains: ['deck'],
       description: 'Create a new stack (column) in a Deck board.',
       parameters: {
@@ -1135,6 +1180,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_rename_stack',
+      mutates: true,
       domains: ['deck'],
       description: 'Rename a stack (column) in a Deck board.',
       parameters: {
@@ -1168,6 +1214,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_stack',
+      mutates: true,
       writes: true,
       domains: ['deck'],
       description: 'Permanently delete a stack (column) and all its cards from a Deck board. This is irreversible and requires confirmation.',
@@ -1203,6 +1250,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_get_card',
+      readOnly: true,
       domains: ['deck'],
       description: 'Get full details of a card including description, due date, assigned users, labels, and comments. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read from a shared board.',
       parameters: {
@@ -1254,6 +1302,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_update_card',
+      mutates: true,
       domains: ['deck'],
       description: 'Update a card\'s title, description, or due date. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
@@ -1306,6 +1355,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_delete_card',
+      mutates: true,
       writes: true,
       domains: ['deck'],
       description: 'Delete a card from the board. This is destructive and requires confirmation. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to delete a card on a shared board.',
@@ -1338,6 +1388,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_assign_user',
+      mutates: true,
       domains: ['deck'],
       description: 'Assign a user to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to assign on a shared board.',
       parameters: {
@@ -1384,6 +1435,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_unassign_user',
+      mutates: true,
       domains: ['deck'],
       description: 'Remove a user assignment from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to unassign on a shared board.',
       parameters: {
@@ -1419,6 +1471,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_set_due_date',
+      mutates: true,
       domains: ['deck'],
       description: 'Set or clear the due date on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to update a card on a shared board.',
       parameters: {
@@ -1472,6 +1525,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_label',
+      mutates: true,
       domains: ['deck'],
       description: 'Add a label to a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board. The label must already exist on the target board (use deck_create_label first if needed).',
       parameters: {
@@ -1511,6 +1565,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_remove_label',
+      mutates: true,
       domains: ['deck'],
       description: 'Remove a label from a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to operate on a shared board.',
       parameters: {
@@ -1549,6 +1604,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_create_label',
+      mutates: true,
       domains: ['deck'],
       description: 'Create a new label on a board. Use this when the board needs a label that doesn\'t exist yet.',
       parameters: {
@@ -1575,6 +1631,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_add_comment',
+      mutates: true,
       domains: ['deck'],
       description: 'Add a comment to a card. Use this to leave notes, updates, or communicate about a task. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to comment on a shared board.',
       parameters: {
@@ -1603,6 +1660,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_list_comments',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all comments on a card. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to read comments on a shared board.',
       parameters: {
@@ -1641,6 +1699,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_share_board',
+      mutates: true,
       writes: true,
       domains: ['deck'],
       description: 'Share a board you own with another user or group. Requires confirmation.',
@@ -1681,6 +1740,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_overview',
+      readOnly: true,
       domains: ['deck'],
       description: 'Get a summary of all accessible boards: board names, card counts per stack, and overdue items. Use when asked for a board overview or status summary.',
       parameters: { type: 'object', properties: {}, required: [] },
@@ -1718,6 +1778,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_my_assigned_cards',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all cards assigned to a user across all accessible boards. Defaults to you if no user specified.',
       parameters: {
@@ -1753,6 +1814,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_overdue_cards',
+      readOnly: true,
       domains: ['deck'],
       description: 'List all cards with past due dates across all accessible boards.',
       parameters: { type: 'object', properties: {}, required: [] },
@@ -1779,6 +1841,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_mark_done',
+      mutates: true,
       domains: ['deck'],
       description: 'Mark a card as done by moving it to the Done stack. Card identified by title (partial match) or #ID. Defaults to the task board; pass `board` to mark a card on a shared board (requires a stack titled "Done" on that board).',
       parameters: {
@@ -1822,6 +1885,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_complete_task',
+      mutates: true,
       domains: ['deck'],
       description: 'Mark a task as complete: moves the card to Done and adds a completion comment.',
       parameters: {
@@ -1845,6 +1909,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_complete_review',
+      mutates: true,
       domains: ['deck'],
       description: 'Complete the review process: moves a card from Review to Done with an optional final note.',
       parameters: {
@@ -1870,6 +1935,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_setup_workflow',
+      mutates: true,
       writes: true,
       domains: ['deck'],
       description: 'Create a new board with a set of named stacks (columns), optionally seed it with cards in the first stack, and optionally share it with a user. Use when asked to set up a workflow or project board with a defined column structure. Requires confirmation.',
@@ -1952,6 +2018,7 @@ class ToolRegistry {
 
     this.register({
       name: 'deck_troubleshoot',
+      readOnly: true,
       domains: ['deck'],
       description: 'Diagnose board access and visibility issues. Lists accessible boards and reports whether a specific board exists. Does NOT perform sharing — if a share is needed, use deck_share_board.',
       parameters: {
@@ -2010,6 +2077,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_list_events',
+      readOnly: true,
       domains: ['calendar'],
       description: 'List upcoming calendar events. Returns event titles, times, and descriptions.',
       parameters: {
@@ -2047,6 +2115,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_create_event',
+      mutates: true,
       writes: true,
       domains: ['calendar'],
       description: 'Create a calendar event. Optionally checks availability first (set check_availability: true). Supports attendees with automatic invitation emails. Use duration_minutes OR end to set the event length (default: 60 minutes).',
@@ -2184,6 +2253,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_update_event',
+      mutates: true,
       writes: true,
       domains: ['calendar'],
       description: 'Update an existing calendar event. Use to reschedule, rename, change duration, add attendees, or modify any event property.',
@@ -2293,6 +2363,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_delete_event',
+      mutates: true,
       writes: true,
       domains: ['calendar'],
       description: 'Delete a calendar event.',
@@ -2325,6 +2396,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_check_availability',
+      readOnly: true,
       domains: ['calendar'],
       description: 'Check whether a time slot is free. Returns availability and any conflicting events. If end is omitted, checks a 1-hour window from start.',
       parameters: {
@@ -2374,6 +2446,7 @@ class ToolRegistry {
 
     this.register({
       name: 'calendar_cancel_meeting',
+      mutates: true,
       writes: true,
       domains: ['calendar'],
       description: 'Cancel a scheduled meeting and send cancellation notices to all attendees.',
@@ -2408,6 +2481,7 @@ class ToolRegistry {
 
     this.register({
       name: 'meeting_compose',
+      mutates: true,
       domains: ['calendar'],
       description: 'Start or continue a smart meeting scheduling flow. Resolves participant names from Nextcloud Contacts, checks calendar conflicts, asks for confirmation, creates the event, sends invitations, and tracks RSVPs on Deck. Works in multiple languages (EN/DE/PT). Use this for natural language meeting requests like "Schedule a meeting with João and Maria next Tuesday at 2pm".',
       parameters: {
@@ -2445,6 +2519,7 @@ class ToolRegistry {
 
     this.register({
       name: 'meeting_check_rsvp',
+      readOnly: true,
       domains: ['calendar'],
       description: 'Check RSVP status for a scheduled meeting. Shows who accepted, declined, or hasn\'t responded yet.',
       parameters: {
@@ -2516,6 +2591,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_read',
+      readOnly: true,
       domains: ['file'],
       description: 'Read the contents of a text file from Nextcloud. Works with .txt, .md, .json, .csv, .yaml, .html, .xml, and similar text files. For PDF or Word documents, use file_extract instead.',
       parameters: {
@@ -2554,6 +2630,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_list',
+      readOnly: true,
       domains: ['file'],
       description: 'List files and folders in a Nextcloud directory. Shows name, size, modified date, and type.',
       parameters: {
@@ -2619,6 +2696,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_write',
+      mutates: true,
       writes: true,
       domains: ['file'],
       description: 'Write content to a file in your Nextcloud workspace. Creates the file if it doesn\'t exist, overwrites if it does.',
@@ -2665,6 +2743,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_info',
+      readOnly: true,
       domains: ['file'],
       description: 'Get metadata about a file: size, last modified, type, permissions, and whether it\'s shared.',
       parameters: {
@@ -2707,6 +2786,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_move',
+      mutates: true,
       writes: true,
       domains: ['file'],
       description: 'Move or rename a file within Nextcloud.',
@@ -2731,6 +2811,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_copy',
+      mutates: true,
       domains: ['file'],
       description: 'Copy a file to a new location.',
       parameters: {
@@ -2754,6 +2835,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_delete',
+      mutates: true,
       writes: true,
       domains: ['file'],
       description: 'Delete a file or folder. Requires confirmation.',
@@ -2777,6 +2859,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_mkdir',
+      mutates: true,
       domains: ['file'],
       description: 'Create a new folder in your workspace.',
       parameters: {
@@ -2799,6 +2882,7 @@ class ToolRegistry {
 
     this.register({
       name: 'file_share',
+      mutates: true,
       writes: true,
       domains: ['file'],
       description: 'Share a file or folder with a user. Uses NC\'s native sharing. Requires confirmation.',
@@ -2827,6 +2911,7 @@ class ToolRegistry {
     if (extractor) {
       this.register({
         name: 'file_extract',
+        readOnly: true,
         domains: ['file'],
         description: 'Extract text content from PDF, Word (.docx), or Excel (.xlsx) files. Downloads the file and extracts readable text.',
         parameters: {
@@ -2880,6 +2965,7 @@ class ToolRegistry {
 
     this.register({
       name: 'unified_search',
+      readOnly: true,
       domains: ['search'],
       description: 'Search across everything in Nextcloud — files, tasks, calendar events, contacts, chat messages. Use when you don\'t know which app contains what you\'re looking for.',
       parameters: {
@@ -2947,6 +3033,7 @@ class ToolRegistry {
 
     this.register({
       name: 'tag_file',
+      mutates: true,
       domains: ['file'],
       description: 'Assign a system tag to a file. Tags: pending, processed, needs-review, ai-flagged.',
       parameters: {
@@ -2984,6 +3071,7 @@ class ToolRegistry {
 
     this.register({
       name: 'memory_recall',
+      readOnly: true,
       domains: ['search'],
       description: 'Search the learning log for information about a topic. Use this when you need to recall something previously learned.',
       parameters: {
@@ -3030,6 +3118,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_read',
+      readOnly: true,
       domains: ['wiki'],
       description: 'Read a page from the Moltagent Knowledge wiki. Returns page content with frontmatter metadata summary.',
       parameters: {
@@ -3072,6 +3161,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_write',
+      mutates: true,
       writes: true,
       domains: ['wiki'],
       description: 'Create or update a page in the Moltagent Knowledge wiki. Content can include YAML frontmatter between --- delimiters. To ADD to an existing page rather than replace it, call wiki_read first, then wiki_write with the merged content.',
@@ -3237,6 +3327,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_search',
+      readOnly: true,
       domains: ['wiki'],
       description: 'Search the Moltagent Knowledge wiki for pages matching a query.',
       parameters: {
@@ -3326,6 +3417,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_list',
+      readOnly: true,
       domains: ['wiki', 'search'],
       description: 'List pages in a section of the Moltagent Knowledge wiki. Sections: People, Projects, Procedures, Research, Meta.',
       parameters: {
@@ -3386,6 +3478,7 @@ class ToolRegistry {
 
     this.register({
       name: 'wiki_delete',
+      mutates: true,
       writes: true,
       domains: ['wiki'],
       description: 'Delete (trash) a page from the Moltagent Knowledge wiki. This action cannot be undone.',
@@ -3431,6 +3524,7 @@ class ToolRegistry {
     if (searxng) {
       this.register({
         name: 'web_search',
+        readOnly: true,
         universal: true,
         description: 'Search the web via SearXNG (default) or commercial providers. Use provider="multi" to query all available sources in parallel with deduplication.',
         parameters: {
@@ -3541,6 +3635,7 @@ class ToolRegistry {
     if (webReader) {
       this.register({
         name: 'web_read',
+        readOnly: true,
         domains: ['search'],
         description: 'Fetch and extract readable content from a URL. Returns article text, title, and metadata.',
         parameters: {
@@ -3575,6 +3670,7 @@ class ToolRegistry {
 
     this.register({
       name: 'contacts_search',
+      readOnly: true,
       domains: ['email', 'search'],
       description: 'Search Nextcloud Contacts (address book) by name. Returns matching contacts with name, email, phone, and organization. Use when you need to find someone\'s email or contact details.',
       parameters: {
@@ -3623,6 +3719,7 @@ class ToolRegistry {
 
     this.register({
       name: 'contacts_get',
+      readOnly: true,
       domains: ['email'],
       description: 'Get full details for a specific contact by their CardDAV href. Use after contacts_search to get complete contact information.',
       parameters: {
@@ -3677,6 +3774,7 @@ class ToolRegistry {
 
     this.register({
       name: 'contacts_resolve',
+      readOnly: true,
       domains: ['email'],
       description: 'Look up a contact by name. Returns email, phone, and other details. Handles partial names and disambiguates if multiple matches are found.',
       parameters: {
@@ -3723,6 +3821,7 @@ class ToolRegistry {
 
     this.register({
       name: 'memory_search',
+      readOnly: true,
       domains: ['email', 'wiki', 'search'],
       description: 'Search across your knowledge wiki, Talk conversations, files, tasks, and calendar. Use to recall past decisions, people, project details, conversations, or events. Supports time filtering with since/until.',
       parameters: {
@@ -3795,6 +3894,7 @@ class ToolRegistry {
 
     this.register({
       name: 'workflow_deck_move_card',
+      mutates: true,
       domains: ['workflow'],
       description: 'Move a card to a different stack using raw numeric IDs. Use this in workflow processing to move cards between stacks on any board.',
       parameters: {
@@ -3822,6 +3922,7 @@ class ToolRegistry {
 
     this.register({
       name: 'workflow_deck_add_comment',
+      mutates: true,
       domains: ['workflow'],
       description: 'Add a comment to a card using its numeric ID. Use this in workflow processing to log actions on cards in any board.',
       parameters: {
@@ -3848,6 +3949,7 @@ class ToolRegistry {
 
     this.register({
       name: 'workflow_deck_create_card',
+      mutates: true,
       domains: ['workflow'],
       description: 'Create a card on any board. Provide board_id and either stack (name) or stack_id. Stack names are resolved against the target board to avoid cross-board ID mismatches.',
       parameters: {
@@ -3919,6 +4021,7 @@ class ToolRegistry {
 
     this.register({
       name: 'workflow_deck_update_card',
+      mutates: true,
       domains: ['workflow'],
       description: 'Update a card on any board using raw numeric IDs. Use this in workflow processing to modify card title, description, or due date.',
       parameters: {
@@ -3983,6 +4086,7 @@ class ToolRegistry {
 
     this.register({
       name: 'workflow_deck_assign_label',
+      mutates: true,
       domains: ['workflow'],
       description: 'Assign a label to a card using raw numeric IDs. Use this in workflow processing to add labels (e.g. GATE, APPROVED) to cards on any board.',
       parameters: {
@@ -4019,6 +4123,7 @@ class ToolRegistry {
     if (emailHandler) {
       this.register({
         name: 'mail_send',
+        mutates: true,
         writes: true,
         domains: ['email'],
         description: 'Send an email. REQUIRES human approval before execution. Provide recipient, subject, and body. The email will be sent via SMTP from the configured Moltagent email account.',
@@ -4058,6 +4163,7 @@ class ToolRegistry {
     if (newsClient) {
       this.register({
         name: 'news_get_items',
+        readOnly: true,
         domains: ['news'],
         description: 'Get recent unread articles from NC News RSS feeds. Returns title, URL, body summary, and feed source for each item.',
         parameters: {
@@ -4095,6 +4201,7 @@ class ToolRegistry {
 
       this.register({
         name: 'news_list_feeds',
+        readOnly: true,
         domains: ['news'],
         description: 'List all RSS feeds subscribed in NC News with their unread counts.',
         parameters: {
@@ -4123,6 +4230,7 @@ class ToolRegistry {
 
       this.register({
         name: 'news_mark_read',
+        mutates: true,
         domains: ['news'],
         description: 'Mark a news item as read after it has been evaluated or turned into a Deck card.',
         parameters: {

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -745,6 +745,7 @@ class MessageProcessor {
             user: extracted.user,
             gate,
             domain,
+            language: clsLanguage,
             compound,
             systemSuffix: focusContext ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext) : flushPrompt,
             onArtifact
@@ -813,6 +814,7 @@ class MessageProcessor {
                 user: extracted.user,
                 gate,
                 domain,
+                language: clsLanguage,
                 compound,
                 systemSuffix: focusContext || undefined,
                 onArtifact
@@ -848,6 +850,7 @@ class MessageProcessor {
               user: extracted.user,
               gate,
               domain,
+              language: clsLanguage,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -892,6 +895,7 @@ class MessageProcessor {
               user: extracted.user,
               gate,
               domain,
+              language: clsLanguage,
               systemSuffix: focusContext
                 ? (flushPrompt ? flushPrompt + '\n' + focusContext : focusContext)
                 : flushPrompt,
@@ -937,6 +941,7 @@ class MessageProcessor {
               user: extracted.user,
               gate,
               domain,
+              language: clsLanguage,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -967,6 +972,7 @@ class MessageProcessor {
               user: extracted.user,
               gate,
               domain,
+              language: clsLanguage,
               systemSuffix: focusContext || undefined,
               onArtifact
             });
@@ -1007,6 +1013,7 @@ class MessageProcessor {
             user: extracted.user,
             gate,
             domain,
+            language: clsLanguage,
             compound
           };
 

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -45,7 +45,15 @@ function createMockContextLoader(context = '') {
   };
 }
 
-function createMockToolRegistry(tools = {}) {
+/**
+ * @param {Object} tools - name → handler
+ * @param {string[]} [readOnly] - names that change nothing. Everything else
+ *   mutates, mirroring ToolRegistry.isMutating's fail-safe default: a tool that
+ *   cannot say is assumed to have acted, so the guard never prints a false
+ *   "nothing happened" over a real mutation.
+ */
+function createMockToolRegistry(tools = {}, readOnly = []) {
+  const readOnlyNames = new Set(readOnly);
   return {
     getToolDefinitions: () => Object.keys(tools).map(name => ({
       type: 'function',
@@ -55,9 +63,12 @@ function createMockToolRegistry(tools = {}) {
       if (tools[name]) return tools[name](args);
       return { success: false, result: '', error: `Unknown tool: ${name}` };
     },
-    has: (name) => name in tools
+    has: (name) => name in tools,
+    isMutating: (name) => !readOnlyNames.has(name)
   };
 }
+
+const { NO_ACTION_TRAILER } = require('../../../src/lib/agent/action-guard');
 
 // Write a temp SOUL.md for testing
 const testSoulPath = path.join(__dirname, 'test-soul.md');
@@ -1468,8 +1479,12 @@ asyncTest('action-hallucination guard fires at most once per turn (legitimate te
   });
 
   const response = await loop.process('delete card 42 on Imaginary board', 'room-abc', { gate: 'action' });
-  assert.strictEqual(response, 'I cannot delete it — the board does not exist.');
   assert.strictEqual(provider._getCallCount(), 2);  // exactly 2 LLM calls, no infinite loop
+
+  // The refusal survives intact — the honesty floor appends beneath it and never
+  // replaces it. Replacement would delete the one useful sentence in the turn.
+  assert.ok(response.startsWith('I cannot delete it — the board does not exist.'));
+  assert.ok(response.endsWith(NO_ACTION_TRAILER.EN));
 });
 
 asyncTest('action-hallucination guard bumps maxIter when capped at 2 (short-message heuristic case)', async () => {
@@ -1596,17 +1611,27 @@ asyncTest('action-hallucination guard: response stages HITL marker after read-on
   assert.strictEqual(response, 'Deleted card #42.');
 });
 
-asyncTest('action-hallucination guard does NOT fire when read-only tool runs and response has no HITL marker (legitimate summarize-result reply)', async () => {
-  // gate=action + one read-only tool + clean text response = legitimate.
-  // Common case: "how many cards" classified as action; list-then-summarize is right.
+asyncTest('a read-only turn misclassified as gate=action carries the trailer (diagnostic, not suppressed)', async () => {
+  // "how many cards" classified as action; list-then-summarize is the right work,
+  // but the classifier called it an action. Nothing structural distinguishes this
+  // from a prose offer — both are gate=action with only a read — and separating
+  // them would mean reading prose. So the guard re-prompts and the trailer lands.
+  //
+  // That is deliberate. The trailer is a classifier-quality signal surfacing in
+  // production: it says, truthfully, that this turn changed nothing. No heuristic
+  // suppresses it, and its journal line carries the gate and the invoked tool
+  // names so a recurring false fire is attributable to the classification, which
+  // is where the fix belongs.
   const provider = createMockProvider([
     { content: null, toolCalls: [{ id: 'call_1', name: 'deck_list_cards', arguments: {} }] },
+    { content: 'There are 3 cards in Ideas.', toolCalls: null },
     { content: 'There are 3 cards in Ideas.', toolCalls: null }
   ]);
 
-  const registry = createMockToolRegistry({
-    deck_list_cards: async () => ({ success: true, result: '#1, #2, #3' })
-  });
+  const registry = createMockToolRegistry(
+    { deck_list_cards: async () => ({ success: true, result: '#1, #2, #3' }) },
+    ['deck_list_cards']
+  );
 
   const loop = new AgentLoop({
     toolRegistry: registry,
@@ -1616,9 +1641,36 @@ asyncTest('action-hallucination guard does NOT fire when read-only tool runs and
     logger: silentLogger
   });
 
-  const response = await loop.process('list cards on the board', 'room-abc', { gate: 'action' });
+  const response = await loop.process('how many cards on the board', 'room-abc', { gate: 'action' });
+  assert.ok(response.startsWith('There are 3 cards in Ideas.'), 'informational answer preserved');
+  assert.ok(response.endsWith(NO_ACTION_TRAILER.EN), 'trailer appended beneath it');
+  assert.strictEqual(provider._getCallCount(), 3);  // one bounded re-prompt
+});
+
+asyncTest('a read-only turn at gate=knowledge is untouched (no re-prompt, no trailer)', async () => {
+  // The guard is armed only at gate=action. A knowledge turn that reads and
+  // summarizes is exactly what it should do.
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'call_1', name: 'deck_list_cards', arguments: {} }] },
+    { content: 'There are 3 cards in Ideas.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry(
+    { deck_list_cards: async () => ({ success: true, result: '#1, #2, #3' }) },
+    ['deck_list_cards']
+  );
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('how many cards on the board', 'room-abc', { gate: 'knowledge' });
   assert.strictEqual(response, 'There are 3 cards in Ideas.');
-  assert.strictEqual(provider._getCallCount(), 2);  // no re-prompt
+  assert.strictEqual(provider._getCallCount(), 2);
 });
 
 asyncTest('action-hallucination guard: HITL marker fires at gate=confirmation (#85 — destructive intent via follow-up turn)', async () => {
@@ -1981,6 +2033,245 @@ asyncTest('#164: text-form call on a gate=action turn is invoked, reply is synth
 // ============================================================
 // Cleanup & Summary
 // ============================================================
+
+// ============================================================
+// #81 commit 2 — the write-class guard, the honesty floor,
+// and the two production transcripts of 2026-07-09
+// ============================================================
+
+// ── Fixture 1: the fabricated confirmation ──────────────────
+//
+// gate=action, zero tool calls, no 🔐 marker, and a final reply asserting a
+// deletion that never happened. The guard re-prompted; the model spent its one
+// second chance producing a MORE confident falsehood. One re-prompt is a
+// request, not a guarantee — the floor is what stops the lie.
+
+asyncTest('#81 fixture 1: fabricated tool confirmation is re-prompted, then floored', async () => {
+  const provider = createMockProvider([
+    { content: 'Ich lösche die Karte.', toolCalls: null },
+    { content: 'Ich habe die Karte gelöscht — die Tool-Bestätigung liegt vor. Karte #2475 ist weg.', toolCalls: null }
+  ]);
+
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('lösch die Karte test a', 'room-abc', { gate: 'action', language: 'DE' });
+
+  assert.strictEqual(provider._getCallCount(), 2, 'one bounded re-prompt');
+  // The lie still reaches the user — the model cannot be prevented from writing it.
+  // What cannot happen is the turn ENDING on it without contradiction.
+  assert.ok(response.includes('Ich habe die Karte gelöscht'));
+  assert.ok(response.endsWith(NO_ACTION_TRAILER.DE), 'floor states, in the user\'s language, that nothing was executed');
+});
+
+// ── Fixture 2: the prose offer after a read call ────────────
+//
+// gate=action, deck_list_cards ran, the turn ends asking "Delete it?" in prose.
+// Defeats BOTH pre-#266 signals: actionWithoutToolCall is false (a tool ran) and
+// responseStagesApproval is false (no 🔐 marker). This is why the condition had
+// to become "no MUTATING call" rather than "no call".
+//
+// This shape is a UX degradation, not a safety hole, and only because #264
+// landed first: the prose offer opens no approval poll and creates no
+// PendingAction record, so a later "ja" finds no record, self-authorizes
+// nothing, and lands in a real ceremony. The re-prompt is its remedy, not the
+// floor — the floor intercepts false success claims, and an offer claims
+// nothing. "Delete it?" is a question; there is no proposition to be ungrounded.
+
+asyncTest('#81 fixture 2: prose offer after a read-only call is re-prompted into the real tool call', async () => {
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'c1', name: 'deck_list_cards', arguments: {} }] },
+    { content: 'Found it — card #2460 "ORG-RECORD" is in the Reference stack. Delete it?', toolCalls: null },
+    { content: null, toolCalls: [{ id: 'c2', name: 'deck_delete_card', arguments: { card: '#2460' } }] },
+    { content: 'Deleted card #2460.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_list_cards: async () => ({ success: true, result: '#2460 ORG-RECORD' }),
+    deck_delete_card: async () => ({ success: true, result: 'Deleted card #2460.' })
+  }, ['deck_list_cards']);
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('take care of ORG-RECORD', 'room-abc', { gate: 'action', language: 'EN' });
+
+  // The re-prompt did its job: the destructive tool was actually invoked, so the
+  // turn acted and the floor stays silent.
+  assert.strictEqual(response, 'Deleted card #2460.');
+  assert.ok(!response.includes(NO_ACTION_TRAILER.EN), 'no trailer once the turn mutated');
+  assert.strictEqual(provider._getCallCount(), 4);
+});
+
+asyncTest('#81 fixture 2 (unrepaired): if the model re-offers instead of calling, the floor lands', async () => {
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'c1', name: 'deck_list_cards', arguments: {} }] },
+    { content: 'Found it. Delete it?', toolCalls: null },
+    { content: 'Shall I go ahead and delete it?', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_list_cards: async () => ({ success: true, result: '#2460' })
+  }, ['deck_list_cards']);
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('take care of ORG-RECORD', 'room-abc', { gate: 'action', language: 'PT' });
+  assert.ok(response.startsWith('Shall I go ahead and delete it?'));
+  assert.ok(response.endsWith(NO_ACTION_TRAILER.PT));
+  assert.strictEqual(provider._getCallCount(), 3, 'bounded to one re-prompt');
+});
+
+// ── Mutation, not approval ──────────────────────────────────
+
+asyncTest('a successful card creation gets no trailer and no re-prompt (mutating, ungated)', async () => {
+  // The regression that killed the briefed design: deck_create_card mutates but
+  // needs no approval, so keying the guard on the WRITE CLASS printed
+  // "no action was executed" beneath a card that had just been created.
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'c1', name: 'deck_create_card', arguments: { title: 'Q3' } }] },
+    { content: 'Karte erstellt.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_create_card: async () => ({ success: true, result: 'Created card #77.' })
+  });  // not read-only → mutating
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('Erstell eine Karte Q3', 'room-abc', { gate: 'action', language: 'DE' });
+  assert.strictEqual(response, 'Karte erstellt.', 'no trailer on a real mutation');
+  assert.strictEqual(provider._getCallCount(), 2, 'no re-prompt on a turn that acted');
+});
+
+asyncTest('a DENIED destructive call counts as a call — the turn acted, guard and floor stay silent', async () => {
+  // The user said "nein" to the ceremony. That is a legitimate ending: the tool
+  // was really invoked and really answered. Both layers key on the CALL, never
+  // on its success, or a refused deletion would be re-prompted and then told the
+  // user "no action was executed" as though the model had failed to try.
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'c1', name: 'deck_delete_card', arguments: { card: '#1' } }] },
+    { content: 'Okay, ich habe nichts gelöscht.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    deck_delete_card: async () => ({ success: false, result: '', error: 'Action blocked: denied or timed out' })
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('lösch Karte #1', 'room-abc', { gate: 'action', language: 'DE' });
+  assert.strictEqual(response, 'Okay, ich habe nichts gelöscht.');
+  assert.strictEqual(provider._getCallCount(), 2);
+});
+
+asyncTest('the consecutive-failure skip path does not count as an invocation', async () => {
+  // iterationToolsCalled.push() also fires when a tool is SKIPPED after repeated
+  // failures. A skipped tool never ran, so it must not satisfy "the turn acted".
+  let attempts = 0;
+  const provider = createMockProvider([
+    { content: null, toolCalls: [{ id: 'c1', name: 'flaky_write', arguments: {} }] },
+    { content: null, toolCalls: [{ id: 'c2', name: 'flaky_write', arguments: {} }] },
+    { content: null, toolCalls: [{ id: 'c3', name: 'flaky_write', arguments: {} }] },  // skipped
+    { content: 'All set.', toolCalls: null },
+    { content: 'All set.', toolCalls: null }
+  ]);
+
+  const registry = createMockToolRegistry({
+    flaky_write: async () => { attempts++; return { success: false, result: '', error: 'boom' }; }
+  });
+
+  const loop = new AgentLoop({
+    toolRegistry: registry,
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('do the thing', 'room-abc', { gate: 'action', language: 'EN' });
+  assert.strictEqual(attempts, 2, 'third call was skipped, not executed');
+  // The two real attempts were invocations of a mutating tool, so the turn "acted"
+  // even though both failed. Failure is an outcome; the guard polices non-invocation.
+  assert.ok(!response.includes(NO_ACTION_TRAILER.EN));
+});
+
+// ── The trailer is multilingual on a code-owned surface ─────
+
+asyncTest('the honesty trailer speaks the turn\'s language', async () => {
+  const cases = [
+    ['DE', NO_ACTION_TRAILER.DE],
+    ['EN', NO_ACTION_TRAILER.EN],
+    ['PT', NO_ACTION_TRAILER.PT],
+    ['DE+EN', NO_ACTION_TRAILER.DE],   // bilingual persona → first tag
+    ['pt', NO_ACTION_TRAILER.PT],      // case-insensitive
+    ['FR', NO_ACTION_TRAILER.EN],      // untemplated language → EN, never a guess
+    [undefined, NO_ACTION_TRAILER.EN]  // unset → EN
+  ];
+
+  for (const [language, expected] of cases) {
+    const provider = createMockProvider([
+      { content: 'Ok.', toolCalls: null },
+      { content: 'Ok.', toolCalls: null }
+    ]);
+    const loop = new AgentLoop({
+      toolRegistry: createMockToolRegistry(),
+      conversationContext: createMockConversationContext(),
+      llmProvider: provider,
+      config: { soulPath: testSoulPath },
+      logger: silentLogger
+    });
+    const response = await loop.process('do it', 'room-abc', { gate: 'action', language });
+    assert.ok(response.endsWith(expected), `language=${language} → ${expected}`);
+  }
+});
+
+asyncTest('the trailer appends and never replaces', async () => {
+  const provider = createMockProvider([
+    { content: 'I could not find a card called "DOES-NOT-EXIST".', toolCalls: null },
+    { content: 'I could not find a card called "DOES-NOT-EXIST".', toolCalls: null }
+  ]);
+  const loop = new AgentLoop({
+    toolRegistry: createMockToolRegistry(),
+    conversationContext: createMockConversationContext(),
+    llmProvider: provider,
+    config: { soulPath: testSoulPath },
+    logger: silentLogger
+  });
+
+  const response = await loop.process('delete DOES-NOT-EXIST', 'room-abc', { gate: 'action', language: 'EN' });
+  assert.ok(response.startsWith('I could not find a card called "DOES-NOT-EXIST".'),
+    'the specific refusal is the useful sentence and must survive');
+  assert.ok(response.endsWith(NO_ACTION_TRAILER.EN));
+});
 
 setTimeout(() => {
   try { fs.unlinkSync(testSoulPath); } catch { /* ignore */ }

--- a/test/unit/security/write-class-policy.test.js
+++ b/test/unit/security/write-class-policy.test.js
@@ -63,6 +63,12 @@ const registered = new Set(registry.tools.keys());
 const declaredWrites = new Set(
   [...registry.tools.values()].filter(t => t.writes === true).map(t => t.name)
 );
+const declaredMutates = new Set(
+  [...registry.tools.values()].filter(t => t.mutates === true).map(t => t.name)
+);
+const declaredReadOnly = new Set(
+  [...registry.tools.values()].filter(t => t.readOnly === true).map(t => t.name)
+);
 
 console.log('Write-Class Policy Pin\n');
 
@@ -133,6 +139,63 @@ test('the write class covers the tools that leave the box', () => {
   for (const tool of ['mail_send', 'wiki_write', 'file_write', 'deck_delete_card', 'wiki_delete']) {
     assert.ok(writeClass.has(tool), `${tool} must be write-class`);
   }
+});
+
+// ── The mutation partition (#81 commit 2) ───────────────────────
+//
+// "Does it need approval?" and "does it change the world?" are different
+// questions. The write class answers the first; `mutates` answers the second and
+// is strictly larger — deck_create_card mutates and needs no approval. The action
+// guard reads mutation, and keying it on the write class made it print
+// "no action was executed" beneath a successfully created card.
+
+test('every registered tool declares exactly one of readOnly / mutates', () => {
+  const undeclared = [];
+  const both = [];
+  for (const tool of registry.tools.values()) {
+    const ro = tool.readOnly === true;
+    const mut = tool.mutates === true;
+    if (ro && mut) both.push(tool.name);
+    if (!ro && !mut) undeclared.push(tool.name);
+  }
+  assert.deepStrictEqual(both.sort(), [], `declared both readOnly and mutates: ${both.join(', ')}`);
+  assert.deepStrictEqual(undeclared.sort(), [],
+    `these tools declare neither readOnly nor mutates: ${undeclared.join(', ')}. ` +
+    'Every tool must answer "does calling this change the world?" at its registration ' +
+    'site — the action-hallucination guard reads that answer to decide whether a ' +
+    'gate=action turn actually acted.');
+});
+
+test('the partition is total', () => {
+  assert.strictEqual(declaredReadOnly.size + declaredMutates.size, registered.size);
+});
+
+test('every write-class tool is a mutating tool', () => {
+  const gatedButNotMutating = [...getWriteClassTools()].filter(t => !declaredMutates.has(t)).sort();
+  assert.deepStrictEqual(gatedButNotMutating, [],
+    `these tools require approval but do not declare mutates: ${gatedButNotMutating.join(', ')}. ` +
+    'Approval exists because the tool changes something; a gated tool that changes ' +
+    'nothing is a policy error.');
+});
+
+test('mutation is strictly larger than the write class', () => {
+  // Not a tautology: it pins the distinction the guard depends on. If these ever
+  // coincide, someone has re-conflated approval with mutation.
+  const mutatingButUngated = [...declaredMutates].filter(t => !getWriteClassTools().has(t));
+  assert.ok(mutatingButUngated.length > 0,
+    'expected tools that mutate without needing approval (e.g. deck_create_card)');
+  assert.ok(declaredMutates.has('deck_create_card'), 'deck_create_card must declare mutates');
+  assert.ok(!getWriteClassTools().has('deck_create_card'), 'deck_create_card must not need approval');
+});
+
+test('ToolRegistry.isMutating answers from the declaration, and fails safe', () => {
+  assert.strictEqual(registry.isMutating('deck_create_card'), true);
+  assert.strictEqual(registry.isMutating('deck_delete_card'), true);
+  assert.strictEqual(registry.isMutating('deck_list_cards'), false);
+  assert.strictEqual(registry.isMutating('wiki_read'), false);
+  // Unknown / undeclared: assume the turn acted, so the guard never prints a
+  // false "nothing happened" over a real mutation.
+  assert.strictEqual(registry.isMutating('some_skillforge_tool'), true);
 });
 
 // ── FORBIDDEN is the opposite relationship ──────────────────────


### PR DESCRIPTION
**Advances #81 (commit 2) · Consumes #266's seam · Related #264, #267, #117**

## The invariant

> A `gate=action` turn that invoked no **mutating** tool must not deliver a success claim to the user.

Two bounded layers. **Layer 1** extends the re-prompt condition from *no tool call* to *no mutating tool call*, keeping the once-per-turn bound. **Layer 2** is an honesty floor: at the end of such a turn a code-owned sentence is **appended** stating that nothing was executed.

Appended, never substituted — replacing the narration would delete *"I couldn't find that card"*, the one useful sentence in a refusal, in favour of a generic one.

## Why the briefed design could not ship

The briefing keyed both layers on `getWriteClassTools()`. **The write class is the set of tools that need approval, not the set that changes the world.** They differ by 14 registered tools:

```
registered:                    74
write-class (approval-gated):  16
mutating but NOT write-class:  14
  deck_create_card, deck_move_card, deck_update_card, deck_create_board,
  deck_create_stack, deck_create_label, deck_add_label, deck_remove_label,
  deck_add_comment, deck_assign_user, deck_unassign_user,
  deck_archive_board, deck_complete_task, deck_complete_review
```

Implemented as briefed, a **successful** card creation produced this (real `AgentLoop`, `gate=action`, `language=DE`):

```
guard fired — re-prompting (no write-class tool call, invoked=[deck_create_card])
Honesty trailer appended: writeClassCall=none invoked=[deck_create_card]

  Card created.

  ⚠️ Es wurde keine Aktion ausgeführt — nichts wurde erstellt, geändert oder gelöscht.
```

The card *was* created. This would fire on every create, move, update, assign, comment and label turn — the majority of successful action turns — and burn an extra LLM round-trip re-prompting a turn that had already done its job. It is #81's harm inverted: instead of claiming a success that never happened, the agent denies a success that did. The existing test `guard does NOT fire when LLM calls a tool on iteration 1` caught it.

`deck_create_card` mutates and needs no consent; `deck_list_cards` needs no consent and mutates nothing. **Approval and mutation are orthogonal**, and #266's `writes: true` names the gated set, so it could not serve either.

## The predicate, made structural

Every tool now declares exactly one of `readOnly: true` / `mutates: true` at its registration site — the tool's own answer to *"does calling this change the world?"*, owing nothing to any policy table. The pin asserts:

```
every registered tool declares exactly one     ← totality, no silent default
partition is total (44 mutating + 30 readOnly = 74)
write-class ⊆ mutates                          ← a gated tool that changes nothing is a policy error
mutates ⊋ write-class                          ← pins the distinction the guard depends on
writes:true == write-class                     ← #266, unchanged
```

`ToolRegistry.isMutating()` **fails safe**: an undeclared or unknown tool (a SkillForge tool, a fuzzy alias) is assumed to have acted, so the floor can never print a false *"nothing happened"* over a real mutation. The only unsafe answer is the one it refuses to give.

## Bookkeeping, read rather than assumed

- `toolResultIndices` holds message *indices*; `iterationToolsCalled` resets each iteration. Neither can answer *"did this turn mutate?"*. A turn-scoped `Set` of invoked names is added, populated **only** where a tool is really handed to `_executeWithGuards`. The consecutive-failure **skip path** pushes a name for a tool that never ran and is excluded.
- **A denied or timed-out call counts as a call, and must.** The tool was really invoked and really answered; `"nein"` is a legitimate ending. Both layers key on the *call*, never on its success — the guard polices narration-instead-of-invocation.

## The trailer

Multilingual on a code-owned surface (DE/EN/PT), keyed on the Cockpit language already travelling with the verdict (`clsLanguage`), EN for anything untemplated. No prose is read; no language is detected. This is the same class of surface as the enforcer's approval prompt and the existing feedback messages.

The `ProvenanceAnnotator`'s `groundedRatio` was the briefing's preferred mechanism and is **not consulted**: it scores a fabricated claim as grounded whenever the claim echoes the user's own nouns (#267, filed).

It is also a **diagnostic**. A read-only request misclassified as `gate=action` visibly carries the trailer beneath an informational answer. That is a classifier-quality signal surfacing in production, not a defect here; no heuristic suppresses it, and the journal line carries the gate and the invoked tool names so a recurring false fire is attributable to the classification, where the fix belongs.

## Verification Gate — live on Prime

Deployed `0544649` to the box, restarted, drove real turns through the signed webhook path (`actor.id=users/Funana`), read board state with the Nextcloud MCP.

**1. Clean boot.** `Initialization complete — webhook ready`, `/health` 200, `Trust-based roster: cloud-ok`, 0 error-priority entries.

**2. No false fire, trilingually.** Three action turns that legitimately write:

```
gate=action → Tool call: deck_create_card({"title":"GATE-DE",…})  → "Fertig — Karte "GATE-DE" (#2508) wurde … erstellt."
gate=action → Tool call: deck_create_card({"title":"GATE-EN",…})  → "Done. Created card #2511 "GATE-EN" in your Inbox."
gate=action → Tool call: deck_create_card({"title":"GATE-PT",…})  → "Pronto! Criei o cartão "GATE-PT" (card #2514)…"
```

**Zero** `Action-hallucination guard fired` lines. **Zero** `Honesty trailer appended` lines. All three cards confirmed present by MCP deck read, then cleaned up. This is exactly the regression the briefed design would have produced.

**3. Legitimate refusal, intact beneath a trailer** (Gate item 3, amended reading). `"Lösch die Karte GIBT-ES-NICHT-ABC"`:

```
Tool call: deck_list_cards({})
Action-hallucination guard fired at iteration 2 — re-prompting (no mutating tool call (gate=action, invoked=[deck_list_cards]))
Iteration 3/8
Honesty trailer appended: gate=action mutatingCall=none invoked=[deck_list_cards] guardFired=true language=EN
```

The message the user actually received in Talk:

> Du hast recht — die Karte "GIBT-ES-NICHT-ABC" existiert nicht. Ich kann sie nicht löschen, weil sie auf deinem Board nicht vorhanden ist.
>
> ⚠️ No action was executed — nothing was created, changed, or deleted.

The specific refusal survives; the trailer sits beneath it. One bounded re-prompt.

**4. A blocked ceremony takes neither layer.** `"GATE-DE kann weg"` → the downgrade declined, the ceremony ran, the poll timed out:

```
Tool call: deck_delete_card({"card":"GATE-DE"})
checkApproval: deck_delete_card → MEDIUM severity, requesting HITL
HITL-exit: decision=timeout reply="" elapsedMs=300182 pollIterations=81
ToolGuard approval denied: deck_delete_card — action denied or timed out
chat_outgoing: "Die Deletion wurde blockiert oder ist zeitüberschritten. Versuch es nochmal?"
```

No guard fire, no trailer, and **GATE-DE confirmed still on the board** by MCP read. The tool was invoked; blocking is an outcome, not a non-invocation.

**5. Fixtures.** Both 2026-07-09 transcripts are unit fixtures — the fabricated confirmation (floored) and the prose offer after a read call (re-prompted into the real tool call; and, when the model re-offers instead, floored).

235/235 unit + 6/6 integration test files pass; lint 0 errors.

## One observation worth your eye

In gate item 3 the reply is German and the trailer is **English**, because `language=EN` — `clsLanguage` is the *Cockpit persona language*, not the language of the individual message. The model mirrors the user; code-owned surfaces follow the Cockpit setting. That is consistent with how `getFeedbackMessage` already behaves (the `📋 Working on your tasks...` line in the same exchange is English too), and it is what the spec asked for. Flagging it because the mismatch is visible to a German-speaking user, and if it should instead follow the reply's language that is a separate change with no structural signal to key on today.

## Scope note

Larger than briefed: `tool-registry.js` (74 declarations) and the #266 pin are touched, because the guard's predicate had to move from approval to mutation. Agreed in review before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)