### PR TITLE
fix(calendar): one past-date guard for create+update; #160 dies structurally (#167, #160)

### DIFF
--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -506,6 +506,16 @@ class ToolRegistry {
    * @private
    */
   async _findCalendarEvent(cal, searchTerm) {
+    // Structural backstop for #160: coerce the identifier to a string once, at
+    // the chokepoint every calendar-event lookup funnels through, so an
+    // undefined/object identifier can never reach `.toLowerCase()` as a
+    // non-string. An empty identifier resolves to no match rather than matching
+    // the first event (`''.includes('')` is true) — a missing id must never
+    // silently select an arbitrary event. Handlers still validate presence up
+    // front for a correctable message; this guarantees the TypeError class is
+    // unreachable regardless of caller.
+    const term = String(searchTerm ?? '').trim();
+    if (!term) return null;
     const now = new Date();
     const searchStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const searchEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
@@ -514,9 +524,9 @@ class ToolRegistry {
     for (const calendar of calendars) {
       const events = await cal.getEvents(calendar.id, searchStart, searchEnd);
       for (const event of events) {
-        const matchByUid = event.uid === searchTerm;
+        const matchByUid = event.uid === term;
         const matchByTitle = event.summary &&
-          event.summary.toLowerCase().includes(searchTerm.toLowerCase());
+          event.summary.toLowerCase().includes(term.toLowerCase());
         if (matchByUid || matchByTitle) {
           return { event, calendarId: calendar.id };
         }
@@ -2283,9 +2293,19 @@ class ToolRegistry {
         required: ['event']
       },
       handler: async (args) => {
-        const match = await this._findCalendarEvent(cal, args.event);
+        // #160 dies structurally: validate the identifier's presence and shape
+        // BEFORE any string op, returning a specific correctable tool-result the
+        // model can list-then-retry from — rather than letting an undefined/
+        // malformed identifier reach a `.toLowerCase()` TypeError that surfaces
+        // as a generic, uncorrectable error.
+        const identifier = typeof args.event === 'string' ? args.event.trim() : '';
+        if (!identifier) {
+          return 'event identifier required — provide the uid or the event title as returned by calendar_list_events.';
+        }
+
+        const match = await this._findCalendarEvent(cal, identifier);
         if (!match) {
-          return `No event found matching "${args.event}" in the next 30 days or past 7 days.`;
+          return `No event found matching "${identifier}" in the next 30 days or past 7 days.`;
         }
         const { event: foundEvent, calendarId: foundCalendar } = match;
 

--- a/src/lib/integrations/caldav-client.js
+++ b/src/lib/integrations/caldav-client.js
@@ -367,6 +367,31 @@ class CalDAVClient {
   }
 
   /**
+   * Past-date guard, shared by createEvent and updateEvent so both inherit ONE
+   * implementation, not two copies (#167-D2, #169). Rejects a start more than
+   * 24h in the past — the shape of an LLM date hallucination. Delete/cancel do
+   * NOT call this: removing a past event is legitimate.
+   *
+   * The thrown message is model-facing tier-2 text — a tool result the LLM reads
+   * and retries from — not user-facing surface text. It names the current
+   * datetime so the model can self-correct, stays English, and deliberately does
+   * NOT migrate to surface-text.js: it never reaches Talk verbatim, which is the
+   * surface-text pin's membership boundary.
+   *
+   * @param {Date|string} start - The event start being written
+   * @throws {Error} if start is a valid instant more than 24h in the past
+   * @private
+   */
+  _assertStartNotInPast(start) {
+    const startDate = start instanceof Date ? start : new Date(start);
+    const now = new Date();
+    const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    if (!isNaN(startDate.getTime()) && startDate < twentyFourHoursAgo) {
+      throw new Error(`Rejected: start date ${startDate.toISOString()} is in the past. Current date/time is ${now.toISOString()}. Please use the correct date.`);
+    }
+  }
+
+  /**
    * Create a new event
    * @param {Object} event - Event details
    * @param {string} event.summary - Event title
@@ -380,19 +405,11 @@ class CalDAVClient {
    * @returns {Promise<Object>} Created event
    */
   async createEvent(event) {
-    // Past-date guard at the substrate (#169). Every creation path — createEvent,
-    // quickSchedule, scheduleMeeting — routes through here, so the guard fires once
-    // and all paths inherit it (previously it lived in only one of four tool
-    // handlers). Reject starts more than 24h in the past: a likely LLM date
-    // hallucination. The message names the current datetime so the model can
-    // self-correct. Throwing matches createEvent's existing failure contract;
-    // ToolRegistry.execute() surfaces it to the model as an actionable error.
-    const startDate = event.start instanceof Date ? event.start : new Date(event.start);
-    const now = new Date();
-    const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    if (!isNaN(startDate.getTime()) && startDate < twentyFourHoursAgo) {
-      throw new Error(`Rejected: start date ${startDate.toISOString()} is in the past. Current date/time is ${now.toISOString()}. Please use the correct date.`);
-    }
+    // Past-date guard at the substrate (#167-D2, #169): a creation always sets
+    // the start, so createEvent unconditionally validates it. See
+    // _assertStartNotInPast for why the guard lives in one shared method that
+    // updateEvent also calls — one guard, inherited by both, not two copies.
+    this._assertStartNotInPast(event.start);
 
     const calendarId = event.calendarId || this.defaultCalendar;
     const uid = this._generateUID();
@@ -456,6 +473,15 @@ class CalDAVClient {
    * Update an existing event
    */
   async updateEvent(calendarId, uid, updates, etag = null) {
+    // Past-date guard, inherited from the same substrate method as createEvent
+    // (#167-D2). Fire ONLY when this update changes the start: rescheduling TO
+    // the past is the LLM-error shape the guard exists for, but editing the
+    // description/location of a past event is legitimate and must pass. An update
+    // that does not touch the start leaves `updates.start` undefined.
+    if (updates && updates.start !== undefined) {
+      this._assertStartNotInPast(updates.start);
+    }
+
     // Always fetch fresh to get current ETag + state (caller's ETag may be stale
     // from a REPORT query — RSVP replies can change the event between fetch and write)
     const current = await this.getEvent(calendarId, uid);

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -569,6 +569,42 @@ asyncTest('calendar_create_event with check_availability:true and a free slot cr
   assert.ok(result.result.includes('Free slot'));
 });
 
+// --- #160: calendar_update_event identifier validation dies structurally ---
+
+asyncTest('calendar_update_event with a missing identifier returns a specific correctable error (#160)', async () => {
+  const registry = new ToolRegistry({ calDAVClient: createMockCalDAVClient(), logger: silentLogger });
+
+  const result = await registry.execute('calendar_update_event', { title: 'New title' });
+
+  assert.ok(result.success, 'returns a tool result, not a thrown TypeError');
+  assert.ok(/event identifier required/i.test(result.result), 'names what was missing so the model can list-then-retry');
+  assert.ok(/calendar_list_events/.test(result.result), 'points the model at the recovery tool');
+});
+
+asyncTest('calendar_update_event with a non-string identifier never hits undefined.toLowerCase (#160)', async () => {
+  const registry = new ToolRegistry({ calDAVClient: createMockCalDAVClient(), logger: silentLogger });
+
+  // The exact D3 failure shape: a malformed (object) identifier that previously
+  // reached `.toLowerCase()` as a non-string and crashed with a generic error.
+  const result = await registry.execute('calendar_update_event', { event: {}, title: 'x' });
+
+  assert.ok(result.success, 'no TypeError — a correctable tool result comes back');
+  assert.ok(/event identifier required/i.test(result.result), 'correctable message, not a generic crash');
+});
+
+asyncTest('_findCalendarEvent coerces a non-string identifier instead of throwing (#160 backstop)', async () => {
+  const registry = new ToolRegistry({ calDAVClient: createMockCalDAVClient(), logger: silentLogger });
+  const cal = {
+    getEventCalendars: async () => [{ id: 'personal' }],
+    getEvents: async () => [{ uid: 'ev1', summary: 'Standup' }]
+  };
+
+  // Directly exercise the chokepoint with the crashing shape: undefined must
+  // resolve to "no match" (null), never a TypeError, regardless of caller.
+  const result = await registry._findCalendarEvent(cal, undefined);
+  assert.strictEqual(result, null, 'undefined identifier resolves to no match, no crash');
+});
+
 test('retired calendar tools are not registered (#169)', () => {
   const registry = new ToolRegistry({
     calDAVClient: createMockCalDAVClient(),

--- a/test/unit/integrations/caldav-client.test.js
+++ b/test/unit/integrations/caldav-client.test.js
@@ -791,6 +791,86 @@ asyncTest('TC-EVENT-GUARD-004: quickSchedule inherits the past-date guard', asyn
   }
 });
 
+// --- #167-D2: the guard is inherited by updateEvent, and only on start changes ---
+
+asyncTest('TC-EVENT-GUARD-005: updateEvent rejects an update that reschedules the start to the past', async () => {
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const past = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  try {
+    await client.updateEvent('personal', 'event1', {
+      start: past,
+      end: new Date(past.getTime() + 60 * 60 * 1000)
+    });
+    assert.fail('Should have rejected rescheduling to the past');
+  } catch (error) {
+    assert.ok(error.message.includes('in the past'), 'update inherits the same past-date rejection');
+    assert.ok(error.message.includes('Current date/time is'), 'same corrective message shape as createEvent');
+  }
+});
+
+asyncTest('TC-EVENT-GUARD-006: updateEvent leaves a past event alone when the start is not changed', async () => {
+  // SAMPLE_ICS (the default GET for event1) is dated in 2025 — a past event.
+  // Editing only its description is legitimate and must NOT trip the guard.
+  const mockNC = createCalDAVMockNC({
+    'PUT:/remote.php/dav/calendars/testuser/personal/event1.ics': {
+      status: 204,
+      body: '',
+      headers: {}
+    }
+  });
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const updated = await client.updateEvent('personal', 'event1', {
+    description: 'Corrected notes on a past meeting'
+  });
+
+  assert.ok(updated, 'description-only update on a past event succeeds');
+  assert.strictEqual(updated.description, 'Corrected notes on a past meeting');
+});
+
+asyncTest('TC-EVENT-GUARD-007: deleteEvent has NO start-time guard — deleting a past event succeeds', async () => {
+  // Deliberate: cancelling or deleting a past event is legitimate. This test
+  // pins that intent so the guard is never "helpfully" extended to delete.
+  const mockNC = createCalDAVMockNC();
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const result = await client.deleteEvent('personal', 'event1');
+  assert.strictEqual(result, true, 'past-dated event deletes without a past-date rejection');
+});
+
+asyncTest('TC-EVENT-GUARD-008: create and update route through ONE guard implementation', async () => {
+  // Structural single-guard assertion: both mutation paths invoke the same
+  // _assertStartNotInPast method, so there is one implementation site, not two
+  // copies that could drift.
+  const mockNC = createCalDAVMockNC({
+    'PUT:/remote.php/dav/calendars/testuser/personal/event1.ics': {
+      status: 204,
+      body: '',
+      headers: {}
+    }
+  });
+  const client = new CalDAVClient(mockNC, null, { username: 'testuser' });
+
+  const calls = [];
+  client._assertStartNotInPast = (start) => { calls.push(start); };
+
+  const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  await client.createEvent({
+    summary: 'Structural probe',
+    start: future,
+    end: new Date(future.getTime() + 60 * 60 * 1000),
+    calendarId: 'personal'
+  });
+  await client.updateEvent('personal', 'event1', {
+    start: future,
+    end: new Date(future.getTime() + 60 * 60 * 1000)
+  });
+
+  assert.strictEqual(calls.length, 2, 'both createEvent and updateEvent invoked the single shared guard');
+});
+
 asyncTest('TC-EVENT-006: Delete event', async () => {
   let deleteCalled = false;
 


### PR DESCRIPTION
Fixes the **D2** finding from the #167 gate report (updateEvent did not inherit the past-date guard — reschedule-to-past succeeded silently) and **#160** (`calendar_update_event` data-dependent `undefined.toLowerCase`). Advances #169's guard-inheritance table: create ✅ → **update ✅**.

## A. Guard at the substrate, inherited by construction
The past-date check now lives in one shared `_assertStartNotInPast(start)` in `caldav-client.js`:
- **Create** calls it unconditionally (a creation always sets the start) — unchanged behavior.
- **Update** calls it *only when `updates.start` is present*, so rescheduling **to** the past is rejected while editing the description/location of a past event still passes.
- **Delete/cancel** deliberately never call it — removing a past event is legitimate. Pinned by a test so it is never "helpfully" extended.

The thrown message keeps its corrective shape and stays model-facing tier-2 text (a tool result the LLM retries from) — it does **not** migrate to `surface-text.js`, since it never reaches Talk verbatim (the pin's membership boundary). Noted in a comment. The `createEvent` comment that claimed universal inheritance is corrected to describe the shared-method reality.

## B. #160 dies structurally
`calendar_update_event` validates the identifier's presence and shape **before any string op**, returning a specific correctable tool result (`event identifier required — provide the uid or the event title as returned by calendar_list_events`) so the model can list-then-retry. `_findCalendarEvent` coerces the identifier once at the chokepoint and treats an empty id as **no-match** — guarding both the `undefined.toLowerCase` TypeError *and* the `''.includes('')` silent first-event match (a wrong-deletion risk the coercion alone would have introduced; caught by a test). The class is fixed, not the instance.

## Tests (all green)
Create-past rejected · update-to-past rejected (same message shape) · description-only update on a past event succeeds · delete of a past event unguarded · single-guard structural assertion (create+update invoke one method) · #160 missing / non-string / chokepoint-backstop shapes.

## Verification (live on Prime)
- `npm run lint`: 0 errors. Full unit suite green except one pre-existing unrelated `wiki-steward` failure.
- Deployed to Prime, restart, **clean boot**, `journalctl -p err` empty.
- Scratch harness loading the **real shipped** `caldav-client` + `tool-registry` against production NC:
  1. create future titled → verified=true
  2. reschedule-to-past → **rejected** with corrective message
  3. description-only update → **succeeds**
  4. readback stored start → **unchanged (future, never past)**
  5. create-past → **rejected**
  6. #160 missing id + object id → **correctable tool result, no TypeError**
  7. cleanup delete → ok. Both test events removed via MCP (204).

Fixes #167 (D2), #160.

Co-authored-by: moltagent <github@moltagent.cloud>

🤖 Generated with [Claude Code](https://claude.com/claude-code)