### PR TITLE
feat(surface): one home for code-owned user-facing text (#276)

### DIFF
--- a/src/lib/agent/action-guard.js
+++ b/src/lib/agent/action-guard.js
@@ -23,8 +23,9 @@ const { HITL_PROMPT_MARKER } = require('./guardrail-enforcer');
  * must therefore be unconditional. The "no mutating tool call on an action
  * turn" signal stays gate-conditional and lives in the caller.
  *
- * This module also owns the honesty floor's text (#81 commit 2). The invariant
- * both halves serve:
+ * This module owns the honesty floor's *predicate*. Its text lives in
+ * `surface-text.js` (#276), with every other code-owned sentence a user reads.
+ * The invariant both halves serve:
  *
  *   A gate=action turn that invoked no mutating tool must not deliver a
  *   success claim to the user.
@@ -79,64 +80,8 @@ const ACTION_REPROMPT_DIRECTIVE =
   'If you can perform the action, call the appropriate tool now. If you cannot, explain what prevented you. ' +
   'Do not describe a result the tool has not returned.';
 
-/**
- * The honesty floor's text, per language.
- *
- * This is output templating on a code-owned surface — the same class as the
- * enforcer's approval prompt — not language handling. No prose is read and no
- * language is detected here: the key is the Cockpit language already travelling
- * with the turn on the classification verdict. Unknown languages fall back to EN
- * rather than guessing.
- *
- * The text states a fact about what the turn did, and claims nothing about why.
- * It sits beneath the model's narration, so a specific refusal ("I couldn't find
- * that card") keeps its place as the useful sentence and this only adds the part
- * the model may have omitted or contradicted.
- */
-const NO_ACTION_TRAILER = {
-  EN: '⚠️ No action was executed — nothing was created, changed, or deleted.',
-  DE: '⚠️ Es wurde keine Aktion ausgeführt — nichts wurde erstellt, geändert oder gelöscht.',
-  PT: '⚠️ Nenhuma ação foi executada — nada foi criado, alterado ou eliminado.',
-};
-
-/**
- * Normalise a Cockpit language tag to a trailer key.
- *
- * Accepts the shapes the verdict actually carries: 'DE', 'de', 'DE+EN' (the
- * bilingual persona setting), null. Anything not templated falls back to EN.
- *
- * @param {string|null|undefined} language
- * @returns {'EN'|'DE'|'PT'}
- */
-function _trailerKey(language) {
-  const key = String(language || 'EN').toUpperCase().split('+')[0].trim();
-  return Object.prototype.hasOwnProperty.call(NO_ACTION_TRAILER, key) ? key : 'EN';
-}
-
-/**
- * The honesty floor (#81 commit 2, Layer 2).
- *
- * A gate=action turn that invoked no mutating tool did not act, whatever its
- * prose says. Rather than inspect that prose — the ProvenanceAnnotator's
- * groundedRatio scores a fabricated claim as "grounded" whenever it echoes the
- * user's own nouns, see #267 — the floor appends a code-owned statement of what
- * the turn actually did.
- *
- * Appended, never substituted: replacing the narration would destroy a
- * legitimate specific refusal, and the trailer's job is to add a true sentence,
- * not to remove a useful one.
- *
- * @param {string|null|undefined} language - Cockpit language from the verdict
- * @returns {string}
- */
-function buildNoActionTrailer(language) {
-  return NO_ACTION_TRAILER[_trailerKey(language)];
-}
-
 module.exports = {
   stagesApprovalCeremony,
   stripApprovalMarker,
-  buildNoActionTrailer,
   ACTION_REPROMPT_DIRECTIVE,
-  NO_ACTION_TRAILER,
 };

--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -3,7 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 const { extractArtifact } = require('./artifact-extractor');
-const { stagesApprovalCeremony, stripApprovalMarker, buildNoActionTrailer, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
+const { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
+const { surfaceText, normalizeLanguage } = require('./surface-text');
 
 /**
  * AgentLoop - The Nervous System
@@ -464,7 +465,7 @@ class AgentLoop {
       }
 
       if (!lastResponse) {
-        lastResponse = 'I ran into a loop trying to process your request. Please try rephrasing.';
+        lastResponse = surfaceText('fallback_max_iterations', options.language);
         this.logger.warn(`[AgentLoop] Hit max iterations (${maxIter})`);
       }
 
@@ -520,7 +521,7 @@ class AgentLoop {
         `[AgentLoop] Honesty trailer appended: gate=action expectsMutation=true mutatingCall=none ` +
         `invoked=[${[...toolsInvokedThisTurn].join(', ')}] guardFired=${actionGuardFired} language=${options.language || 'unset'}`
       );
-      lastResponse = `${lastResponse}\n\n${buildNoActionTrailer(options.language)}`;
+      lastResponse = `${lastResponse}\n\n${surfaceText('no_action_trailer', options.language)}`;
     }
 
     const elapsed = Date.now() - startTime;
@@ -742,11 +743,17 @@ class AgentLoop {
    *
    * @param {Object} params
    * @param {string} params.userMessage - The user's reply that resolved the offer
-   * @param {string} params.label - Human-readable action label
+   * @param {string} params.label - Human-readable action label, already in the user's language
    * @param {string} params.outcome - What actually happened (tool result or cancellation)
+   * @param {string|null} [params.language] - The offer's birth language (#273/#276)
    * @returns {Promise<string>} A sentence for the user
    */
-  async narrateOutcome({ userMessage, label, outcome }) {
+  async narrateOutcome({ userMessage, label, outcome, language = null }) {
+    // "Reply in the person's language" is unusable here: the person said "ja".
+    // A one-word reply carries no language worth reading, which is why the
+    // offer's language was stored on the record at birth (#273). Name it.
+    const replyLanguage = normalizeLanguage(language);
+
     try {
       const response = await this.llmProvider.chat({
         job: 'synthesis',
@@ -754,7 +761,7 @@ class AgentLoop {
           'You report an outcome to the person you assist. The action is already finished.',
           '',
           'Rules:',
-          '  - Reply in the same language the person used.',
+          `  - Reply in this language: ${replyLanguage}. The person's own words may be too short to tell.`,
           '  - One or two sentences. State what happened.',
           '  - Never ask for confirmation. Never offer to do it again. It is done.',
         ].join('\n'),
@@ -825,7 +832,7 @@ class AgentLoop {
 
     // GuardrailEnforcer: dynamic Cockpit guardrails with HITL confirmation
     if (this.guardrailEnforcer) {
-      const result = await this.guardrailEnforcer.check(toolCall.name, toolCall.arguments, roomToken);
+      const result = await this.guardrailEnforcer.check(toolCall.name, toolCall.arguments, roomToken, { language });
       if (!result.allowed) {
         if (result.editRequest) {
           this.logger.info(`[AgentLoop] GuardrailEnforcer edit requested: ${toolCall.name}`);

--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -3,6 +3,7 @@
 const { classifyConfirmationReply } = require('../shared/confirmation-classifier');
 const { PendingActionStore } = require('../pending-action-store');
 const { REQUIRES_APPROVAL } = require('../../security/guards/tool-guard');
+const { surfaceText, hasSurfaceText, toolLabel, fieldLabel } = require('./surface-text');
 
 /**
  * GuardrailEnforcer - Runtime Guardrail Enforcement
@@ -95,35 +96,23 @@ const HIGH_SEVERITY_TOOLS = new Set([
   'calendar_cancel_meeting',
 ]);
 
-const TOOL_APPROVAL_LABELS = {
-  deck_delete_card:        'Delete Deck card',
-  deck_delete_board:       'Delete Deck board',
-  deck_delete_stack:       'Delete Deck stack',
-  deck_setup_workflow:     'Set up Deck workflow',
-  deck_share_board:        'Share board',
-  file_delete:             'Delete file',
-  file_move:               'Move file',
-  file_write:              'Write file',
-  file_share:              'Share file',
-  calendar_create_event:   'Create calendar event',
-  calendar_update_event:   'Update calendar event',
-  calendar_delete_event:   'Delete calendar event',
-  calendar_cancel_meeting: 'Cancel meeting',
-  wiki_write:              'Write wiki page',
-  wiki_delete:             'Delete wiki page',
-  mail_send:               'Send email',
-};
+// The tool names a user reads live in surface-text.js (#276), keyed
+// `tool_label_<tool>`. `toolLabel()` renders one, falling back to the raw tool
+// name for anything unlabelled.
 
 // #107: the approval prompt renders the arguments the tool actually registered.
 // Keys are real schema arg names (see ToolRegistry); unmapped tools fall back to
 // a generic key-value render, so no tool can print a placeholder identifier.
+// The second element is a surface-text key, not a word — the mapping from
+// argument to label is structure and lives here; the label itself is text and
+// lives in the table.
 const TOOL_APPROVAL_FIELDS = {
-  deck_delete_card:       [['card', 'Card'], ['board', 'Board']],
-  file_delete:            [['path', 'Path']],
-  wiki_delete:            [['page_title', 'Page']],
-  deck_share_board:       [['board', 'Board'], ['participant', 'With'], ['permission', 'Permission']],
-  file_share:             [['path', 'Path'], ['share_with', 'With'], ['permission', 'Permission']],
-  calendar_cancel_meeting:[['event_uid', 'Event'], ['calendar_id', 'Calendar'], ['reason', 'Reason']],
+  deck_delete_card:       [['card', 'field_card'], ['board', 'field_board']],
+  file_delete:            [['path', 'field_path']],
+  wiki_delete:            [['page_title', 'field_page']],
+  deck_share_board:       [['board', 'field_board'], ['participant', 'field_with'], ['permission', 'field_permission']],
+  file_share:             [['path', 'field_path'], ['share_with', 'field_with'], ['permission', 'field_permission']],
+  calendar_cancel_meeting:[['event_uid', 'field_event'], ['calendar_id', 'field_calendar'], ['reason', 'field_reason']],
 };
 
 // Tools whose effect the user cannot walk back — the prompt says so explicitly
@@ -241,7 +230,7 @@ class GuardrailEnforcer {
    * @param {string|null} roomToken - Talk room token (null for workflow/non-interactive)
    * @returns {Promise<{allowed: boolean, reason: string|null, editRequest?: boolean, editMessage?: string}>}
    */
-  async check(toolName, toolArgs, roomToken) {
+  async check(toolName, toolArgs, roomToken, { language = null } = {}) {
     // Fail open: no cockpitManager → no guardrails to check
     if (!this.cockpitManager) {
       return { allowed: true, reason: null };
@@ -283,7 +272,7 @@ class GuardrailEnforcer {
 
       if (matchResult === 'YES') {
         // Guardrail triggered — request HITL confirmation
-        const response = await this._requestConfirmation(title, toolName, toolArgs, roomToken);
+        const response = await this._requestConfirmation(title, toolName, toolArgs, roomToken, language);
 
         if (response.decision === 'edit') {
           this.logger.info(`[GuardrailEnforcer] ${toolName}: "${title}" → EDIT requested`);
@@ -464,7 +453,7 @@ class GuardrailEnforcer {
    * @returns {Promise<{decision: 'yes'|'no'|'edit'|'timeout', message?: string}>}
    * @private
    */
-  async _requestConfirmation(guardrailTitle, toolName, toolArgs, roomToken) {
+  async _requestConfirmation(guardrailTitle, toolName, toolArgs, roomToken, language = null) {
     // Can't ask = fail closed
     if (!this.talkSendQueue || !this.conversationContext) {
       this.logger.warn('[GuardrailEnforcer] Cannot request confirmation — Talk unavailable, blocking');
@@ -476,7 +465,7 @@ class GuardrailEnforcer {
       return { decision: 'no' };
     }
 
-    const message = this._buildConfirmationMessage(toolName, toolArgs, guardrailTitle);
+    const message = this._buildConfirmationMessage(toolName, toolArgs, guardrailTitle, language);
     const requestTimestamp = Date.now();
     const searchAfter = Math.max(requestTimestamp, this._lastConsumedTimestamp);
 
@@ -577,46 +566,46 @@ class GuardrailEnforcer {
   // ── Confirmation message templates ──────────────────────────────
 
   /** @private */
-  _buildConfirmationMessage(toolName, toolArgs, guardrailTitle) {
-    const guardrailLine = `*Guardrail: "${guardrailTitle}"*`;
+  _buildConfirmationMessage(toolName, toolArgs, guardrailTitle, language) {
+    const guardrailLine = surfaceText('guardrail_attribution', language, { title: guardrailTitle });
 
     switch (toolName) {
       case 'mail_send':
       case 'mail_reply':
-        return this._buildEmailConfirmation(toolArgs, guardrailLine);
+        return this._buildEmailConfirmation(toolArgs, guardrailLine, language);
       case 'file_delete':
-        return this._buildFileDeleteConfirmation(toolArgs, guardrailLine);
+        return this._buildFileDeleteConfirmation(toolArgs, guardrailLine, language);
       case 'file_move':
-        return this._buildFileMoveConfirmation(toolArgs, guardrailLine);
+        return this._buildFileMoveConfirmation(toolArgs, guardrailLine, language);
       case 'calendar_create_event':
       case 'calendar_update_event':
-        return this._buildCalendarConfirmation(toolName, toolArgs, guardrailLine);
+        return this._buildCalendarConfirmation(toolName, toolArgs, guardrailLine, language);
       case 'calendar_delete_event':
       case 'calendar_cancel_meeting':
-        return this._buildCalendarDeleteConfirmation(toolArgs, guardrailLine);
+        return this._buildCalendarDeleteConfirmation(toolArgs, guardrailLine, language);
       case 'wiki_write':
-        return this._buildWikiWriteConfirmation(toolArgs, guardrailLine);
+        return this._buildWikiWriteConfirmation(toolArgs, guardrailLine, language);
       case 'wiki_delete':
       case 'deck_delete_card':
       case 'deck_share_board':
       case 'file_share':
-        return this._buildGenericConfirmation(toolName, toolArgs, guardrailLine);
+        return this._buildGenericConfirmation(toolName, toolArgs, guardrailLine, language);
       default:
-        return this._buildGenericConfirmation(toolName, toolArgs, guardrailLine);
+        return this._buildGenericConfirmation(toolName, toolArgs, guardrailLine, language);
     }
   }
 
   /** @private */
-  _buildEmailConfirmation(args, guardrailLine) {
+  _buildEmailConfirmation(args, guardrailLine, language) {
     const separator = '\u2500'.repeat(25);
-    const body = args.body || args.text || '(no body)';
-    const cc = args.cc ? `\nCC: ${args.cc}` : '';
+    const body = args.body || args.text || surfaceText('placeholder_no_body', language);
+    const cc = args.cc ? `\n${fieldLabel('field_cc', language)}: ${args.cc}` : '';
 
     return [
-      '\u{1f4e7} **Email ready to send**',
+      surfaceText('confirm_email_header', language),
       '',
-      `**To:** ${args.to || '(no recipient)'}${cc}`,
-      `**Subject:** ${args.subject || '(no subject)'}`,
+      `**${fieldLabel('field_to', language)}:** ${args.to || surfaceText('placeholder_no_recipient', language)}${cc}`,
+      `**${fieldLabel('field_subject', language)}:** ${args.subject || surfaceText('placeholder_no_subject', language)}`,
       '',
       separator,
       body.trim(),
@@ -624,123 +613,114 @@ class GuardrailEnforcer {
       '',
       guardrailLine,
       '',
-      'Reply **yes** to send \u00b7 **no** to cancel \u00b7 **edit** to revise',
+      surfaceText('confirm_email_reply', language),
     ].join('\n');
   }
 
   /** @private */
-  _buildFileDeleteConfirmation(args, guardrailLine) {
-    const filePath = args.path || args.file || args.filename || '(unknown file)';
+  _buildFileDeleteConfirmation(args, guardrailLine, language) {
+    const filePath = args.path || args.file || args.filename || surfaceText('placeholder_unknown_file', language);
     return [
-      '\u{1f5d1}\ufe0f **File deletion requires your approval**',
+      surfaceText('confirm_file_delete_header', language),
       '',
-      `**File:** ${filePath}`,
+      `**${fieldLabel('field_file', language)}:** ${filePath}`,
       '',
-      '\u26a0\ufe0f This action cannot be undone.',
+      surfaceText('confirm_file_delete_warning', language),
       '',
       guardrailLine,
       '',
-      'Reply **yes** to delete \u00b7 **no** to cancel',
+      surfaceText('confirm_delete_reply', language),
     ].join('\n');
   }
 
   /** @private */
-  _buildFileMoveConfirmation(args, guardrailLine) {
+  _buildFileMoveConfirmation(args, guardrailLine, language) {
+    const unknown = surfaceText('placeholder_unknown', language);
     return [
-      '\u{1f4c1} **File move requires your approval**',
+      surfaceText('confirm_file_move_header', language),
       '',
-      `**From:** ${args.from || args.source || args.path || '(unknown)'}`,
-      `**To:** ${args.to || args.destination || '(unknown)'}`,
+      `**${fieldLabel('field_from', language)}:** ${args.from || args.source || args.path || unknown}`,
+      `**${fieldLabel('field_to', language)}:** ${args.to || args.destination || unknown}`,
       '',
       guardrailLine,
       '',
-      'Reply **yes** to proceed \u00b7 **no** to cancel',
+      surfaceText('confirm_proceed_reply', language),
     ].join('\n');
   }
 
   /** @private */
-  _buildCalendarConfirmation(toolName, args, guardrailLine) {
-    const actionMap = {
-      calendar_create_event: 'Create event',
-      calendar_update_event: 'Update event',
-    };
-    const action = actionMap[toolName] || 'Calendar action';
+  _buildCalendarConfirmation(toolName, args, guardrailLine, language) {
+    const actionKey = {
+      calendar_create_event: 'calendar_action_create',
+      calendar_update_event: 'calendar_action_update',
+    }[toolName] || 'calendar_action_other';
+    const action = surfaceText(actionKey, language);
     const attendees = Array.isArray(args.attendees) ? args.attendees.join(', ') : (args.attendee || '');
 
     return [
-      '\u{1f4c5} **Calendar change requires your approval**',
+      surfaceText('confirm_calendar_header', language),
       '',
-      `**Action:** ${action}`,
-      `**Title:** ${args.title || args.summary || '(no title)'}`,
-      args.start ? `**Date:** ${args.start}` : null,
-      args.location ? `**Location:** ${args.location}` : null,
-      attendees ? `**Attendees:** ${attendees}` : null,
+      `**${fieldLabel('field_action', language)}:** ${action}`,
+      `**${fieldLabel('field_title', language)}:** ${args.title || args.summary || surfaceText('placeholder_no_title', language)}`,
+      args.start ? `**${fieldLabel('field_date', language)}:** ${args.start}` : null,
+      args.location ? `**${fieldLabel('field_location', language)}:** ${args.location}` : null,
+      attendees ? `**${fieldLabel('field_attendees', language)}:** ${attendees}` : null,
       '',
       guardrailLine,
       '',
-      'Reply **yes** to confirm \u00b7 **no** to cancel \u00b7 **edit** to revise',
+      surfaceText('confirm_calendar_reply', language),
     ].filter(line => line !== null).join('\n');
   }
 
   /** @private */
-  _buildCalendarDeleteConfirmation(args, guardrailLine) {
+  _buildCalendarDeleteConfirmation(args, guardrailLine, language) {
     return [
-      '\u{1f4c5} **Calendar deletion requires your approval**',
+      surfaceText('confirm_calendar_delete_header', language),
       '',
-      `**Event:** ${args.title || args.event_uid || args.eventId || '(unknown event)'}`,
-      args.reason ? `**Reason:** ${args.reason}` : null,
+      `**${fieldLabel('field_event', language)}:** ${args.title || args.event_uid || args.eventId || surfaceText('placeholder_unknown_event', language)}`,
+      args.reason ? `**${fieldLabel('field_reason', language)}:** ${args.reason}` : null,
       '',
-      '\u26a0\ufe0f This will remove the event from all attendees.',
+      surfaceText('confirm_calendar_delete_warning', language),
       '',
       guardrailLine,
       '',
-      'Reply **yes** to delete \u00b7 **no** to cancel',
+      surfaceText('confirm_delete_reply', language),
     ].filter(line => line !== null).join('\n');
   }
 
   /** @private */
-  _buildWikiWriteConfirmation(args, guardrailLine) {
-    const page = args.page_title || '(unknown page)';
+  _buildWikiWriteConfirmation(args, guardrailLine, language) {
+    const page = args.page_title || surfaceText('placeholder_unknown_page', language);
     const contentPreview = (args.content || '').slice(0, 200);
     const truncated = (args.content || '').length > 200 ? '...' : '';
 
     return [
-      '\u{1f4d6} **Wiki write requires your approval**',
+      surfaceText('confirm_wiki_write_header', language),
       '',
-      `**Page:** ${page}`,
-      `**Preview:** ${contentPreview}${truncated}`,
+      `**${fieldLabel('field_page', language)}:** ${page}`,
+      `**${fieldLabel('field_preview', language)}:** ${contentPreview}${truncated}`,
       '',
       guardrailLine,
       '',
-      'Reply **yes** to save \u00b7 **no** to cancel \u00b7 **edit** to revise',
+      surfaceText('confirm_wiki_write_reply', language),
     ].join('\n');
   }
 
   /** @private */
-  _buildGenericConfirmation(toolName, toolArgs, guardrailLine) {
-    const actionMap = {
-      mail_send: 'send an email',
-      file_delete: 'delete a file',
-      file_move: 'move a file',
-      calendar_create_event: 'create a calendar event',
-      calendar_update_event: 'update a calendar event',
-      calendar_delete_event: 'delete a calendar event',
-      wiki_delete: 'delete a wiki page',
-      deck_delete_card: 'delete a Deck card',
-      deck_share_board: 'share a Deck board',
-      file_share: 'share a file',
-      calendar_cancel_meeting: 'cancel a meeting',
-    };
-    const action = actionMap[toolName] || `perform an action (${toolName})`;
+  _buildGenericConfirmation(toolName, toolArgs, guardrailLine, language) {
+    const actionKey = `generic_action_${toolName}`;
+    const action = hasSurfaceText(actionKey)
+      ? surfaceText(actionKey, language)
+      : surfaceText('generic_action_fallback', language, { tool: toolName });
 
     return [
-      '\u26a0\ufe0f **Action requires your approval**',
+      surfaceText('confirm_generic_header', language),
       '',
-      `I'm about to: **${action}**`,
+      surfaceText('confirm_generic_intent', language, { action }),
       '',
       guardrailLine,
       '',
-      'Reply **yes** to proceed \u00b7 **no** to cancel',
+      surfaceText('confirm_proceed_reply', language),
     ].join('\n');
   }
 
@@ -789,7 +769,10 @@ class GuardrailEnforcer {
       return { allowed: true, reason: null };
     }
 
-    const label = TOOL_APPROVAL_LABELS[toolName] || toolName;
+    // The label is rendered in the user's language here, at the offer's birth,
+    // and stored on the PendingAction record with it. A resolution minutes later
+    // reads the record rather than re-deriving from a one-word reply (#273).
+    const label = toolLabel(toolName, language);
     const response = await this._requestToolApproval(label, toolName, toolArgs, roomToken, language);
 
     if (response.decision === 'yes') {
@@ -844,8 +827,13 @@ class GuardrailEnforcer {
     const userMessage = this._lastUserMessage(history);
     if (!userMessage) return false;
 
-    const label = TOOL_APPROVAL_LABELS[toolName] || toolName;
-    const rendered = this._renderApprovalFields(toolName, toolArgs)
+    // Pinned to English: this renders a tier-2 CLASSIFIER prompt, not a Talk
+    // surface. Its few-shot examples below are English ("Delete Deck card —
+    // Card: Q3 Planning"), and the action description must match them. The
+    // model reads the user's message in whatever language it arrives in; that
+    // is the model's job, not this string's.
+    const label = toolLabel(toolName, 'EN');
+    const rendered = this._renderApprovalFields(toolName, toolArgs, 'EN')
       .map(({ label: field, value }) => `${field}: ${value}`)
       .join(', ') || '(no arguments)';
 
@@ -1007,7 +995,7 @@ class GuardrailEnforcer {
       return { decision: 'no' };
     }
 
-    const message = this._buildToolApprovalMessage(label, toolName, toolArgs);
+    const message = this._buildToolApprovalMessage(label, toolName, toolArgs, language);
     const requestTimestamp = Date.now();
     const searchAfter = Math.max(requestTimestamp, this._lastConsumedTimestamp);
 
@@ -1115,20 +1103,22 @@ class GuardrailEnforcer {
    * @returns {string}
    * @private
    */
-  _buildToolApprovalMessage(label, toolName, toolArgs) {
-    const lines = [`${HITL_PROMPT_MARKER} **${label}** \u2014 requires approval\n`];
+  _buildToolApprovalMessage(label, toolName, toolArgs, language) {
+    // The marker codepoint is this module's, and language-independent; the
+    // words after it come from the table.
+    const lines = [`${HITL_PROMPT_MARKER} ${surfaceText('tool_approval_header', language, { label })}\n`];
 
-    for (const { label: field, value } of this._renderApprovalFields(toolName, toolArgs)) {
+    for (const { label: field, value } of this._renderApprovalFields(toolName, toolArgs, language)) {
       lines.push(`${field}: **${value}**`);
     }
 
     if (toolName === 'calendar_cancel_meeting') {
-      lines.push('\u26a0\ufe0f Cancellation notices will be sent to attendees.');
+      lines.push(surfaceText('tool_approval_cancellation_notice', language));
     } else if (IRREVERSIBLE_TOOLS.has(toolName)) {
-      lines.push('\u26a0\ufe0f This cannot be undone.');
+      lines.push(surfaceText('tool_approval_irreversible', language));
     }
 
-    lines.push('\nReply **yes** to approve or **no** to deny.');
+    lines.push(`\n${surfaceText('tool_approval_reply', language)}`);
     return lines.join('\n');
   }
 
@@ -1141,17 +1131,19 @@ class GuardrailEnforcer {
    *
    * @param {string} toolName
    * @param {Object} toolArgs
+   * @param {string|null} [language] - Resolved message language. Pass 'EN'
+   *   explicitly when rendering into a tier-2 prompt rather than a Talk surface.
    * @returns {Array<{label: string, value: string}>}
    * @private
    */
-  _renderApprovalFields(toolName, toolArgs) {
+  _renderApprovalFields(toolName, toolArgs, language = null) {
     const args = toolArgs || {};
     const fields = TOOL_APPROVAL_FIELDS[toolName];
 
     const entries = fields
       ? fields
         .filter(([key]) => args[key] !== undefined && args[key] !== null && args[key] !== '')
-        .map(([key, label]) => [label, args[key]])
+        .map(([key, labelKey]) => [fieldLabel(labelKey, language), args[key]])
       : Object.entries(args).slice(0, 5);
 
     return entries.map(([label, value]) => ({
@@ -1256,7 +1248,6 @@ module.exports = {
   GuardrailEnforcer,
   HIGH_SEVERITY_TOOLS,
   SENSITIVE_TOOLS,
-  TOOL_APPROVAL_LABELS,
   HITL_PROMPT_MARKER,
   getWriteClassTools,
 };

--- a/src/lib/agent/micro-pipeline.js
+++ b/src/lib/agent/micro-pipeline.js
@@ -16,6 +16,7 @@
 const { buildMicroContext } = require('./micro-pipeline-context');
 const { extractArtifact } = require('./artifact-extractor');
 const { stagesApprovalCeremony } = require('./action-guard');
+const { surfaceText } = require('./surface-text');
 
 const INTENTS = Object.freeze({
   QUESTION: 'question',
@@ -209,7 +210,7 @@ class MicroPipeline {
       if (err.code === 'DOMAIN_ESCALATE') throw err;
       this.stats.errors++;
       this.logger.error(`[MicroPipeline] Error: ${err.message}`);
-      return 'I had trouble processing that. Could you rephrase or simplify your request?';
+      return surfaceText('fallback_processing_trouble', context.language);
     }
   }
 
@@ -779,7 +780,7 @@ Sub-questions:`;
             messages.push({ role: 'tool', content: `Error: Unknown tool "${toolCall.name}"` });
             continue;
           }
-          const toolResult = await this._executeWithGuards(toolCall, context.roomToken || null);
+          const toolResult = await this._executeWithGuards(toolCall, context.roomToken || null, context.language || null);
 
           // Capture artifact focus from structured tool results
           if (toolResult.success && context.onArtifact) {
@@ -838,14 +839,17 @@ Sub-questions:`;
    * @returns {Promise<Object>} { success, result, error? }
    * @private
    */
-  async _executeWithGuards(toolCall, roomToken) {
+  async _executeWithGuards(toolCall, roomToken, language = null) {
     // ToolGuard: hardcoded security policy
     if (this.toolGuard) {
       const guardResult = this.toolGuard.evaluate(toolCall.name);
       if (!guardResult.allowed) {
         if (guardResult.level === 'APPROVAL_REQUIRED' && this.guardrailEnforcer) {
+          // The resolved language rides along, as it does in AgentLoop: this
+          // path renders the same 🔐 ceremony, and rendered English here would
+          // have been a hole in "no surface resolves language independently".
           const approvalResult = await this.guardrailEnforcer.checkApproval(
-            toolCall.name, toolCall.arguments, roomToken, []
+            toolCall.name, toolCall.arguments, roomToken, [], { language }
           );
           if (!approvalResult.allowed) {
             this.logger.info(`[MicroPipeline] ToolGuard approval denied: ${toolCall.name} — ${approvalResult.reason}`);
@@ -861,7 +865,7 @@ Sub-questions:`;
 
     // GuardrailEnforcer: dynamic Cockpit guardrails with HITL confirmation
     if (this.guardrailEnforcer) {
-      const result = await this.guardrailEnforcer.check(toolCall.name, toolCall.arguments, roomToken);
+      const result = await this.guardrailEnforcer.check(toolCall.name, toolCall.arguments, roomToken, { language });
       if (!result.allowed) {
         // Edit requests treated as blocks (MicroPipeline has no revision loop)
         this.logger.info(`[MicroPipeline] GuardrailEnforcer blocked: ${toolCall.name} — ${result.reason}`);

--- a/src/lib/agent/surface-text.js
+++ b/src/lib/agent/surface-text.js
@@ -1,0 +1,462 @@
+'use strict';
+
+/**
+ * Moltagent Surface Text — one home for code-owned user-facing text
+ *
+ * Copyright (C) 2026 Moltagent
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Architecture Brief:
+ * -------------------
+ * Problem: every string a user reads that the model did not write was hardcoded
+ * English, scattered across the module that happened to emit it (#276). The 🔐
+ * approval prompt was the sharpest case: a German speaker asking to delete a
+ * card was shown an English safety prompt and asked to type an English word
+ * before an irreversible action. The one surface where comprehension is a
+ * safety property was the one surface that ignored the user's language.
+ *
+ * Pattern: a flat table keyed by surface, then language, read through a single
+ * accessor. Flat and not nested-by-feature because the coverage pin asserts
+ * against shape, and nesting defeats it.
+ *
+ * This is OUTPUT TEMPLATING on a code-owned surface, not language handling
+ * (CLAUDE.md Rule 1). Nothing here reads prose, detects a language, or
+ * translates at runtime. The language arrives as a fact — the classification
+ * verdict's reading of the message, resolved once by
+ * `MessageProcessor._resolveMessageLanguage()` (#273) — and this module renders
+ * a sentence in it. Adding a language edits the table, never a code path.
+ *
+ * The distinction that decides membership: a string belongs here when it
+ * reaches Talk VERBATIM. A string fed to a model that re-narrates it is a
+ * tier-2 prompt and stays English — the model is the language layer for those.
+ * So `ACTION_REPROMPT_DIRECTIVE` and `checkApproval`'s `reason` are absent by
+ * design, while `narrateOutcome`'s fallback (which reaches Talk when the
+ * narration call fails) is present.
+ *
+ * Key Dependencies: none, and deliberately so. Importing the HITL marker from
+ * guardrail-enforcer would cycle, since the enforcer reads this table. The
+ * marker is prefixed by its owner; the table holds only the words.
+ *
+ * @module agent/surface-text
+ */
+
+/** The languages this system carries code-owned text in. */
+const SURFACE_LANGUAGES = ['EN', 'DE', 'PT'];
+
+/**
+ * The table. Every key exists in every language in SURFACE_LANGUAGES, with an
+ * identical placeholder set across the three — the coverage pin enforces both,
+ * and `test/unit/agent/surface-text.test.js` mutation-tests the pin itself.
+ *
+ * Portuguese is European Portuguese ("eliminar", not "deletar"), matching the
+ * register the honesty trailer established.
+ */
+const SURFACE_TEXT = {
+  // ── The honesty floor (#81 commit 2) — this table's first entries, ───────
+  // relocated from action-guard.js. It states a fact about what the turn did
+  // and claims nothing about why, so it sits beneath the model's narration
+  // rather than replacing it.
+  no_action_trailer: {
+    EN: '⚠️ No action was executed — nothing was created, changed, or deleted.',
+    DE: '⚠️ Es wurde keine Aktion ausgeführt — nichts wurde erstellt, geändert oder gelöscht.',
+    PT: '⚠️ Nenhuma ação foi executada — nada foi criado, alterado ou eliminado.',
+  },
+
+  // ── The 🔐 approval ceremony (ToolGuard APPROVAL_REQUIRED path) ──────────
+  // The marker codepoint is prefixed by GuardrailEnforcer, which owns it.
+  tool_approval_header: {
+    EN: '**{label}** — requires approval',
+    DE: '**{label}** — Freigabe erforderlich',
+    PT: '**{label}** — requer aprovação',
+  },
+  tool_approval_irreversible: {
+    EN: '⚠️ This cannot be undone.',
+    DE: '⚠️ Das kann nicht rückgängig gemacht werden.',
+    PT: '⚠️ Isto não pode ser anulado.',
+  },
+  tool_approval_cancellation_notice: {
+    EN: '⚠️ Cancellation notices will be sent to attendees.',
+    DE: '⚠️ Absagen werden an alle Teilnehmenden gesendet.',
+    PT: '⚠️ Serão enviadas notificações de cancelamento aos participantes.',
+  },
+  // The user answers in their own language; `classifyPendingReply` is an LLM
+  // (#263 removed the English-only regexes), so "ja" and "sim" resolve.
+  tool_approval_reply: {
+    EN: 'Reply **yes** to approve or **no** to deny.',
+    DE: 'Antworte **ja** zum Freigeben oder **nein** zum Ablehnen.',
+    PT: 'Responde **sim** para aprovar ou **não** para recusar.',
+  },
+
+  // ── Tool labels: the name of the act, as the user reads it ───────────────
+  tool_label_deck_delete_card: {
+    EN: 'Delete Deck card', DE: 'Deck-Karte löschen', PT: 'Eliminar cartão do Deck',
+  },
+  tool_label_deck_delete_board: {
+    EN: 'Delete Deck board', DE: 'Deck-Board löschen', PT: 'Eliminar quadro do Deck',
+  },
+  tool_label_deck_delete_stack: {
+    EN: 'Delete Deck stack', DE: 'Deck-Stapel löschen', PT: 'Eliminar pilha do Deck',
+  },
+  tool_label_deck_setup_workflow: {
+    EN: 'Set up Deck workflow', DE: 'Deck-Workflow einrichten', PT: 'Configurar fluxo de trabalho do Deck',
+  },
+  tool_label_deck_share_board: {
+    EN: 'Share board', DE: 'Board teilen', PT: 'Partilhar quadro',
+  },
+  tool_label_file_delete: {
+    EN: 'Delete file', DE: 'Datei löschen', PT: 'Eliminar ficheiro',
+  },
+  tool_label_file_move: {
+    EN: 'Move file', DE: 'Datei verschieben', PT: 'Mover ficheiro',
+  },
+  tool_label_file_write: {
+    EN: 'Write file', DE: 'Datei schreiben', PT: 'Escrever ficheiro',
+  },
+  tool_label_file_share: {
+    EN: 'Share file', DE: 'Datei teilen', PT: 'Partilhar ficheiro',
+  },
+  tool_label_calendar_create_event: {
+    EN: 'Create calendar event', DE: 'Kalendereintrag erstellen', PT: 'Criar evento no calendário',
+  },
+  tool_label_calendar_update_event: {
+    EN: 'Update calendar event', DE: 'Kalendereintrag aktualisieren', PT: 'Atualizar evento no calendário',
+  },
+  tool_label_calendar_delete_event: {
+    EN: 'Delete calendar event', DE: 'Kalendereintrag löschen', PT: 'Eliminar evento do calendário',
+  },
+  tool_label_calendar_cancel_meeting: {
+    EN: 'Cancel meeting', DE: 'Termin absagen', PT: 'Cancelar reunião',
+  },
+  tool_label_wiki_write: {
+    EN: 'Write wiki page', DE: 'Wiki-Seite schreiben', PT: 'Escrever página wiki',
+  },
+  tool_label_wiki_delete: {
+    EN: 'Delete wiki page', DE: 'Wiki-Seite löschen', PT: 'Eliminar página wiki',
+  },
+  tool_label_mail_send: {
+    EN: 'Send email', DE: 'E-Mail senden', PT: 'Enviar email',
+  },
+
+  // ── Field labels, shared by the 🔐 prompt and the confirmation templates ──
+  field_card:        { EN: 'Card',       DE: 'Karte',        PT: 'Cartão' },
+  field_board:       { EN: 'Board',      DE: 'Board',        PT: 'Quadro' },
+  field_path:        { EN: 'Path',       DE: 'Pfad',         PT: 'Caminho' },
+  field_page:        { EN: 'Page',       DE: 'Seite',        PT: 'Página' },
+  field_with:        { EN: 'With',       DE: 'Mit',          PT: 'Com' },
+  field_permission:  { EN: 'Permission', DE: 'Berechtigung', PT: 'Permissão' },
+  field_event:       { EN: 'Event',      DE: 'Termin',       PT: 'Evento' },
+  field_calendar:    { EN: 'Calendar',   DE: 'Kalender',     PT: 'Calendário' },
+  field_reason:      { EN: 'Reason',     DE: 'Grund',        PT: 'Motivo' },
+  field_to:          { EN: 'To',         DE: 'An',           PT: 'Para' },
+  field_from:        { EN: 'From',       DE: 'Von',          PT: 'De' },
+  field_cc:          { EN: 'CC',         DE: 'CC',           PT: 'CC' },
+  field_subject:     { EN: 'Subject',    DE: 'Betreff',      PT: 'Assunto' },
+  field_file:        { EN: 'File',       DE: 'Datei',        PT: 'Ficheiro' },
+  field_action:      { EN: 'Action',     DE: 'Aktion',       PT: 'Ação' },
+  field_title:       { EN: 'Title',      DE: 'Titel',        PT: 'Título' },
+  field_date:        { EN: 'Date',       DE: 'Datum',        PT: 'Data' },
+  field_location:    { EN: 'Location',   DE: 'Ort',          PT: 'Local' },
+  field_attendees:   { EN: 'Attendees',  DE: 'Teilnehmende', PT: 'Participantes' },
+  field_preview:     { EN: 'Preview',    DE: 'Vorschau',     PT: 'Pré-visualização' },
+
+  // ── Placeholders for absent arguments ────────────────────────────────────
+  placeholder_no_body:      { EN: '(no body)',       DE: '(kein Text)',     PT: '(sem corpo)' },
+  placeholder_no_recipient: { EN: '(no recipient)',  DE: '(kein Empfänger)', PT: '(sem destinatário)' },
+  placeholder_no_subject:   { EN: '(no subject)',    DE: '(kein Betreff)',  PT: '(sem assunto)' },
+  placeholder_no_title:     { EN: '(no title)',      DE: '(kein Titel)',    PT: '(sem título)' },
+  placeholder_unknown_file: { EN: '(unknown file)',  DE: '(unbekannte Datei)', PT: '(ficheiro desconhecido)' },
+  placeholder_unknown_event:{ EN: '(unknown event)', DE: '(unbekannter Termin)', PT: '(evento desconhecido)' },
+  placeholder_unknown_page: { EN: '(unknown page)',  DE: '(unbekannte Seite)', PT: '(página desconhecida)' },
+  placeholder_unknown:      { EN: '(unknown)',       DE: '(unbekannt)',     PT: '(desconhecido)' },
+
+  // ── Dynamic Cockpit-guardrail confirmation templates ─────────────────────
+  guardrail_attribution: {
+    EN: '*Guardrail: "{title}"*',
+    DE: '*Guardrail: "{title}"*',
+    PT: '*Guardrail: "{title}"*',
+  },
+  confirm_email_header: {
+    EN: '📧 **Email ready to send**',
+    DE: '📧 **E-Mail bereit zum Senden**',
+    PT: '📧 **Email pronto a enviar**',
+  },
+  confirm_email_reply: {
+    EN: 'Reply **yes** to send · **no** to cancel · **edit** to revise',
+    DE: 'Antworte **ja** zum Senden · **nein** zum Abbrechen · **edit** zum Überarbeiten',
+    PT: 'Responde **sim** para enviar · **não** para cancelar · **edit** para rever',
+  },
+  confirm_file_delete_header: {
+    EN: '🗑️ **File deletion requires your approval**',
+    DE: '🗑️ **Das Löschen der Datei erfordert deine Freigabe**',
+    PT: '🗑️ **A eliminação do ficheiro requer a tua aprovação**',
+  },
+  confirm_file_delete_warning: {
+    EN: '⚠️ This action cannot be undone.',
+    DE: '⚠️ Diese Aktion kann nicht rückgängig gemacht werden.',
+    PT: '⚠️ Esta ação não pode ser anulada.',
+  },
+  // Shared by file deletion and calendar deletion — both offer delete/cancel.
+  confirm_delete_reply: {
+    EN: 'Reply **yes** to delete · **no** to cancel',
+    DE: 'Antworte **ja** zum Löschen · **nein** zum Abbrechen',
+    PT: 'Responde **sim** para eliminar · **não** para cancelar',
+  },
+  confirm_file_move_header: {
+    EN: '📁 **File move requires your approval**',
+    DE: '📁 **Das Verschieben der Datei erfordert deine Freigabe**',
+    PT: '📁 **A mudança do ficheiro requer a tua aprovação**',
+  },
+  confirm_proceed_reply: {
+    EN: 'Reply **yes** to proceed · **no** to cancel',
+    DE: 'Antworte **ja** zum Fortfahren · **nein** zum Abbrechen',
+    PT: 'Responde **sim** para continuar · **não** para cancelar',
+  },
+  confirm_calendar_header: {
+    EN: '📅 **Calendar change requires your approval**',
+    DE: '📅 **Die Kalenderänderung erfordert deine Freigabe**',
+    PT: '📅 **A alteração do calendário requer a tua aprovação**',
+  },
+  confirm_calendar_reply: {
+    EN: 'Reply **yes** to confirm · **no** to cancel · **edit** to revise',
+    DE: 'Antworte **ja** zum Bestätigen · **nein** zum Abbrechen · **edit** zum Überarbeiten',
+    PT: 'Responde **sim** para confirmar · **não** para cancelar · **edit** para rever',
+  },
+  confirm_calendar_delete_header: {
+    EN: '📅 **Calendar deletion requires your approval**',
+    DE: '📅 **Das Löschen des Kalendereintrags erfordert deine Freigabe**',
+    PT: '📅 **A eliminação do evento requer a tua aprovação**',
+  },
+  confirm_calendar_delete_warning: {
+    EN: '⚠️ This will remove the event from all attendees.',
+    DE: '⚠️ Der Termin wird bei allen Teilnehmenden entfernt.',
+    PT: '⚠️ Isto remove o evento de todos os participantes.',
+  },
+  confirm_wiki_write_header: {
+    EN: '📖 **Wiki write requires your approval**',
+    DE: '📖 **Das Schreiben der Wiki-Seite erfordert deine Freigabe**',
+    PT: '📖 **A escrita da página wiki requer a tua aprovação**',
+  },
+  confirm_wiki_write_reply: {
+    EN: 'Reply **yes** to save · **no** to cancel · **edit** to revise',
+    DE: 'Antworte **ja** zum Speichern · **nein** zum Abbrechen · **edit** zum Überarbeiten',
+    PT: 'Responde **sim** para guardar · **não** para cancelar · **edit** para rever',
+  },
+  confirm_generic_header: {
+    EN: '⚠️ **Action requires your approval**',
+    DE: '⚠️ **Die Aktion erfordert deine Freigabe**',
+    PT: '⚠️ **A ação requer a tua aprovação**',
+  },
+  confirm_generic_intent: {
+    EN: "I'm about to: **{action}**",
+    DE: 'Ich bin dabei: **{action}**',
+    PT: 'Estou prestes a: **{action}**',
+  },
+  calendar_action_create: { EN: 'Create event', DE: 'Termin erstellen', PT: 'Criar evento' },
+  calendar_action_update: { EN: 'Update event', DE: 'Termin aktualisieren', PT: 'Atualizar evento' },
+  calendar_action_other:  { EN: 'Calendar action', DE: 'Kalenderaktion', PT: 'Ação de calendário' },
+
+  // ── The generic confirmation's verb phrases ──────────────────────────────
+  generic_action_mail_send: {
+    EN: 'send an email', DE: 'eine E-Mail senden', PT: 'enviar um email',
+  },
+  generic_action_file_delete: {
+    EN: 'delete a file', DE: 'eine Datei löschen', PT: 'eliminar um ficheiro',
+  },
+  generic_action_file_move: {
+    EN: 'move a file', DE: 'eine Datei verschieben', PT: 'mover um ficheiro',
+  },
+  generic_action_file_share: {
+    EN: 'share a file', DE: 'eine Datei teilen', PT: 'partilhar um ficheiro',
+  },
+  generic_action_calendar_create_event: {
+    EN: 'create a calendar event', DE: 'einen Kalendereintrag erstellen', PT: 'criar um evento no calendário',
+  },
+  generic_action_calendar_update_event: {
+    EN: 'update a calendar event', DE: 'einen Kalendereintrag aktualisieren', PT: 'atualizar um evento no calendário',
+  },
+  generic_action_calendar_delete_event: {
+    EN: 'delete a calendar event', DE: 'einen Kalendereintrag löschen', PT: 'eliminar um evento do calendário',
+  },
+  generic_action_calendar_cancel_meeting: {
+    EN: 'cancel a meeting', DE: 'einen Termin absagen', PT: 'cancelar uma reunião',
+  },
+  generic_action_wiki_delete: {
+    EN: 'delete a wiki page', DE: 'eine Wiki-Seite löschen', PT: 'eliminar uma página wiki',
+  },
+  generic_action_deck_delete_card: {
+    EN: 'delete a Deck card', DE: 'eine Deck-Karte löschen', PT: 'eliminar um cartão do Deck',
+  },
+  generic_action_deck_share_board: {
+    EN: 'share a Deck board', DE: 'ein Deck-Board teilen', PT: 'partilhar um quadro do Deck',
+  },
+  generic_action_fallback: {
+    EN: 'perform an action ({tool})',
+    DE: 'eine Aktion ausführen ({tool})',
+    PT: 'executar uma ação ({tool})',
+  },
+
+  // ── Resolution of a PendingAction, in the language the offer was born in ──
+  // These reach `narrateOutcome` as its `outcome`, and reach Talk verbatim on
+  // its fallback path when the narration call fails.
+  outcome_done: {
+    EN: 'Done.', DE: 'Erledigt.', PT: 'Feito.',
+  },
+  outcome_failed: {
+    EN: 'The action failed: {error}',
+    DE: 'Die Aktion ist fehlgeschlagen: {error}',
+    PT: 'A ação falhou: {error}',
+  },
+  outcome_cancelled: {
+    EN: 'Cancelled at your request. Nothing was changed.',
+    DE: 'Auf deinen Wunsch abgebrochen. Es wurde nichts geändert.',
+    PT: 'Cancelado a teu pedido. Nada foi alterado.',
+  },
+
+  // ── Terminal fallbacks that reach Talk verbatim ──────────────────────────
+  fallback_max_iterations: {
+    EN: 'I ran into a loop trying to process your request. Please try rephrasing.',
+    DE: 'Ich bin bei deiner Anfrage in eine Schleife geraten. Bitte formuliere sie anders.',
+    PT: 'Entrei num ciclo ao processar o teu pedido. Tenta reformulá-lo, por favor.',
+  },
+  // The outermost catch, where classification itself may be what threw. Its
+  // language comes from the persona, because no verdict survived to read.
+  fallback_unexpected_error: {
+    EN: 'I ran into an unexpected error processing your message. Could you try rephrasing?',
+    DE: 'Bei der Verarbeitung deiner Nachricht ist ein unerwarteter Fehler aufgetreten. Kannst du sie anders formulieren?',
+    PT: 'Ocorreu um erro inesperado ao processar a tua mensagem. Podes reformulá-la?',
+  },
+  fallback_processing_trouble: {
+    EN: 'I had trouble processing that. Could you rephrase or simplify your request?',
+    DE: 'Ich hatte Schwierigkeiten damit. Kannst du deine Anfrage anders oder einfacher formulieren?',
+    PT: 'Tive dificuldade em processar isso. Podes reformular ou simplificar o teu pedido?',
+  },
+};
+
+/**
+ * The module's single language normalizer, relocated from `action-guard.js`'s
+ * `_trailerKey` and now serving every surface rather than one.
+ *
+ * Accepts the shapes the resolved language actually arrives in: 'DE', 'de',
+ * 'DE+EN' (the bilingual persona setting), null. Anything this table does not
+ * carry falls back to EN rather than guessing.
+ *
+ * The `split('+')` is string manipulation on a Cockpit setting's known format,
+ * not parsing of natural language.
+ *
+ * @param {string|null|undefined} language
+ * @returns {'EN'|'DE'|'PT'}
+ */
+function normalizeLanguage(language) {
+  const key = String(language || 'EN').toUpperCase().split('+')[0].trim();
+  return SURFACE_LANGUAGES.includes(key) ? key : 'EN';
+}
+
+/** Matches this table's own `{placeholder}` tokens — never user prose. */
+const PLACEHOLDER_TOKEN = /\{(\w+)\}/g;
+
+/**
+ * The placeholder names a template declares, as a Set. The coverage pin uses
+ * this to assert that a key's three languages agree on their parameters.
+ *
+ * @param {string} template
+ * @returns {Set<string>}
+ */
+function placeholdersOf(template) {
+  return new Set(Array.from(template.matchAll(PLACEHOLDER_TOKEN), m => m[1]));
+}
+
+/**
+ * Whether the table carries this key. Callers with an open-ended key space
+ * (any tool name, any argument name) ask before rendering, and fall back to the
+ * raw identifier rather than crashing on a tool nobody wrote a label for.
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+function hasSurfaceText(key) {
+  return Object.prototype.hasOwnProperty.call(SURFACE_TEXT, key);
+}
+
+/**
+ * Render one surface in one language.
+ *
+ * Unknown keys and missing parameters THROW rather than degrade. Both are
+ * structural errors the coverage pin makes unshippable, and the failure
+ * direction is the safe one: an approval prompt that cannot render is an
+ * approval that does not happen. A silent fallback would put a raw key, or the
+ * literal text `{card}`, in front of a user deciding whether to delete
+ * something.
+ *
+ * @param {string} key - A key of SURFACE_TEXT
+ * @param {string|null|undefined} language - Resolved message language (#273)
+ * @param {Object} [params] - Values for the template's `{placeholders}`
+ * @returns {string}
+ * @throws {Error} on an unknown key or an unsupplied placeholder
+ */
+function surfaceText(key, language, params = {}) {
+  if (!hasSurfaceText(key)) {
+    throw new Error(`[surfaceText] Unknown key: ${key}`);
+  }
+  const template = SURFACE_TEXT[key][normalizeLanguage(language)];
+
+  return template.replace(PLACEHOLDER_TOKEN, (_match, name) => {
+    if (!Object.prototype.hasOwnProperty.call(params, name)) {
+      throw new Error(`[surfaceText] Missing parameter "${name}" for key: ${key}`);
+    }
+    return String(params[name]);
+  });
+}
+
+const TOOL_LABEL_PREFIX = 'tool_label_';
+
+/**
+ * The user-facing name of a tool, falling back to the raw tool name. Tools
+ * arrive from the registry, so the key space is open: a tool with no label
+ * renders its identifier rather than throwing inside an approval prompt.
+ *
+ * @param {string} toolName
+ * @param {string|null|undefined} language
+ * @returns {string}
+ */
+function toolLabel(toolName, language) {
+  const key = `${TOOL_LABEL_PREFIX}${toolName}`;
+  return hasSurfaceText(key) ? surfaceText(key, language) : toolName;
+}
+
+/**
+ * Every tool this table names, derived from the keys rather than kept as a
+ * second list. The pins that used to read `TOOL_APPROVAL_LABELS` read this:
+ * a label must name a registered tool, and a retired tool must lose its label.
+ *
+ * @returns {string[]} tool names
+ */
+function labelledTools() {
+  return Object.keys(SURFACE_TEXT)
+    .filter(key => key.startsWith(TOOL_LABEL_PREFIX))
+    .map(key => key.slice(TOOL_LABEL_PREFIX.length));
+}
+
+/**
+ * The user-facing name of a field label key, falling back to the key's own
+ * suffix. Same open-key-space reasoning as `toolLabel`: an unmapped tool
+ * renders its raw argument names.
+ *
+ * @param {string} labelKey - e.g. 'field_card'
+ * @param {string|null|undefined} language
+ * @returns {string}
+ */
+function fieldLabel(labelKey, language) {
+  return hasSurfaceText(labelKey) ? surfaceText(labelKey, language) : labelKey;
+}
+
+module.exports = {
+  SURFACE_TEXT,
+  SURFACE_LANGUAGES,
+  surfaceText,
+  hasSurfaceText,
+  normalizeLanguage,
+  placeholdersOf,
+  toolLabel,
+  labelledTools,
+  fieldLabel,
+};

--- a/src/lib/server/message-processor.js
+++ b/src/lib/server/message-processor.js
@@ -42,6 +42,7 @@ const { MODES } = require('../integrations/cockpit-modes');
 const ProvenanceAnnotator = require('../security/provenance-annotator');
 const { getFeedbackMessage } = require('../talk/feedback-messages');
 const IntentDecomposer = require('../agent/intent-decomposer');
+const { surfaceText } = require('../agent/surface-text');
 const ollamaGate = require('../shared/ollama-gate');
 const CONFIG = require('../config');
 const { OBSERVATION_TYPES } = require('../maintenance/observation-log');
@@ -698,6 +699,10 @@ class MessageProcessor {
           roomToken: extracted.token,
           warmMemory: focusContext || '',
           onArtifact,
+          // This branch runs before classification, so no verdict exists to read
+          // the message's language from. The resolver's absent-verdict case is
+          // the honest answer: the persona language, because nothing read it.
+          language: this._resolveMessageLanguage(null),
           // Layer 3: Action ledger accessors
           getLastAction: session ? (dp) => this.sessionManager.getLastAction(session, dp) : undefined,
           getRecentActions: session ? (dp) => this.sessionManager.getRecentActions(session, dp) : undefined,
@@ -879,6 +884,7 @@ class MessageProcessor {
               roomToken: extracted.token,
               warmMemory: focusContext || '',
               intent,  // Skip re-classification inside MicroPipeline
+              language,
               onArtifact,
               // Layer 3: Action ledger accessors
               getLastAction: session ? (dp) => this.sessionManager.getLastAction(session, dp) : undefined,
@@ -931,6 +937,7 @@ class MessageProcessor {
               roomToken: extracted.token,
               warmMemory: focusContext || '',
               intent,  // Skip re-classification inside MicroPipeline
+              language,
               onArtifact,
               // Layer 3: Action ledger accessors
               getLastAction: session ? (dp) => this.sessionManager.getLastAction(session, dp) : undefined,
@@ -1236,7 +1243,7 @@ class MessageProcessor {
       await this.statusIndicator?.setStatus('ready');
       // Guarantee a response to the user even when pre-routing logic throws
       if (extracted.token) {
-        const fallback = "I ran into an unexpected error processing your message. Could you try rephrasing?";
+        const fallback = surfaceText('fallback_unexpected_error', this._resolveMessageLanguage(null));
         this.sendTalkReply(extracted.token, fallback, extracted.messageId).catch(err => {
           console.error('[Process] Failed to send fallback error reply:', err.message);
         });
@@ -1827,6 +1834,11 @@ class MessageProcessor {
     const verdict = await enforcer.classifyPendingReply(message);
     console.log(`[Message] PendingAction ${record.tool}: classifier=${verdict}`);
 
+    // Every surface below speaks the language the OFFER was born in, read from
+    // the record — never the language of the reply that resolves it. "ja" is one
+    // word; the classifier tags it OTHER, and re-deriving from it would answer a
+    // German offer in English (#276, amendment 4). The label was already
+    // rendered in that language at birth.
     if (verdict === 'approve') {
       const approved = enforcer.consumePendingAction(extracted.token);
       if (!approved) return null; // expired between lookup and consumption
@@ -1834,11 +1846,11 @@ class MessageProcessor {
         { name: approved.tool, arguments: approved.args }, extracted.token
       );
       const outcome = toolResult.success
-        ? (toolResult.result || 'Done.')
-        : `The action failed: ${toolResult.error}`;
+        ? (toolResult.result || surfaceText('outcome_done', approved.language))
+        : surfaceText('outcome_failed', approved.language, { error: toolResult.error });
       console.log(`[Message] PendingAction executed: ${approved.tool} success=${toolResult.success}`);
       const response = await this.agentLoop.narrateOutcome({
-        userMessage: message, label: approved.label, outcome
+        userMessage: message, label: approved.label, outcome, language: approved.language
       });
       return { response, result: { intent: 'pending_action_executed', provider: 'agent' } };
     }
@@ -1849,7 +1861,8 @@ class MessageProcessor {
       const response = await this.agentLoop.narrateOutcome({
         userMessage: message,
         label: denied.label,
-        outcome: 'Cancelled at your request. Nothing was changed.'
+        outcome: surfaceText('outcome_cancelled', denied.language),
+        language: denied.language
       });
       return { response, result: { intent: 'pending_action_denied', provider: 'agent' } };
     }

--- a/test/unit/agent/agent-loop.test.js
+++ b/test/unit/agent/agent-loop.test.js
@@ -68,7 +68,12 @@ function createMockToolRegistry(tools = {}, readOnly = []) {
   };
 }
 
-const { NO_ACTION_TRAILER } = require('../../../src/lib/agent/action-guard');
+const { surfaceText } = require('../../../src/lib/agent/surface-text');
+const NO_ACTION_TRAILER = {
+  EN: surfaceText('no_action_trailer', 'EN'),
+  DE: surfaceText('no_action_trailer', 'DE'),
+  PT: surfaceText('no_action_trailer', 'PT'),
+};
 
 // Write a temp SOUL.md for testing
 const testSoulPath = path.join(__dirname, 'test-soul.md');

--- a/test/unit/agent/guardrail-enforcer.test.js
+++ b/test/unit/agent/guardrail-enforcer.test.js
@@ -7,7 +7,8 @@
 const assert = require('assert');
 const { test, asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
 
-const { GuardrailEnforcer, TOOL_APPROVAL_LABELS } = require('../../../src/lib/agent/guardrail-enforcer');
+const { GuardrailEnforcer } = require('../../../src/lib/agent/guardrail-enforcer');
+const { toolLabel } = require('../../../src/lib/agent/surface-text');
 const { PendingActionStore } = require('../../../src/lib/pending-action-store');
 
 // ============================================================
@@ -1344,7 +1345,7 @@ async function runTests() {
       calendar_cancel_meeting: { calendar_id: 'personal', event_uid: 'uid-1' },
     };
     for (const [tool, toolArgs] of Object.entries(args)) {
-      const msg = enforcer._buildToolApprovalMessage(TOOL_APPROVAL_LABELS[tool], tool, toolArgs);
+      const msg = enforcer._buildToolApprovalMessage(toolLabel(tool, 'EN'), tool, toolArgs, 'EN');
       assert.ok(!msg.includes('**#?**'), `${tool} rendered a placeholder`);
       assert.ok(!msg.includes('?**'), `${tool} rendered a placeholder`);
       const identifier = Object.values(toolArgs)[0];

--- a/test/unit/agent/orphan-tools.test.js
+++ b/test/unit/agent/orphan-tools.test.js
@@ -269,15 +269,18 @@ asyncTest('contacts_resolve no match returns not found', async () => {
 });
 
 // ============================================================
-// REQUIRES_APPROVAL tools have TOOL_APPROVAL_LABELS
+// REQUIRES_APPROVAL tools have a surface-text label
 // ============================================================
 
-test('surviving calendar approval tools have TOOL_APPROVAL_LABELS (#169)', () => {
-  const { TOOL_APPROVAL_LABELS } = require('../../../src/lib/agent/guardrail-enforcer');
-  assert.ok(TOOL_APPROVAL_LABELS.calendar_cancel_meeting, 'calendar_cancel_meeting label');
+test('surviving calendar approval tools have a surface-text label (#169)', () => {
+  // The labels moved from guardrail-enforcer's TOOL_APPROVAL_LABELS into
+  // surface-text.js, where they are multilingual (#276). The pin is unchanged.
+  const { labelledTools } = require('../../../src/lib/agent/surface-text');
+  const labelled = new Set(labelledTools());
+  assert.ok(labelled.has('calendar_cancel_meeting'), 'calendar_cancel_meeting label');
   // Retired tools must not linger as ghost references.
-  assert.ok(!TOOL_APPROVAL_LABELS.calendar_quick_schedule, 'calendar_quick_schedule label removed');
-  assert.ok(!TOOL_APPROVAL_LABELS.calendar_schedule_meeting, 'calendar_schedule_meeting label removed');
+  assert.ok(!labelled.has('calendar_quick_schedule'), 'calendar_quick_schedule label removed');
+  assert.ok(!labelled.has('calendar_schedule_meeting'), 'calendar_schedule_meeting label removed');
 });
 
 // ============================================================

--- a/test/unit/agent/surface-text.test.js
+++ b/test/unit/agent/surface-text.test.js
@@ -1,0 +1,291 @@
+'use strict';
+
+/**
+ * Surface-text pin (#276)
+ *
+ * Copyright (C) 2026 Moltagent
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Bidirectional, because each half misses what the other catches:
+ *
+ *   Coverage — every key exists in EN/DE/PT with identical placeholder sets.
+ *              Catches a missing translation, and a `{card}` that silently
+ *              became `{karte}` in the DE row.
+ *   Strays   — a targeted denylist over the migrated call sites. Catches a new
+ *              English literal appearing at a surface already migrated.
+ *
+ * The pin is MUTATION-TESTED here before it is trusted. Both halves are pure
+ * functions over their input, so the suite feeds them deliberately broken
+ * tables and a synthetic stray and asserts they complain. A green pin that
+ * cannot fail is worse than no pin: it licenses the assumption it was written
+ * to check.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const {
+  SURFACE_TEXT,
+  SURFACE_LANGUAGES,
+  surfaceText,
+  normalizeLanguage,
+  placeholdersOf,
+  toolLabel,
+  fieldLabel,
+} = require('../../../src/lib/agent/surface-text');
+
+// ── The pin, as pure functions ──────────────────────────────────────────────
+
+/**
+ * @param {Object} table
+ * @returns {string[]} violations, empty when the table is whole
+ */
+function coverageViolations(table) {
+  const violations = [];
+
+  for (const [key, entry] of Object.entries(table)) {
+    const reference = entry[SURFACE_LANGUAGES[0]];
+
+    if (typeof reference !== 'string') {
+      violations.push(`${key}: missing ${SURFACE_LANGUAGES[0]}`);
+      continue;
+    }
+    const referencePlaceholders = placeholdersOf(reference);
+
+    for (const language of SURFACE_LANGUAGES) {
+      const template = entry[language];
+
+      if (typeof template !== 'string' || template.trim() === '') {
+        violations.push(`${key}: missing ${language}`);
+        continue;
+      }
+
+      const placeholders = placeholdersOf(template);
+      const missing = [...referencePlaceholders].filter(p => !placeholders.has(p));
+      const extra = [...placeholders].filter(p => !referencePlaceholders.has(p));
+
+      if (missing.length || extra.length) {
+        violations.push(
+          `${key}[${language}]: placeholder drift — missing [${missing}] extra [${extra}]`
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+// Phrases that lived at the migrated sites before #276. Each must now exist
+// only inside surface-text.js. Fragments, not whole sentences, so a reworded
+// stray is still caught.
+const STRAY_PHRASES = [
+  // The rendered header, em-dash included. Deliberately not the bare
+  // "requires approval": `checkApproval`'s no-room-token reason contains that
+  // fragment, and it is LLM-facing — a tier-2 prompt, out of scope.
+  '— requires approval',
+  'requires your approval',
+  'Reply **yes**',
+  'cannot be undone',
+  'No action was executed',
+  'Cancelled at your request',
+  'The action failed',
+  'ready to send',
+  'Guardrail: "',
+  "I'm about to",
+  'try rephrasing',
+  'trouble processing',
+];
+
+const MIGRATED_SITES = [
+  'src/lib/agent/guardrail-enforcer.js',
+  'src/lib/agent/action-guard.js',
+  'src/lib/agent/agent-loop.js',
+  'src/lib/agent/micro-pipeline.js',
+  'src/lib/server/message-processor.js',
+];
+
+/**
+ * @param {string} source - file contents
+ * @param {string} label - file name, for the message
+ * @returns {string[]} violations
+ */
+function strayViolations(source, label) {
+  return STRAY_PHRASES
+    .filter(phrase => source.includes(phrase))
+    .map(phrase => `${label}: stray surface text "${phrase}"`);
+}
+
+const repoRoot = path.join(__dirname, '..', '..', '..');
+const readSite = site => fs.readFileSync(path.join(repoRoot, site), 'utf8');
+
+// ── Coverage ────────────────────────────────────────────────────────────────
+
+test('every key carries every language, with identical placeholder sets', () => {
+  assert.deepStrictEqual(coverageViolations(SURFACE_TEXT), []);
+});
+
+test('the table is flat — no nested groups to hide a key from the pin', () => {
+  for (const [key, entry] of Object.entries(SURFACE_TEXT)) {
+    for (const language of Object.keys(entry)) {
+      assert.ok(
+        SURFACE_LANGUAGES.includes(language),
+        `${key} has non-language child "${language}" — the table must be key → language → string`
+      );
+    }
+  }
+});
+
+// ── Coverage: mutation-tested ───────────────────────────────────────────────
+
+test('MUTATION — a deleted DE row fails the coverage pin', () => {
+  const mutated = JSON.parse(JSON.stringify(SURFACE_TEXT));
+  delete mutated.no_action_trailer.DE;
+
+  const violations = coverageViolations(mutated);
+  assert.ok(violations.length > 0, 'pin must catch a missing translation');
+  assert.ok(violations.some(v => v.includes('no_action_trailer: missing DE')), violations.join('; '));
+});
+
+test('MUTATION — an empty PT row fails the coverage pin', () => {
+  const mutated = JSON.parse(JSON.stringify(SURFACE_TEXT));
+  mutated.outcome_done.PT = '   ';
+
+  assert.ok(
+    coverageViolations(mutated).some(v => v.includes('outcome_done: missing PT')),
+    'pin must treat a whitespace-only translation as absent'
+  );
+});
+
+test('MUTATION — a renamed placeholder in one language fails the coverage pin', () => {
+  const mutated = JSON.parse(JSON.stringify(SURFACE_TEXT));
+  mutated.tool_approval_header.DE = '**{bezeichnung}** — Freigabe erforderlich';
+
+  const violations = coverageViolations(mutated);
+  assert.ok(
+    violations.some(v => v.includes('tool_approval_header[DE]') && v.includes('placeholder drift')),
+    `pin must catch {label} → {bezeichnung}: ${violations.join('; ')}`
+  );
+});
+
+test('MUTATION — a dropped placeholder fails the coverage pin', () => {
+  const mutated = JSON.parse(JSON.stringify(SURFACE_TEXT));
+  mutated.outcome_failed.PT = 'A ação falhou.';
+
+  assert.ok(
+    coverageViolations(mutated).some(v => v.includes('outcome_failed[PT]')),
+    'pin must catch a translation that silently drops {error}'
+  );
+});
+
+// ── Strays ──────────────────────────────────────────────────────────────────
+
+test('no migrated site still holds its English literals', () => {
+  const violations = MIGRATED_SITES.flatMap(site => strayViolations(readSite(site), site));
+  assert.deepStrictEqual(violations, []);
+});
+
+test('MUTATION — a reintroduced English literal fails the stray pin', () => {
+  const resurrected = `lines.push('\\nReply **yes** to approve or **no** to deny.');`;
+
+  assert.ok(
+    strayViolations(resurrected, 'fake.js').length > 0,
+    'pin must catch an English literal returning to a migrated site'
+  );
+});
+
+test('MUTATION — the stray pin is not vacuous: clean source passes', () => {
+  const clean = `lines.push(surfaceText('tool_approval_reply', language));`;
+  assert.deepStrictEqual(strayViolations(clean, 'fake.js'), []);
+});
+
+// ── The accessor ────────────────────────────────────────────────────────────
+
+test('normalizeLanguage takes the shapes the resolved language arrives in', () => {
+  assert.strictEqual(normalizeLanguage('DE'), 'DE');
+  assert.strictEqual(normalizeLanguage('de'), 'DE');
+  assert.strictEqual(normalizeLanguage('DE+EN'), 'DE', 'the bilingual persona setting');
+  assert.strictEqual(normalizeLanguage('pt'), 'PT');
+  assert.strictEqual(normalizeLanguage(null), 'EN');
+  assert.strictEqual(normalizeLanguage(undefined), 'EN');
+  assert.strictEqual(normalizeLanguage('OTHER'), 'EN', 'a language the table does not carry');
+  assert.strictEqual(normalizeLanguage('ja'), 'EN', 'Japanese falls back, never guesses');
+});
+
+test('surfaceText renders the requested language', () => {
+  assert.ok(surfaceText('no_action_trailer', 'DE').includes('keine Aktion ausgeführt'));
+  assert.ok(surfaceText('no_action_trailer', 'PT').includes('Nenhuma ação'));
+  assert.ok(surfaceText('no_action_trailer', 'EN').includes('No action was executed'));
+});
+
+test('surfaceText interpolates every occurrence of a placeholder', () => {
+  assert.strictEqual(
+    surfaceText('tool_approval_header', 'EN', { label: 'Delete Deck card' }),
+    '**Delete Deck card** — requires approval'
+  );
+  assert.strictEqual(
+    surfaceText('tool_approval_header', 'DE', { label: 'Deck-Karte löschen' }),
+    '**Deck-Karte löschen** — Freigabe erforderlich'
+  );
+});
+
+test('surfaceText throws on an unknown key rather than leaking it to Talk', () => {
+  assert.throws(() => surfaceText('no_such_key', 'EN'), /Unknown key: no_such_key/);
+});
+
+test('surfaceText throws on a missing parameter rather than rendering {label}', () => {
+  assert.throws(
+    () => surfaceText('tool_approval_header', 'EN'),
+    /Missing parameter "label"/,
+    'an approval prompt that cannot render must not render half of itself'
+  );
+});
+
+test('toolLabel translates a known tool and falls back to the raw name', () => {
+  assert.strictEqual(toolLabel('deck_delete_card', 'DE'), 'Deck-Karte löschen');
+  assert.strictEqual(toolLabel('deck_delete_card', 'PT'), 'Eliminar cartão do Deck');
+  assert.strictEqual(toolLabel('some_unregistered_tool', 'DE'), 'some_unregistered_tool');
+});
+
+test('fieldLabel translates a known field and falls back to the key', () => {
+  assert.strictEqual(fieldLabel('field_card', 'DE'), 'Karte');
+  assert.strictEqual(fieldLabel('field_card', 'PT'), 'Cartão');
+  assert.strictEqual(fieldLabel('board_id', 'DE'), 'board_id', 'unmapped args render their own key');
+});
+
+// ── The safety property this module exists for ──────────────────────────────
+
+test('every approval-ceremony surface differs across EN/DE/PT', () => {
+  // A translation that was copy-pasted from EN is a silent failure the
+  // coverage pin cannot see: the key exists, the placeholders match.
+  const ceremonyKeys = [
+    'tool_approval_header',
+    'tool_approval_irreversible',
+    'tool_approval_reply',
+    'confirm_file_delete_header',
+    'confirm_delete_reply',
+    'confirm_generic_header',
+    'outcome_cancelled',
+  ];
+
+  for (const key of ceremonyKeys) {
+    const { EN, DE, PT } = SURFACE_TEXT[key];
+    assert.notStrictEqual(DE, EN, `${key}: DE is untranslated`);
+    assert.notStrictEqual(PT, EN, `${key}: PT is untranslated`);
+    assert.notStrictEqual(DE, PT, `${key}: DE and PT are identical`);
+  }
+});
+
+test('every tool label is translated in DE and PT', () => {
+  const toolKeys = Object.keys(SURFACE_TEXT).filter(k => k.startsWith('tool_label_'));
+  assert.ok(toolKeys.length >= 16, `expected the full APPROVAL label set, got ${toolKeys.length}`);
+
+  for (const key of toolKeys) {
+    const { EN, DE, PT } = SURFACE_TEXT[key];
+    assert.notStrictEqual(DE, EN, `${key}: DE is untranslated`);
+    assert.notStrictEqual(PT, EN, `${key}: PT is untranslated`);
+  }
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/security/write-class-policy.test.js
+++ b/test/unit/security/write-class-policy.test.js
@@ -28,9 +28,10 @@ const { test, summary, exitWithCode } = require('../../helpers/test-runner');
 
 const { ToolRegistry } = require('../../../src/lib/agent/tool-registry');
 const {
-  getWriteClassTools, HIGH_SEVERITY_TOOLS, SENSITIVE_TOOLS, TOOL_APPROVAL_LABELS
+  getWriteClassTools, HIGH_SEVERITY_TOOLS, SENSITIVE_TOOLS
 } = require('../../../src/lib/agent/guardrail-enforcer');
 const { FORBIDDEN, REQUIRES_APPROVAL } = require('../../../src/security/guards/tool-guard');
+const { labelledTools } = require('../../../src/lib/agent/surface-text');
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
 
@@ -99,9 +100,9 @@ test('every SENSITIVE_TOOLS name is a registered tool', () => {
   assert.deepStrictEqual(ghosts, [], `SENSITIVE_TOOLS names non-tools: ${ghosts.join(', ')}`);
 });
 
-test('every TOOL_APPROVAL_LABELS key is a registered tool', () => {
-  const ghosts = Object.keys(TOOL_APPROVAL_LABELS).filter(t => !registered.has(t));
-  assert.deepStrictEqual(ghosts, [], `TOOL_APPROVAL_LABELS labels non-tools: ${ghosts.join(', ')}`);
+test('every surface-text tool label names a registered tool', () => {
+  const ghosts = labelledTools().filter(t => !registered.has(t));
+  assert.deepStrictEqual(ghosts, [], `surface-text labels non-tools: ${ghosts.join(', ')}`);
 });
 
 // ── Direction 2: registered ∩ destructive ⊆ policy — no ungated tool ──


### PR DESCRIPTION
## What

One home for code-owned user-facing text: `src/lib/agent/surface-text.js`. Closes #276, consumes the per-message language signal from #273 (Stage 1 of the package briefing).

Before this, every string a user reads that the model did *not* write was hardcoded English, scattered across whichever module emitted it. The 🔐 approval ceremony was the sharpest case — a German speaker asking to delete a card was shown an English safety prompt and asked to type an English word before an irreversible action. The one surface where comprehension is a safety property was the one surface that ignored the user's language.

## Approach

A flat `SURFACE_TEXT` table keyed by surface then language, read through one accessor `surfaceText(key, language, params)`. `_trailerKey`'s normalization (`DE+EN` → `DE`, case-insensitivity, EN fallback) becomes the module's single normalizer, and `NO_ACTION_TRAILER` moves in as the table's first entries.

This is output templating on a code-owned surface, **not** language handling (Rule 1). No prose is read, no language is detected, nothing is translated at runtime. The language arrives as a fact from the classification verdict, resolved once by `_resolveMessageLanguage()`. Adding a language edits the table, never a code path.

**Membership rule:** a string belongs here when it reaches Talk *verbatim*. A string fed to a model that re-narrates it is a tier-2 prompt and stays English, because the model is the language layer for those. So `ACTION_REPROMPT_DIRECTIVE` and `checkApproval`'s `reason` are out by design, and `_renderApprovalFields` is pinned to `EN` on the one path that renders into a classifier prompt rather than a Talk surface (its few-shot examples are English and the action description must match them).

## The pin

Bidirectional and mutation-tested before it is trusted:
- **Coverage** — every key × EN/DE/PT with identical placeholder sets. Catches a missing translation and a `{card}` that silently became `{karte}`.
- **Strays** — a targeted denylist over the migrated sites. Catches a new English literal at an already-migrated surface.

Six mutations each assert the pin fails (or passes) as it must: a deleted row, an empty row, a renamed placeholder, a dropped placeholder, a resurrected literal, a clean control. The stray half earned its keep immediately — it found an English fallback in message-processor's outermost catch that the migration list had missed.

## Two gaps closed that the plan did not name

1. `micro-pipeline.js` called `checkApproval` with four arguments and never threaded `language`, so its ceremony rendered English whatever the user wrote. "No surface resolves language independently" had a hole.
2. `narrateOutcome` told the model to reply in the person's language — but the person had said "ja". A one-word reply carries no language worth reading, which is why the offer's language is stored on the PendingAction record at birth. It is now named in the prompt, and the resolution texts read the record, not the reply.

The trailer's own doc comment claimed it keyed on "the Cockpit language" — true before #274, backwards after. The fossil died with the move.

## Verification (live on Prime, persona set to EN throughout)

The persona was **EN** for every test (Cockpit Persona card reads `EN`), so the evidence shows surfaces following the *user*, which is the point of the two-stage sequence.

| Surface | Verdict | Rendered (real Talk message) |
|---|---|---|
| 🔐 DE ceremony | `language=DE` | `🔐 **Deck-Karte löschen** — Freigabe erforderlich / Karte: … / ⚠️ Das kann nicht rückgängig gemacht werden. / Antworte **ja** …` |
| 🔐 PT ceremony | `language=PT` | `🔐 **Eliminar cartão do Deck** — requer aprovação / Cartão: … / ⚠️ Isto não pode ser anulado. / Responde **sim** …` |
| 🔐 EN ceremony | `language=EN` | `🔐 **Delete Deck card** — requires approval / Card: … / ⚠️ This cannot be undone. / Reply **yes** …` |
| Honesty trailer | `language=DE` | `⚠️ Es wurde keine Aktion ausgeführt — nichts wurde erstellt, geändert oder gelöscht.` |
| Record inheritance | record `language=DE`, reply `ja` (OTHER) | `Die Karte "…" wurde aus deinem Posteingang gelöscht.` — German resolution under EN persona; language read from the record, not the reply. Chain: `classifier=approve → consumed → pre-granted by record → executed success=true`. |

- `npm run lint` → 0 errors.
- `npm run test:unit` → 238/238 test files pass, including the new `surface-text.test.js` (18 assertions, 6 of them the pin's own mutation tests).
- Driven via forged signed Talk webhooks against the live `:3000` service; every rendering read back from the actual Talk message via NC MCP, not assumed. Disposable test cards created and cleaned up; Prime restored to `next@ea177f8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
