### PR TITLE
fix(calendar): title becomes optional with a language-keyed default (#167 PR-1)

### DIFF
--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -91,9 +91,12 @@ class AgentLoop {
       this.llmProvider.resetConversation();
     }
 
-    // Propagate requesting user identity to tool handlers
-    if (options.user && this.toolRegistry.setRequestContext) {
-      this.toolRegistry.setRequestContext({ user: options.user });
+    // Propagate requesting user identity and the turn's language to tool
+    // handlers. The language (verdict-derived, #273/#274) lets a handler default
+    // user-facing calendar content — e.g. an absent event title — in the tongue
+    // the user wrote in, without any handler re-deriving it from message text.
+    if (this.toolRegistry.setRequestContext) {
+      this.toolRegistry.setRequestContext({ user: options.user, language: options.language });
     }
 
     // 1. Load context

--- a/src/lib/agent/tool-registry.js
+++ b/src/lib/agent/tool-registry.js
@@ -2122,7 +2122,7 @@ class ToolRegistry {
       parameters: {
         type: 'object',
         properties: {
-          title: { type: 'string', description: 'Event title' },
+          title: { type: 'string', description: 'Event title (optional). When omitted, the handler supplies a sensible default in the user\'s language — do NOT invent a title or ask the user for one; a request that states time and duration is complete.' },
           start: { type: 'string', description: 'Start datetime as ISO 8601 string' },
           end: { type: 'string', description: 'End datetime as ISO 8601 string. Overrides duration_minutes if both are given (default: start + duration_minutes, or +1 hour).' },
           duration_minutes: { type: 'number', description: 'Event length in minutes. Used to compute end when end is omitted (default: 60).' },
@@ -2142,12 +2142,37 @@ class ToolRegistry {
             }
           }
         },
-        required: ['title', 'start']
+        required: ['start']
       },
       handler: async (args) => {
         const startDate = new Date(args.start);
         if (isNaN(startDate.getTime())) {
           return `Invalid start date: "${args.start}". Use ISO 8601 format (e.g. 2026-02-26T14:00:00).`;
+        }
+
+        // Title is optional (#167 PR-1). A request that gives a time and duration
+        // is complete; it need not name the event. When no title is supplied the
+        // handler defaults one in the turn's language — rather than making the
+        // model invent one (small models fabricate, cloud models decline and the
+        // turn stalls into the #280 clarify loop). Enrichment is structural only: named
+        // attendees from the args append to the default; no prose is inspected.
+        // Calendar content reaches the user through CalDAV, not Talk, so this
+        // default lives in the handler, not surface-text.js (the same membership
+        // boundary the past-date guard's model-facing text observes).
+        const DEFAULT_TITLE = { EN: 'Meeting', DE: 'Termin', PT: 'Reunião' };
+        const suppliedTitle = typeof args.title === 'string' ? args.title.trim() : '';
+        let title = suppliedTitle;
+        let titleDefaulted = false;
+        if (!title) {
+          title = DEFAULT_TITLE[this.getRequestContext().language] || DEFAULT_TITLE.EN;
+          if (Array.isArray(args.attendees) && args.attendees.length > 0) {
+            const names = args.attendees
+              .map(a => (typeof a === 'string' ? a : a.name || a.email))
+              .filter(Boolean)
+              .join(', ');
+            if (names) title += `: ${names}`;
+          }
+          titleDefaulted = true;
         }
 
         // Past-date rejection lives in the CalDAVClient.createEvent substrate (#169),
@@ -2183,7 +2208,7 @@ class ToolRegistry {
         }
 
         const eventData = {
-          summary: args.title,
+          summary: title,
           start: startDate,
           end: endDate,
           description: args.description || '',
@@ -2235,14 +2260,17 @@ class ToolRegistry {
         const event = await cal.createEvent(eventData);
 
         if (!event || !event.uid) {
-          return `Calendar event "${args.title}" may not have been created — no event ID returned. Check the calendar to verify.`;
+          return `Calendar event "${title}" may not have been created — no event ID returned. Check the calendar to verify.`;
         }
 
         if (event.verified === false) {
-          return `Warning: "${args.title}" was sent to the server but could not be verified. The event may not have been saved. Event ID: ${event.uid}. Please check the calendar.`;
+          return `Warning: "${title}" was sent to the server but could not be verified. The event may not have been saved. Event ID: ${event.uid}. Please check the calendar.`;
         }
 
-        let msg = `Created "${args.title}" on ${startDate.toLocaleDateString()} at ${startDate.toLocaleTimeString()}. Event ID: ${event.uid}`;
+        let msg = `Created "${title}" on ${startDate.toLocaleDateString()} at ${startDate.toLocaleTimeString()}. Event ID: ${event.uid}`;
+        if (titleDefaulted) {
+          msg += ` No title was given, so the default "${title}" was applied — mention this so the user can rename it if they'd like.`;
+        }
         if (args.attendees && args.attendees.length > 0) {
           const names = args.attendees.map(a => a.name || a.email).join(', ');
           msg += ` Invitations sent to: ${names}.`;

--- a/test/unit/agent/tool-registry.test.js
+++ b/test/unit/agent/tool-registry.test.js
@@ -414,6 +414,69 @@ asyncTest('calendar_create_event creates event', async () => {
   assert.ok(result.result.includes('Test meeting'));
 });
 
+asyncTest('calendar_create_event: title present is untouched (regression pin)', async () => {
+  let captured;
+  const cal = createMockCalDAVClient();
+  cal.createEvent = async (event) => { captured = event; return { uid: 'ev-t', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+  registry.setRequestContext({ user: 'fu', language: 'DE' });
+
+  const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    title: 'Budget Review',
+    start: futureDate.toISOString()
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(captured.summary, 'Budget Review', 'user title must win over the default');
+  assert.ok(!result.result.includes('default'), 'no defaulting note when a title was given');
+});
+
+asyncTest('calendar_create_event: absent title gets the language default and the result names it', async () => {
+  const cases = [
+    { language: 'EN', expected: 'Meeting' },
+    { language: 'DE', expected: 'Termin' },
+    { language: 'PT', expected: 'Reunião' },
+    { language: 'OTHER', expected: 'Meeting' },
+    { language: undefined, expected: 'Meeting' }
+  ];
+  const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  for (const { language, expected } of cases) {
+    let captured;
+    const cal = createMockCalDAVClient();
+    cal.createEvent = async (event) => { captured = event; return { uid: 'ev-d', ...event }; };
+    const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+    registry.setRequestContext({ user: 'fu', language });
+
+    const result = await registry.execute('calendar_create_event', {
+      start: futureDate.toISOString()
+    });
+
+    assert.ok(result.success, `lang=${language} should succeed`);
+    assert.strictEqual(captured.summary, expected, `lang=${language} default title`);
+    assert.ok(result.result.includes(expected), `lang=${language} result names the title`);
+    assert.ok(result.result.includes('default'), `lang=${language} result names the defaulting`);
+  }
+});
+
+asyncTest('calendar_create_event: absent title enriches from attendee args (structural, no prose)', async () => {
+  let captured;
+  const cal = createMockCalDAVClient();
+  cal.createEvent = async (event) => { captured = event; return { uid: 'ev-e', ...event }; };
+  const registry = new ToolRegistry({ calDAVClient: cal, logger: silentLogger });
+  registry.setRequestContext({ user: 'fu', language: 'EN' });
+
+  const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const result = await registry.execute('calendar_create_event', {
+    start: futureDate.toISOString(),
+    attendees: [{ email: 'antonio@example.com', name: 'Antonio' }]
+  });
+
+  assert.ok(result.success);
+  assert.strictEqual(captured.summary, 'Meeting: Antonio', 'attendee name appends to the default');
+});
+
 asyncTest('calendar_create_event rejects invalid start date', async () => {
   const registry = new ToolRegistry({
     calDAVClient: createMockCalDAVClient(),


### PR DESCRIPTION
## What

`calendar_create_event` no longer requires a `title`. When the user's request carries a time and duration but no title — a complete request that needn't name the event — the handler supplies a language-correct default instead of demanding one from the model.

## Why

Phase 0 (Calendar Arc gate report, #167) traced the flagship failure to one generator: **the schema demanded information the user's complete request didn't contain.** "Schedule a meeting tomorrow at 19:00 for 90 minutes" (no title) made cloud models (Haiku) correctly decline to invent a title and ask — but the clarifying turn mutates nothing, so the #268 guard re-prompted and the honesty floor appended "no action was taken": an apology loop wrapping a reasonable question. Small models (qwen3:8b) instead fabricated a title. Both are the same generator.

## The fix

- **`title` optional; handler defaults it** — `EN Meeting / DE Termin / PT Reunião`, keyed on the turn's language (verdict-derived, #274), threaded through the tool request context in `agent-loop.js`. EN fallback for OTHER/absent.
- **Structural enrichment only** — named attendees from the *args* append to the default (`Meeting: Antonio`). No prose is inspected (Rule 1).
- **Declarative schema** — the field's description tells the model it will be defaulted, so cloud stops asking and small models stop inventing.
- **The result names the defaulting** — the tool result says a default was applied so narration can surface it and the user can rename.
- **Home** — calendar content reaches the user via CalDAV, not Talk, so the default table lives in the handler, not `surface-text.js` (the same membership boundary the past-date guard's model-facing text observes).

No guard/floor changes. No prose→title mining. No changes to `start` (genuinely required) or local date handling (PR-4).

## Filed alongside

**#280** — the clarify-class this title default makes moot for calendar but does not close: an expected-mutation turn has no *structural* way to end in a legitimate clarifying question (the guard's truth table is missing a cell). Recorded, not fixed — deserves its own design conversation with a second motivating instance.

## Tests

Unit (`test/unit/agent/tool-registry.test.js`): absent title → language default across EN/DE/PT/OTHER/undefined; result names the defaulting; attendee-arg enrichment; supplied title untouched (regression pin).

## Verification (live on Prime, cloud-ok)

Deployed to Prime, clean boot. Drove the **real** `ToolRegistry.calendar_create_event` handler against production NC (real `CalDAVClient`, real NC) with the language set in the request context — the exact path `agent-loop.js` threads:

- Absent title, EN/DE/PT → events created with `Meeting` / `Termin` / `Reunião`, read back off the server verbatim, 19:00 local, 90-min duration; result named the defaulting in each case.
- Supplied title (`Budget Review`) → user's title won, read back verbatim, no false default claim.
- All four events cleaned up (DELETE). 28/28 assertions green.

The LLM-behavioral half — Haiku declining to ask now that the schema declares the default — is model-side and covered by the schema change + unit coverage; the substrate is proven correct regardless of whether the model sends a title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)