### PR TITLE
fix(trust): the escalation fork consults trust; exhaustion carries its cause (#269)

### DIFF
--- a/src/lib/agent/providers/router-chat-bridge.js
+++ b/src/lib/agent/providers/router-chat-bridge.js
@@ -360,7 +360,7 @@ class RouterChatBridge {
 
         return result;
       } catch (err) {
-        errors.push({ provider: providerId, error: err.message, status: err.status });
+        errors.push({ provider: providerId, error: err.message, status: err.status, cause: err });
         failoverPath.push(providerId);
 
         // Record failure with router
@@ -399,9 +399,15 @@ class RouterChatBridge {
     this.router.stats.errors++;
 
     const lastProvider = candidates[candidates.length - 1];
+    // The last provider error is the root cause of this exhaustion. Carrying it
+    // on `.cause` lets ErrorHandler.classify() name the real category (TIMEOUT,
+    // NETWORK) instead of falling back to INTERNAL on the wrapper's message.
+    const lastCause = errors[errors.length - 1]?.cause || null;
     const chainedErr = new Error(
-      `All providers exhausted for job ${job}. Tried: ${failoverPath.join(' → ')}`
+      `All providers exhausted for job ${job}. Tried: ${failoverPath.join(' → ')}` +
+      (lastCause ? `. Last error: ${lastCause.message}` : '')
     );
+    if (lastCause) chainedErr.cause = lastCause;
     chainedErr._errorChain = {
       primary: `${primaryId}: ${errors[0]?.error || 'failed'}`,
       fallback: errors.length > 1

--- a/src/lib/errors/error-handler.js
+++ b/src/lib/errors/error-handler.js
@@ -63,6 +63,11 @@ const LOG_LEVELS = {
 };
 
 /**
+ * How far classify() follows an error's `.cause` chain before giving up.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
  * Custom error class for Moltagent
  */
 class MoltAgentError extends Error {
@@ -139,11 +144,40 @@ class ErrorHandler {
   }
 
   /**
-   * Classify an error into a category
+   * Classify an error into a category.
+   *
+   * An error that wraps another (`.cause`) inherits its category when it has
+   * none of its own: INTERNAL means "nothing here identified it", so the chain
+   * is walked until something does. The first non-INTERNAL category wins, so a
+   * top-level classification is never overridden by its cause.
+   *
    * @param {Error} error
    * @returns {string} - ErrorCategory value
    */
   classify(error) {
+    const seen = new Set();
+    let current = error;
+
+    for (let depth = 0; current && depth < MAX_CAUSE_DEPTH; depth++) {
+      if (seen.has(current)) break; // cycle
+      seen.add(current);
+
+      const category = this._classifyOne(current);
+      if (category !== ErrorCategory.INTERNAL) return category;
+
+      current = current.cause instanceof Error ? current.cause : null;
+    }
+
+    return ErrorCategory.INTERNAL;
+  }
+
+  /**
+   * Classify a single error, ignoring any cause it wraps.
+   * @param {Error} error
+   * @returns {string} - ErrorCategory value
+   * @private
+   */
+  _classifyOne(error) {
     if (!error) {
       return ErrorCategory.INTERNAL;
     }

--- a/src/lib/llm/router.js
+++ b/src/lib/llm/router.js
@@ -475,7 +475,7 @@ class LLMRouter {
 
       } catch (error) {
         console.log(`[LLMRouter] Provider ${providerId} failed: ${error.message}`);
-        errors.push({ provider: providerId, error: error.message, status: error.status });
+        errors.push({ provider: providerId, error: error.message, status: error.status, cause: error });
         failoverPath.push(providerId);
 
         // Record failure with circuit breaker
@@ -552,11 +552,16 @@ class LLMRouter {
     // All providers exhausted
     this.stats.errors++;
 
+    // The last provider error is the root cause of this exhaustion. Pre-flight
+    // entries (circuit open, budget, rate limit) carry no Error object; only a
+    // real provider throw does.
+    const lastCause = [...errors].reverse().find(e => e.cause instanceof Error)?.cause || null;
+
     await this.auditLog('llm_all_exhausted', {
       task,
       role,
       attempted: failoverPath,
-      errors
+      errors: errors.map(({ cause, ...rest }) => rest)
     });
 
     // Notify user
@@ -568,7 +573,10 @@ class LLMRouter {
     });
 
     const label = job ? `job ${job}` : `role ${role}`;
-    throw new Error(`All providers exhausted for ${label}. Tried: ${failoverPath.join(' -> ')}`);
+    const suffix = lastCause ? `. Last error: ${lastCause.message}` : '';
+    const exhausted = new Error(`All providers exhausted for ${label}. Tried: ${failoverPath.join(' -> ')}${suffix}`);
+    if (lastCause) exhausted.cause = lastCause;
+    throw exhausted;
   }
 
   /**

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -840,6 +840,10 @@ class MessageProcessor {
             }
             result = { intent: 'smart_mix_knowledge', provider: 'local' };
           } catch (knowledgeErr) {
+            if (!this._cloudEscalationAvailable()) {
+              console.warn(`[Message] Knowledge query failed, escalation skipped (trust=${this._resolveJobTrust('tools')}), surfacing root error: ${knowledgeErr.message}`);
+              throw knowledgeErr;
+            }
             console.warn(`[Message] Knowledge query failed, escalating to cloud: ${knowledgeErr.message}`);
             if (this.agentLoop?.llmProvider?.skipLocalForConversation) {
               this.agentLoop.llmProvider.skipLocalForConversation();
@@ -885,6 +889,10 @@ class MessageProcessor {
             result = { intent: `smart_mix_domain:${intent}`, provider: 'local-tools' };
           } catch (domainErr) {
             // Domain escalation: local tool-calling failed → fall back to cloud
+            if (!this._cloudEscalationAvailable()) {
+              console.warn(`[Message] Domain ${intent} failed, escalation skipped (trust=${this._resolveJobTrust('tools')}), surfacing root error: ${domainErr.message}`);
+              throw domainErr;
+            }
             console.warn(`[Message] Domain ${intent} escalated to cloud: ${domainErr.message}`);
             if (this.agentLoop.llmProvider?.skipLocalForConversation) {
               this.agentLoop.llmProvider.skipLocalForConversation();
@@ -931,6 +939,10 @@ class MessageProcessor {
             }
             result = { intent: `smart_mix_local:${intent}`, provider: 'local' };
           } catch (chatErr) {
+            if (!this._cloudEscalationAvailable()) {
+              console.warn(`[Message] Chitchat failed, escalation skipped (trust=${this._resolveJobTrust('tools')}), surfacing root error: ${chatErr.message}`);
+              throw chatErr;
+            }
             console.warn(`[Message] Chitchat escalated to cloud: ${chatErr.message}`);
             if (this.agentLoop.llmProvider?.skipLocalForConversation) {
               this.agentLoop.llmProvider.skipLocalForConversation();
@@ -1610,6 +1622,30 @@ class MessageProcessor {
     const resolver = this.agentLoop && this.agentLoop.llmProvider && this.agentLoop.llmProvider.modelResolver;
     if (!resolver || typeof resolver.resolveTrust !== 'function') return 'unknown';
     try { return resolver.resolveTrust(job); } catch { return 'unknown'; }
+  }
+
+  /**
+   * Could a cloud retry possibly succeed? Consulted at the FIRST fork — the
+   * decision to escalate — by every failure-driven escalation site.
+   *
+   * The chokepoint (RouterChatBridge) still enforces trust at the last fork.
+   * Under local-only, escalating is worse than a no-op: skipLocalForConversation()
+   * demotes the only providers that exist, cloud stays forbidden, and the retry
+   * dies in "all providers exhausted" — a generic error replacing a classifiable
+   * root cause. Escalation is only meaningful where cloud is both permitted and
+   * present.
+   *
+   * @returns {boolean}
+   * @private
+   */
+  _cloudEscalationAvailable() {
+    if (this._resolveJobTrust('tools') === 'local-only') return false;
+
+    const router = this.agentLoop?.llmProvider?.router;
+    if (router && typeof router.hasCloudPlayers === 'function') {
+      return router.hasCloudPlayers();
+    }
+    return true; // Router absent (legacy wiring / tests): behave as today.
   }
 
   /**

--- a/test/unit/errors/error-handler.test.js
+++ b/test/unit/errors/error-handler.test.js
@@ -520,6 +520,79 @@ asyncTest('TC-RETHROW-002: Rethrow original error', async () => {
   }
 });
 
+// ============================================================
+// Cause-chain classification (#269)
+// ============================================================
+
+console.log('\n--- Cause-chain classification ---\n');
+
+test('TC-CAUSE-001: Wrapped exhaustion error classifies as its cause', () => {
+  const handler = new ErrorHandler();
+  const root = new Error('Ollama request timed out after 60000ms');
+  const wrapper = new Error('All providers exhausted for job tools. Tried: ollama-local');
+  wrapper.cause = root;
+
+  assert.strictEqual(handler.classify(wrapper), ErrorCategory.TIMEOUT);
+});
+
+test('TC-CAUSE-002: Top-level category is never overridden by the cause', () => {
+  const handler = new ErrorHandler();
+  const root = new Error('connection refused');
+  const wrapper = new Error('rate limit exceeded');
+  wrapper.cause = root;
+
+  assert.strictEqual(handler.classify(wrapper), ErrorCategory.RATE_LIMITED);
+});
+
+test('TC-CAUSE-003: Chain is walked past intermediate INTERNAL links', () => {
+  const handler = new ErrorHandler();
+  const root = new Error('socket hang up');
+  const middle = new Error('wrapper without a category');
+  middle.cause = root;
+  const top = new Error('another opaque wrapper');
+  top.cause = middle;
+
+  assert.strictEqual(handler.classify(top), ErrorCategory.NETWORK);
+});
+
+test('TC-CAUSE-004: Cyclic cause chain terminates', () => {
+  const handler = new ErrorHandler();
+  const a = new Error('opaque a');
+  const b = new Error('opaque b');
+  a.cause = b;
+  b.cause = a;
+
+  assert.strictEqual(handler.classify(a), ErrorCategory.INTERNAL);
+});
+
+test('TC-CAUSE-005: Depth is bounded — a cause past the limit is not consulted', () => {
+  const handler = new ErrorHandler();
+  let error = new Error('Ollama request timed out');
+  for (let i = 0; i < 6; i++) {
+    const wrapper = new Error(`opaque wrapper ${i}`);
+    wrapper.cause = error;
+    error = wrapper;
+  }
+
+  assert.strictEqual(handler.classify(error), ErrorCategory.INTERNAL);
+});
+
+test('TC-CAUSE-006: Non-Error cause is ignored', () => {
+  const handler = new ErrorHandler();
+  const wrapper = new Error('opaque wrapper');
+  wrapper.cause = 'timed out';
+
+  assert.strictEqual(handler.classify(wrapper), ErrorCategory.INTERNAL);
+});
+
+test('TC-CAUSE-007: MoltAgentError with INTERNAL category defers to its cause', () => {
+  const handler = new ErrorHandler();
+  const root = new Error('Ollama request timed out');
+  const wrapper = new MoltAgentError('Operation failed', { cause: root });
+
+  assert.strictEqual(handler.classify(wrapper), ErrorCategory.TIMEOUT);
+});
+
 // Summary
 setTimeout(() => {
   summary();

--- a/test/unit/llm/router.test.js
+++ b/test/unit/llm/router.test.js
@@ -518,6 +518,29 @@ asyncTest('TC-ERROR-002: Throw when all providers exhausted', async () => {
   }
 });
 
+asyncTest('TC-ERROR-002b: Exhaustion error carries the last provider error as cause (#269)', async () => {
+  const rootError = new Error('Ollama request timed out after 60000ms');
+  const failingProvider = createMockProvider({
+    id: 'failing',
+    generate: async () => {
+      throw rootError;
+    }
+  });
+
+  const router = new LLMRouter({
+    roles: { value: ['failing'] }
+  });
+  router.providers.set('failing', failingProvider);
+
+  try {
+    await router.route({ task: 'test', content: 'Hello' });
+    assert.fail('Should have thrown');
+  } catch (error) {
+    assert.strictEqual(error.cause, rootError);
+    assert.ok(error.message.includes('Last error: Ollama request timed out after 60000ms'));
+  }
+});
+
 asyncTest('TC-ERROR-003: Log audit when all exhausted', async () => {
   const mockAuditLog = createMockAuditLog();
   const failingProvider = createMockProvider({

--- a/test/unit/server/local-only-escalation.test.js
+++ b/test/unit/server/local-only-escalation.test.js
@@ -1,0 +1,180 @@
+/**
+ * Local-only escalation tests (#269)
+ *
+ * Architecture Brief
+ * ------------------
+ * The escalate-to-cloud pattern (skipLocalForConversation + retry through the
+ * AgentLoop) is only meaningful where cloud is permitted AND present. Under
+ * trust=local-only it demotes the only providers that exist, the chokepoint
+ * still forbids cloud, and the retry dies in "all providers exhausted" — a
+ * generic error that replaces a classifiable root cause.
+ *
+ * These tests pin the first-fork predicate (_cloudEscalationAvailable) and the
+ * field shape it fixes: a local tools timeout must surface as TIMEOUT, after
+ * exactly one provider cycle.
+ *
+ * Run: node test/unit/server/local-only-escalation.test.js
+ *
+ * Copyright (C) 2026 Moltagent
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const assert = require('assert');
+const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const MessageProcessor = require('../../../src/lib/server/message-processor');
+const { ErrorHandler, ErrorCategory } = require('../../../src/lib/errors/error-handler');
+
+const TIMEOUT_MESSAGE = new ErrorHandler().getUserMessage(ErrorCategory.TIMEOUT);
+
+// ============================================================
+// Harness
+// ============================================================
+
+/**
+ * A RouterChatBridge stand-in: the trust authority (modelResolver) and the
+ * cloud-presence authority (router) are the two the predicate reads.
+ */
+function createBridge({ trust, hasCloud }) {
+  const bridge = {
+    skipCalls: 0,
+    clearCalls: 0,
+    chatProviders: new Map([['ollama-local', {}], ['anthropic', {}]]),
+    modelResolver: { resolveTrust: () => trust },
+    router: { hasCloudPlayers: () => hasCloud },
+    resetConversation() {},
+    skipLocalForConversation() { bridge.skipCalls++; },
+    clearLocalSkip() { bridge.clearCalls++; }
+  };
+  return bridge;
+}
+
+function createProcessor({ trust, hasCloud, domainError }) {
+  const bridge = createBridge({ trust, hasCloud });
+  const replies = [];
+
+  const agentLoop = {
+    llmProvider: bridge,
+    processCalls: 0,
+    async process() {
+      agentLoop.processCalls++;
+      return 'cloud answer';
+    }
+  };
+
+  const microPipeline = {
+    async process() { throw domainError; }
+  };
+
+  const processor = new MessageProcessor({
+    commandHandler: { handle: async () => null },
+    sendTalkReply: async (token, message) => { replies.push(message); return true; },
+    botUsername: 'moltagent',
+    botNames: ['moltagent'],
+    auditLog: async () => {},
+    errorHandler: new ErrorHandler(),
+    agentLoop,
+    microPipeline
+  });
+
+  // The classifier is not under test: pin the domain-tools path.
+  processor._smartMixClassify = async () => ({
+    useLocalPipeline: true,
+    useDomainTools: true,
+    intent: 'calendar',
+    compound: false,
+    gate: 'action',
+    domain: 'calendar'
+  });
+
+  return { processor, bridge, agentLoop, replies };
+}
+
+function talkPayload(content) {
+  return {
+    object: { content, id: 'msg-1' },
+    actor: { id: 'users/alice', type: 'users' },
+    target: { id: 'room-abc' }
+  };
+}
+
+// ============================================================
+// Predicate
+// ============================================================
+
+console.log('\n=== Local-only escalation (#269) ===\n');
+console.log('\n--- _cloudEscalationAvailable ---\n');
+
+test('TC-ESC-001: local-only → escalation unavailable', () => {
+  const { processor } = createProcessor({ trust: 'local-only', hasCloud: true, domainError: new Error('x') });
+  assert.strictEqual(processor._cloudEscalationAvailable(), false);
+});
+
+test('TC-ESC-002: cloud-ok with cloud players → escalation available', () => {
+  const { processor } = createProcessor({ trust: 'cloud-ok', hasCloud: true, domainError: new Error('x') });
+  assert.strictEqual(processor._cloudEscalationAvailable(), true);
+});
+
+test('TC-ESC-003: cloud-ok without cloud players → escalation unavailable', () => {
+  const { processor } = createProcessor({ trust: 'cloud-ok', hasCloud: false, domainError: new Error('x') });
+  assert.strictEqual(processor._cloudEscalationAvailable(), false);
+});
+
+test('TC-ESC-004: resolver absent → behaves as today (available)', () => {
+  const { processor, bridge } = createProcessor({ trust: 'cloud-ok', hasCloud: true, domainError: new Error('x') });
+  delete bridge.modelResolver;
+  delete bridge.router;
+  assert.strictEqual(processor._cloudEscalationAvailable(), true);
+});
+
+// ============================================================
+// Field shape: a local tools timeout under local-only
+// ============================================================
+
+console.log('\n--- Domain-path failure under each trust ---\n');
+
+asyncTest('TC-ESC-005: local-only → no skip, no retry, TIMEOUT surfaced to the user', async () => {
+  const timeout = new Error('Ollama request timed out after 60000ms');
+  const { processor, bridge, agentLoop, replies } = createProcessor({
+    trust: 'local-only', hasCloud: false, domainError: timeout
+  });
+
+  const result = await processor.process(talkPayload('Schedule a meeting tomorrow at 19:00 for 90 minutes'));
+
+  assert.strictEqual(bridge.skipCalls, 0, 'local providers must not be demoted');
+  assert.strictEqual(agentLoop.processCalls, 0, 'no doomed cloud retry');
+  assert.strictEqual(result.error, TIMEOUT_MESSAGE);
+  assert.ok(replies.some(r => r === TIMEOUT_MESSAGE));
+});
+
+asyncTest('TC-ESC-006: cloud-ok → skip + retry, unchanged (regression pin)', async () => {
+  const timeout = new Error('Ollama request timed out after 60000ms');
+  const { processor, bridge, agentLoop } = createProcessor({
+    trust: 'cloud-ok', hasCloud: true, domainError: timeout
+  });
+
+  const result = await processor.process(talkPayload('Schedule a meeting tomorrow at 19:00 for 90 minutes'));
+
+  assert.strictEqual(bridge.skipCalls, 1);
+  assert.strictEqual(agentLoop.processCalls, 1);
+  assert.strictEqual(result.response, 'cloud answer');
+});
+
+asyncTest('TC-ESC-007: local-only → an exhaustion error still classifies by its cause', async () => {
+  const exhausted = new Error('All providers exhausted for job tools. Tried: ollama-local');
+  exhausted.cause = new Error('Ollama request timed out after 60000ms');
+  const { processor, agentLoop } = createProcessor({
+    trust: 'local-only', hasCloud: false, domainError: exhausted
+  });
+
+  const result = await processor.process(talkPayload('Termin morgen um 19:00 Uhr für 90 Minuten'));
+
+  assert.strictEqual(agentLoop.processCalls, 0);
+  assert.strictEqual(result.error, TIMEOUT_MESSAGE);
+});
+
+// Summary
+setTimeout(() => {
+  summary();
+  exitWithCode();
+}, 500);


### PR DESCRIPTION
Closes #269. Filed #270 from discovery.

## The field failure

A `local-only` deployment asked for a meeting to be scheduled. Classification was correct, the domain tools call failed, and the domain catch logged `escalated to cloud`, called `skipLocalForConversation()`, and retried — into a chokepoint that forbids cloud. The retry died in `All providers exhausted for job tools`, the outer catch classified *that*, and the user got "Something unexpected went wrong". Twice the wait, none of the truth.

## A. Trust-aware escalation

Trust was enforced at the last fork (RouterChatBridge) and consulted nowhere at the first one — the decision to escalate. One predicate now sits there:

```js
_cloudEscalationAvailable() {
  if (this._resolveJobTrust('tools') === 'local-only') return false;
  const router = this.agentLoop?.llmProvider?.router;
  if (router?.hasCloudPlayers) return router.hasCloudPlayers();
  return true; // legacy wiring: behave as today
}
```

The three failure-driven escalation sites (knowledge, domain, chitchat) consult it. Unavailable → no skip, no retry, rethrow the **original** error so the outer catch classifies the root cause, with one WARN naming the decision. Available → unchanged. The classification-driven pre-skip paths (memory flush, thinking) are untouched, as briefed.

## B. Cause-carrying exhaustion

Two sites throw an exhaustion error: the router's failover loop and the bridge's candidate loop. **The bridge is the one the field failure actually traverses** — the briefing pinned `router.js:571`; the conversational path exits through `router-chat-bridge.js`. Both now name the last provider error in the message and set `.cause` to it.

`ErrorHandler.classify()` walks the chain: `INTERNAL` means "nothing here identified it", so it asks the cause. Bounded to five links, cycle-safe, and a top-level category is never overridden by what it wraps. Generic — every future wrapping site benefits without remembering to format its message.

## Verification

A harness on Prime drives the real `MessageProcessor`, `RouterChatBridge`, `LLMRouter` and `OllamaToolsProvider`. Talk transport is captured; trust is pinned for the harness conversation only (production trust untouched — Prime stays `cloud-ok`). The tools seat points at an unreachable endpoint.

| | before (`next`) | after |
|---|---|---|
| user message | "Something unexpected went wrong" (INTERNAL) | "Unable to reach the service" (NETWORK) |
| elapsed | 4040ms | 2030ms |
| doomed retries | 1 | 0 |
| locals left demoted | yes | no |

With a black-hole endpoint instead (a real `Ollama request timed out after 3000ms`), the after-branch surfaces the TIMEOUT message in one provider cycle.

Cloud-ok regression, same harness: escalation fires, cloud answers, identical on both branches.

The NETWORK verdict is classified three links down — the exhaustion wrapper, `fetch failed`, and undici's `ECONNREFUSED`. That is the chain-walk earning its keep.

## Discovery finding → #270

`_preSkipLocal` is sticky. A failed escalation left locals demoted for the rest of the conversation. On `local-only` that meant one bad turn poisoned the session; the skip moving behind the predicate closes that half (`preSkipLocal left: false`, verified). The cloud-ok half is a semantics decision, not a patch, and is reported in #270 rather than changed here.

## Tests

`test/unit/server/local-only-escalation.test.js` (new): predicate under each trust and with the resolver absent; local-only → no skip, no retry, TIMEOUT surfaced; cloud-ok → skip + retry (regression pin); an exhaustion error classified by its cause.
`error-handler.test.js`: seven cause-chain tests — wrapped exhaustion, top-level wins, walk past INTERNAL links, cycles, depth bound, non-Error cause, `MoltAgentError` deferring to its cause.
`router.test.js`: exhaustion carries `.cause` and names the last error.

236/236 unit test files pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)