### PR TITLE
fix(calendar): local date grounding — the live date rides inside the tool schema (#168)

### DIFF
--- a/src/lib/agent/agent-loop.js
+++ b/src/lib/agent/agent-loop.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { extractArtifact } = require('./artifact-extractor');
 const { stagesApprovalCeremony, stripApprovalMarker, ACTION_REPROMPT_DIRECTIVE } = require('./action-guard');
 const { surfaceText, normalizeLanguage } = require('./surface-text');
+const { injectLiveDate } = require('./calendar-date-grounding');
 
 /**
  * AgentLoop - The Nervous System
@@ -147,9 +148,21 @@ class AgentLoop {
     const scopeDomain = (options.domain && !options.compound && this.toolRegistry.hasDomainTools(options.domain))
       ? options.domain
       : null;
-    const tools = scopeDomain
-      ? this.toolRegistry.getToolSubset(scopeDomain)
-      : this.toolRegistry.getToolDefinitions();
+    // The live date is injected INTO the calendar tools' `start` description
+    // here, at the single per-turn seam where the subset and full paths
+    // converge (#168, PR-4). qwen3:8b ignores the "Today is …" system header —
+    // far from the argument it generates — and anchors "tomorrow" to its ~2023
+    // training prior; a schema description sits next to that argument. The
+    // transform clones (never mutates the shared registry schema), so a stale
+    // date cannot leak into a later turn. Inert for cloud models, which already
+    // ground. See calendar-date-grounding.js.
+    const tools = injectLiveDate(
+      scopeDomain
+        ? this.toolRegistry.getToolSubset(scopeDomain)
+        : this.toolRegistry.getToolDefinitions(),
+      new Date(),
+      this.timezone
+    );
 
     const messages = [
       ...history.map(m => ({ role: m.role, content: m.content })),

--- a/src/lib/agent/calendar-date-grounding.js
+++ b/src/lib/agent/calendar-date-grounding.js
@@ -1,0 +1,153 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * calendar-date-grounding — inject the live date INTO the calendar tool
+ * schemas at prompt-build time (#168, Calendar Arc PR-4).
+ *
+ * ## Why this exists
+ *
+ * qwen3:8b (the local-only tools seat) anchors "tomorrow" to its training
+ * prior — ~October 2023 — on every scheduling turn, in all three languages,
+ * ignoring the "Today is …" header at the top of the system prompt. The header
+ * is structurally FAR from the `start` argument the model is generating: it
+ * sits in the system message while the argument is emitted against the tool
+ * schema. A schema `description` sits RIGHT NEXT to the argument. Moving the
+ * live date into `calendar_*.start.description` grounds the model where it
+ * actually looks. Cloud models (Haiku) already ground correctly and read the
+ * same improved description, so this is inert for them, not a regression.
+ *
+ * ## Why it is code, not a prompt-guard anti-pattern
+ *
+ * This is plumbing (the LLM-is-the-language-layer rule). Code computes the
+ * date STRINGS (Intl formatting + one day of date math) and assembles the
+ * schema; the MODEL still computes the target datetime from the user's phrase.
+ * There is no natural-language parsing here, no code-side relative-date
+ * resolution, no post-hoc substitution of a model-computed date by a
+ * handler-computed one. The past-date guard in caldav-client.js
+ * (`_assertStartNotInPast`, PR-2) remains the substrate backstop; this PR only
+ * reduces how often it has to fire.
+ *
+ * ## Shared, not copied
+ *
+ * Production (AgentLoop, at the single per-turn tools-build seam), the
+ * gap-closer measurement harness, and the unit test all call `injectLiveDate`.
+ * One transform, measured and shipped, never a harness-only re-implementation
+ * that could drift from what production sends.
+ *
+ * @module agent/calendar-date-grounding
+ * @license AGPL-3.0
+ */
+
+'use strict';
+
+// The calendar tools whose `start` the model must ground against today. Read
+// tools (list/get) take no start the model invents, and delete/cancel act on
+// existing UIDs — neither needs date grounding, and the past-date guard
+// deliberately does not touch them either (PR-2). Kept in lock-step with the
+// calendar family registered in tool-registry.js.
+const GROUNDED_TOOLS = new Set([
+  'calendar_create_event',
+  'calendar_update_event',
+  'calendar_check_availability',
+]);
+
+/**
+ * Format a Date as an ISO calendar date (YYYY-MM-DD) in a given IANA zone.
+ * 'en-CA' renders exactly YYYY-MM-DD, so no manual assembly of parts.
+ * @param {Date} date
+ * @param {string} timeZone - IANA zone (e.g. 'Europe/Berlin'); 'UTC' default.
+ * @returns {string}
+ */
+function isoDateInZone(date, timeZone) {
+  return new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric', month: '2-digit', day: '2-digit', timeZone,
+  }).format(date);
+}
+
+/**
+ * The weekday name in a given zone, English (schema text is English; the model
+ * maps to the user's language). Lets the model ground "Friday"/"next Monday".
+ * @param {Date} date
+ * @param {string} timeZone
+ * @returns {string}
+ */
+function weekdayInZone(date, timeZone) {
+  return new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone }).format(date);
+}
+
+/**
+ * Build the grounded `start` description: the tool's own base text plus a
+ * declarative date anchor. Mason discipline — positive anchors (today,
+ * tomorrow), one worked example, no NEVER-stack.
+ *
+ * @param {string} baseDescription - The registered description (e.g. "Start datetime as ISO 8601 string").
+ * @param {{today: string, tomorrow: string, weekday: string}} anchor
+ * @returns {string}
+ */
+function groundedStartDescription(baseDescription, { today, tomorrow, weekday }) {
+  const base = (baseDescription || 'Start datetime as ISO 8601 string.').trim();
+  const dot = /[.!?]$/.test(base) ? '' : '.';
+  // A concrete ISO example (using tomorrow's real date) shows both the format
+  // AND a real value to place — without it, qwen3:8b sometimes copies the word
+  // "tomorrow" literally into the field. "tomorrow's date is X" (not
+  // '"tomorrow" is X') de-quotes the relative word so it is not mistaken for a
+  // value to emit. Positive, imperative — the model converts, then fills.
+  return `${base}${dot} Emit a concrete ISO 8601 timestamp, for example ${tomorrow}T14:00:00. ` +
+    `Today is ${today} (${weekday}); tomorrow's date is ${tomorrow}. ` +
+    `Convert the user's day — tomorrow, Friday, next week — into that concrete calendar date in the current year before filling this field.`;
+}
+
+/**
+ * Return a copy of the tool array with the live date injected into every
+ * grounded calendar tool's `start.description`. Non-calendar tools and tools
+ * without a `start` property pass through by reference (untouched).
+ *
+ * Cloning is targeted: only the spine down to the mutated `start` property is
+ * copied, so the shared registration object in ToolRegistry is NEVER mutated
+ * (its `parameters` is stored by reference and reused every turn — mutating it
+ * would leak a stale date into all later turns). Sibling properties stay shared
+ * by reference; they are not modified.
+ *
+ * @param {Array<{type:string, function:{name:string, description:string, parameters:Object}}>} tools
+ * @param {Date} [now] - The instant "today" is derived from. Injectable for tests/probe.
+ * @param {string} [timeZone] - IANA zone matching the system-prompt date header. Default 'UTC'.
+ * @returns {Array} A new array; grounded entries are fresh objects, the rest are the originals.
+ */
+function injectLiveDate(tools, now = new Date(), timeZone = 'UTC') {
+  if (!Array.isArray(tools)) return tools;
+
+  const today = isoDateInZone(now, timeZone);
+  const tomorrow = isoDateInZone(new Date(now.getTime() + 24 * 60 * 60 * 1000), timeZone);
+  const weekday = weekdayInZone(now, timeZone);
+  const anchor = { today, tomorrow, weekday };
+
+  return tools.map((tool) => {
+    const fn = tool && tool.function;
+    if (!fn || !GROUNDED_TOOLS.has(fn.name)) return tool;
+
+    const startProp = fn.parameters && fn.parameters.properties && fn.parameters.properties.start;
+    if (!startProp) return tool;
+
+    return {
+      ...tool,
+      function: {
+        ...fn,
+        parameters: {
+          ...fn.parameters,
+          properties: {
+            ...fn.parameters.properties,
+            start: { ...startProp, description: groundedStartDescription(startProp.description, anchor) },
+          },
+        },
+      },
+    };
+  });
+}
+
+module.exports = {
+  injectLiveDate,
+  groundedStartDescription,
+  isoDateInZone,
+  GROUNDED_TOOLS,
+};

--- a/src/lib/integrations/caldav-client.js
+++ b/src/lib/integrations/caldav-client.js
@@ -387,7 +387,11 @@ class CalDAVClient {
     const now = new Date();
     const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     if (!isNaN(startDate.getTime()) && startDate < twentyFourHoursAgo) {
-      throw new Error(`Rejected: start date ${startDate.toISOString()} is in the past. Current date/time is ${now.toISOString()}. Please use the correct date.`);
+      // Declarative + directive (#168, PR-4): naming the current datetime alone
+      // let the model PARROT the rejection instead of retrying. State the fact,
+      // then the corrective action, so the model recomputes from today within
+      // the same turn's loop rather than reporting a stall.
+      throw new Error(`Rejected: start ${startDate.toISOString()} is in the past. Today is ${now.toISOString()}. Recompute the start date from today and call the tool again with a start on or after now.`);
     }
   }
 

--- a/src/lib/llm/tool-capability-probe.js
+++ b/src/lib/llm/tool-capability-probe.js
@@ -28,15 +28,27 @@
  *   tool-call failure. The probe converts that silent runtime discovery
  *   into a loud boot line.
  *
+ * Second item (#168, PR-4): a model that produces a tool call can still anchor
+ *   a relative date to its training prior (qwen3:8b emits ~October 2023 for
+ *   "tomorrow"). After the tool-call check passes, the probe sends one canned
+ *   scheduling request whose `start` schema carries the SAME live-date anchor
+ *   production ships (groundedStartDescription) against a FIXED injected
+ *   "today"; a start outside a sane window of that today is DATE_UNGROUNDED —
+ *   demoted like prose. The fixture measures the model as-shipped: if the
+ *   grounding text grounds it, this is a regression pin; if not, the seat
+ *   demotes honestly and the consequence is named, not tuned away (#275).
+ *
  * Data Flow:
  *   webhook-server (boot, inside the ModelScout .then, after the golden-set
  *   probe so the post-probe resolver re-log reflects both — NOTE(#233))
- *     → probe.run(candidates) → { name, status: 'tool-call'|'prose'|'unmeasured' }
- *     → modelResolver.markToolIncapable(name) per prose result
+ *     → probe.run(candidates) → { name, status: 'tool-call'|'prose'|'date-ungrounded'|'unmeasured' }
+ *     → modelResolver.markToolIncapable(name) per prose OR date-ungrounded result
  *
  * Dependency Map:
  *   src/lib/llm/tool-capability-probe.js
- *     ← (no internal imports — standalone; callers inject chatFn)
+ *     ← src/lib/agent/calendar-date-grounding (groundedStartDescription, isoDateInZone)
+ *       — the ONE pure leaf util so the probe's date anchor is byte-identical to
+ *         what production injects; callers still inject chatFn (no transport here).
  *
  * @module llm/tool-capability-probe
  * @license AGPL-3.0
@@ -46,12 +58,14 @@
 
 const fs = require('fs');
 const path = require('path');
+const { groundedStartDescription, isoDateInZone } = require('../agent/calendar-date-grounding');
 
 const CACHE_FILENAME = 'tool-capability-probe.json';
 
 // Bump when the probe schema/instruction or pass criterion changes — old
 // cached verdicts then re-measure instead of masquerading as comparable.
-const PROBE_REV = 1;
+// r2 (#168, PR-4): adds the relative-date grounding item below.
+const PROBE_REV = 2;
 
 // The trivial probe function: one boolean argument, no room for ambiguity.
 const PROBE_TOOL = {
@@ -72,10 +86,52 @@ const PROBE_TOOL = {
 const PROBE_SYSTEM = 'You are a function-calling assistant. You MUST answer by calling the provided function. Never answer in prose.';
 const PROBE_MESSAGE = 'Call the mark_ready function with ready set to true.';
 
+// --- Relative-date grounding item (#168, PR-4) -----------------------------
+// A model can produce a tool call and still anchor "tomorrow" to its training
+// prior (qwen3:8b → ~October 2023). This item measures the SHIPPED grounding
+// mechanism: a schedule tool whose `start` carries the exact live-date anchor
+// production injects (groundedStartDescription), against a FIXED injected
+// "today" so the verdict is deterministic and cacheable by PROBE_REV.
+const PROBE_DATE_TODAY = new Date('2026-06-15T12:00:00Z'); // fixed clock; UTC.
+const PROBE_DATE_TZ = 'UTC';
+const PROBE_DATE_TODAY_ISO = isoDateInZone(PROBE_DATE_TODAY, PROBE_DATE_TZ);
+const PROBE_DATE_TOMORROW_ISO = isoDateInZone(new Date(PROBE_DATE_TODAY.getTime() + 86400000), PROBE_DATE_TZ);
+
+// Sane window: a grounded model lands on or near today (tomorrow = +1). The
+// window catches the gross failure — a start years off (2023) — without
+// demanding tomorrow-exact precision. Inclusive [today-1d, today+7d].
+const PROBE_DATE_WINDOW_MS = 7 * 86400000;
+
+const PROBE_DATE_TOOL = {
+  type: 'function',
+  function: {
+    name: 'schedule_event',
+    description: 'Schedule an event at a given time. Call this — do not answer in text.',
+    parameters: {
+      type: 'object',
+      properties: {
+        start: {
+          type: 'string',
+          description: groundedStartDescription('Start datetime as ISO 8601 string', {
+            today: PROBE_DATE_TODAY_ISO,
+            tomorrow: PROBE_DATE_TOMORROW_ISO,
+            weekday: new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone: PROBE_DATE_TZ }).format(PROBE_DATE_TODAY),
+          }),
+        },
+      },
+      required: ['start'],
+    },
+  },
+};
+
+const PROBE_DATE_SYSTEM = `Today is ${PROBE_DATE_TODAY_ISO}. You are a scheduling assistant; call the schedule_event function with an ISO 8601 start.`;
+const PROBE_DATE_MESSAGE = 'Schedule a meeting tomorrow at 15:00.';
+
 /** Probe verdicts. */
 const VERDICT = {
-  TOOL_CALL: 'tool-call',   // produced a tool call naming the probe function
+  TOOL_CALL: 'tool-call',   // produced a tool call AND grounded the relative date
   PROSE: 'prose',           // answered without a usable tool call
+  DATE_UNGROUNDED: 'date-ungrounded', // called a tool but anchored the date off-window (e.g. 2023)
   UNMEASURED: 'unmeasured', // transport error/timeout — presence unknown, retry next boot
 };
 
@@ -131,8 +187,12 @@ class ToolCapabilityProbe {
         });
         const calls = res && Array.isArray(res.toolCalls) ? res.toolCalls : [];
         if (calls.some(tc => tc && tc.name === PROBE_TOOL.function.name)) {
-          status = VERDICT.TOOL_CALL;
-          detail = 'tool call produced';
+          // Tool-call capable. Now the second item: can it ground a relative
+          // date (#168)? A throw here (transport) propagates to the catch →
+          // UNMEASURED, so a cold host never caches a false date failure.
+          const date = await this._probeDateGrounding(candidate.name);
+          status = date.status;
+          detail = date.detail;
         } else {
           status = VERDICT.PROSE;
           const preview = res && typeof res.content === 'string' ? res.content.slice(0, 60) : '';
@@ -155,6 +215,45 @@ class ToolCapabilityProbe {
 
     if (cacheChanged) this._saveCache(diskCache);
     return results;
+  }
+
+  /**
+   * The relative-date grounding item (#168, PR-4). Sends one canned scheduling
+   * request against a FIXED injected "today", with the shipped grounding anchor
+   * in the `start` schema. A tool call whose start lands in the sane window is
+   * grounded (TOOL_CALL); a start years off (the 2023 anchor) is DATE_UNGROUNDED
+   * and demotes the seat like prose. A transport error throws to the caller,
+   * which records UNMEASURED (not cached) — cold is not an ungrounded date.
+   *
+   * @param {string} model
+   * @returns {Promise<{status: string, detail: string}>}
+   * @private
+   */
+  async _probeDateGrounding(model) {
+    const res = await this.chatFn(model, {
+      system: PROBE_DATE_SYSTEM,
+      messages: [{ role: 'user', content: PROBE_DATE_MESSAGE }],
+      tools: [PROBE_DATE_TOOL],
+    });
+    const calls = res && Array.isArray(res.toolCalls) ? res.toolCalls : [];
+    const call = calls.find(tc => tc && tc.name === PROBE_DATE_TOOL.function.name) || calls[0];
+    if (!call) {
+      return { status: VERDICT.DATE_UNGROUNDED, detail: 'date probe: prose, no scheduling call' };
+    }
+    const args = typeof call.arguments === 'string'
+      ? (() => { try { return JSON.parse(call.arguments); } catch (_e) { return {}; } })()
+      : (call.arguments || {});
+    const startStr = args.start;
+    const startMs = startStr ? Date.parse(startStr) : NaN;
+    if (!startStr || Number.isNaN(startMs)) {
+      return { status: VERDICT.DATE_UNGROUNDED, detail: `date probe: no parseable start (${startStr || 'absent'})` };
+    }
+    const todayMs = PROBE_DATE_TODAY.getTime();
+    const grounded = startMs >= todayMs - 86400000 && startMs <= todayMs + PROBE_DATE_WINDOW_MS;
+    const startDay = String(startStr).slice(0, 10);
+    return grounded
+      ? { status: VERDICT.TOOL_CALL, detail: `tool call + date grounded (start ${startDay})` }
+      : { status: VERDICT.DATE_UNGROUNDED, detail: `date anchored off-window: start ${startDay}, today ${PROBE_DATE_TODAY_ISO}` };
   }
 
   /** @private */

--- a/test/manual/calendar-date-grounding-harness.js
+++ b/test/manual/calendar-date-grounding-harness.js
@@ -1,0 +1,160 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * calendar-date-grounding-harness.js — the gap-closer measurement instrument
+ * for Calendar Arc PR-4 (#168).
+ *
+ * Question it answers: given a "schedule X tomorrow" turn, does the LOCAL-ONLY
+ * tools seat (qwen3:8b) emit a `calendar_create_event` call whose `start` lands
+ * on tomorrow's real date — or on its ~October-2023 training prior?
+ *
+ * Faithfulness: it drives the SAME artifacts production sends the model —
+ *   • the real calendar tool schemas (ToolRegistry.getToolSubset('calendar')),
+ *   • the same live-date injection production applies (injectLiveDate), and
+ *   • the real transport (OllamaToolsProvider → Ollama /api/chat).
+ * It does NOT stand up Nextcloud or Talk (a targeted harness, per S122 — avoids
+ * the shared-NC-account outage). Tool handlers never run: the harness reads the
+ * emitted tool-call arguments, it does not create events.
+ *
+ * Control vs variant is a single flag, so one committed harness measures both
+ * rows of the PR table against identical seed turns:
+ *   node test/manual/calendar-date-grounding-harness.js            # BASELINE (deployed reality: date header only)
+ *   node test/manual/calendar-date-grounding-harness.js --inject   # VARIANT  (date also in the start schema)
+ *
+ * Env:
+ *   OLLAMA_URL    Ollama endpoint (required; e.g. the box's OLLAMA_URL)
+ *   OLLAMA_MODEL  model tag (default qwen3:8b)
+ *   HARNESS_TZ    IANA zone for the date header + injection (default Europe/Berlin)
+ *   TURN_TIMEOUT  per-turn ms (default 300000 — qwen3:8b runs ~200s/turn, #124)
+ */
+
+'use strict';
+
+(async () => {
+  const path = require('path');
+  const { ToolRegistry } = require(path.join('..', '..', 'src', 'lib', 'agent', 'tool-registry'));
+  const { OllamaToolsProvider } = require(path.join('..', '..', 'src', 'lib', 'agent', 'providers', 'ollama-tools'));
+  const { injectLiveDate } = require(path.join('..', '..', 'src', 'lib', 'agent', 'calendar-date-grounding'));
+
+  const GREEN = '\x1b[32m'; const RED = '\x1b[31m'; const YELLOW = '\x1b[33m'; const DIM = '\x1b[2m'; const RESET = '\x1b[0m';
+
+  const INJECT = process.argv.includes('--inject');
+  const ENDPOINT = process.env.OLLAMA_URL;
+  const MODEL = process.env.OLLAMA_MODEL || 'qwen3:8b';
+  const TZ = process.env.HARNESS_TZ || 'Europe/Berlin';
+  const TURN_TIMEOUT = Number(process.env.TURN_TIMEOUT) || 300000;
+
+  if (!ENDPOINT) {
+    console.error(`${RED}OLLAMA_URL is required (the local model endpoint). Aborting.${RESET}`);
+    process.exit(2);
+  }
+
+  // Silence the registry's [BOOT] chatter; we only need the schemas.
+  const silent = { info() {}, warn() {}, error(...a) { console.error(...a); }, debug() {} };
+
+  // Real calendar schemas. A truthy stub client passes the registration gate;
+  // handlers are never invoked here.
+  const registry = new ToolRegistry({ calDAVClient: {}, logger: silent });
+  let tools = registry.getToolSubset('calendar');
+  if (!tools.length) {
+    console.error(`${RED}No calendar tools registered — registration gate changed?${RESET}`);
+    process.exit(2);
+  }
+
+  const now = new Date();
+  if (INJECT) {
+    tools = injectLiveDate(tools, now, TZ);
+  }
+
+  // Reproduce production's system-prompt date header verbatim (agent-loop.js
+  // _buildSystemPrompt). This is the control held constant across both rows;
+  // SOUL/cockpit/persona are omitted (not the variable under test).
+  const dateStr = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: TZ,
+  }).format(now);
+  const timeStr = new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit', minute: '2-digit', hour12: false, timeZone: TZ,
+  }).format(now);
+  const dateHeader = `Today is ${dateStr}. Current time: ${timeStr} (24h format, ${TZ}). Use this for all date-related queries.\n\n`;
+
+  // Faithfulness knob. The minimal prompt makes the date header prominent; that
+  // is NOT what production sends. With SOUL=1 the harness reproduces production's
+  // real ordering (agent-loop.js _buildSystemPrompt: … + dateHeader + this.soul),
+  // so the header is diluted by the full ~443-line SOUL exactly as it is live.
+  // This is the variable that decides whether #168 reproduces.
+  const fs = require('fs');
+  let system;
+  if (process.env.SOUL) {
+    const soul = fs.readFileSync(path.join(__dirname, '..', '..', 'config', 'SOUL.md'), 'utf8');
+    system = dateHeader + soul;
+  } else {
+    system = dateHeader +
+      'You are a scheduling assistant. When the user asks to schedule or book something, ' +
+      'call calendar_create_event with an ISO 8601 start. Do not ask for a title.';
+  }
+
+  // Tomorrow's real date in the header's zone — the single expected answer.
+  const iso = (d) => new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: TZ }).format(d);
+  const TOMORROW = iso(new Date(now.getTime() + 24 * 60 * 60 * 1000));
+
+  // Six seed turns — 2 DE / 2 EN / 2 PT — all anchored on "tomorrow" so the
+  // expected start-date is unambiguous. Same phrasing family as the gap-closer.
+  const TURNS = [
+    { lang: 'DE', text: 'Plane morgen um 15:00 ein Meeting für 90 Minuten.' },
+    { lang: 'DE', text: 'Trag mir morgen um 09:30 einen Termin für 60 Minuten ein.' },
+    { lang: 'EN', text: 'Schedule a meeting tomorrow at 14:00 for 45 minutes.' },
+    { lang: 'EN', text: 'Book something tomorrow at 11:00 for one hour.' },
+    { lang: 'PT', text: 'Agenda uma reunião amanhã às 16:00 por 30 minutos.' },
+    { lang: 'PT', text: 'Marca amanhã às 10:00 um compromisso de 60 minutos.' },
+  ];
+
+  const provider = new OllamaToolsProvider({ endpoint: ENDPOINT, model: MODEL, toolTimeout: TURN_TIMEOUT, timeout: TURN_TIMEOUT }, silent);
+
+  const promptMode = process.env.SOUL ? 'full-SOUL prompt' : 'minimal prompt';
+  const mode = `${INJECT ? 'VARIANT (date-in-schema)' : 'BASELINE (date header only)'} · ${promptMode}`;
+  console.log(`\n${YELLOW}Calendar date-grounding harness — ${mode}${RESET}`);
+  console.log(`${DIM}model=${MODEL}  tz=${TZ}  today=${iso(now)}  tomorrow=${TOMORROW}  timeout=${TURN_TIMEOUT}ms${RESET}\n`);
+
+  // Warm the model once (#124 cold-load >60s would otherwise blow turn 1).
+  process.stdout.write(`${DIM}warming ${MODEL} …${RESET}`);
+  try {
+    await provider.chat({ system: 'ok', messages: [{ role: 'user', content: 'Reply with the word ready.' }], timeout: TURN_TIMEOUT });
+    console.log(`${DIM} warm.${RESET}\n`);
+  } catch (e) {
+    console.log(`${YELLOW} warmup failed (${e.message}) — continuing.${RESET}\n`);
+  }
+
+  let grounded = 0;
+  const rows = [];
+  for (const turn of TURNS) {
+    const started = Date.now();
+    let emittedStart = null; let verdict; let note = '';
+    try {
+      const res = await provider.chat({ system, messages: [{ role: 'user', content: turn.text }], tools, timeout: TURN_TIMEOUT });
+      const call = (res.toolCalls || []).find(c => c.name === 'calendar_create_event')
+        || (res.toolCalls || [])[0];
+      if (!call) {
+        verdict = 'prose'; note = (res.content || '').slice(0, 60).replace(/\n/g, ' ');
+      } else {
+        const args = typeof call.arguments === 'string' ? JSON.parse(call.arguments) : (call.arguments || {});
+        emittedStart = args.start || null;
+        const emittedDate = emittedStart ? String(emittedStart).slice(0, 10) : null;
+        if (emittedDate === TOMORROW) { verdict = 'grounded'; grounded++; }
+        else { verdict = 'wrong'; }
+      }
+    } catch (e) {
+      verdict = 'error'; note = e.message.slice(0, 60);
+    }
+    const secs = ((Date.now() - started) / 1000).toFixed(0);
+    const mark = verdict === 'grounded' ? `${GREEN}✓ grounded${RESET}` : `${RED}✗ ${verdict}${RESET}`;
+    console.log(`${mark}  [${turn.lang}] ${turn.text}`);
+    console.log(`      emitted start: ${emittedStart || '—'}   expected: ${TOMORROW}   (${secs}s)${note ? `  ${DIM}${note}${RESET}` : ''}`);
+    rows.push({ lang: turn.lang, text: turn.text, emittedStart, verdict, secs: Number(secs) });
+  }
+
+  console.log(`\n${grounded === TURNS.length ? GREEN : (grounded === 0 ? RED : YELLOW)}GROUNDED: ${grounded}/${TURNS.length}${RESET}  (${mode})`);
+  // Machine-readable summary line for the PR table.
+  console.log('HARNESS_RESULT ' + JSON.stringify({ mode: INJECT ? 'variant' : 'baseline', model: MODEL, tz: TZ, today: iso(now), tomorrow: TOMORROW, grounded, total: TURNS.length, rows }));
+  process.exit(grounded === TURNS.length ? 0 : 1);
+})().catch((e) => { console.error(e); process.exit(2); });

--- a/test/unit/agent/calendar-date-grounding.test.js
+++ b/test/unit/agent/calendar-date-grounding.test.js
@@ -1,0 +1,145 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * Unit tests for calendar-date-grounding — the per-turn injection of the live
+ * date into the calendar tools' `start` schema description (#168, PR-4).
+ *
+ * Fixed clock throughout: no Date.now(). Every assertion pins a concrete
+ * instant so "today"/"tomorrow" are deterministic across runs and zones.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { test, summary, exitWithCode } = require('../../helpers/test-runner');
+const {
+  injectLiveDate,
+  groundedStartDescription,
+  isoDateInZone,
+  GROUNDED_TOOLS,
+} = require('../../../src/lib/agent/calendar-date-grounding');
+
+// A minimal stand-in for the registry's calendar_create_event schema shape.
+function createTool(name = 'calendar_create_event') {
+  return {
+    type: 'function',
+    function: {
+      name,
+      description: 'Create a calendar event.',
+      parameters: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', description: 'Event title (optional).' },
+          start: { type: 'string', description: 'Start datetime as ISO 8601 string' },
+          end: { type: 'string', description: 'End datetime as ISO 8601 string' },
+        },
+        required: ['start'],
+      },
+    },
+  };
+}
+
+const FIXED = new Date('2026-07-11T09:00:00Z'); // a Saturday in Europe/Berlin
+
+// ---------------------------------------------------------------------------
+// isoDateInZone
+// ---------------------------------------------------------------------------
+
+test('isoDateInZone renders YYYY-MM-DD in the given zone', () => {
+  assert.strictEqual(isoDateInZone(FIXED, 'UTC'), '2026-07-11');
+  assert.strictEqual(isoDateInZone(FIXED, 'Europe/Berlin'), '2026-07-11');
+});
+
+test('isoDateInZone respects the zone across the date line', () => {
+  // 23:30 UTC is already the next calendar day in Berlin (UTC+2 in July).
+  const lateUtc = new Date('2026-07-11T23:30:00Z');
+  assert.strictEqual(isoDateInZone(lateUtc, 'UTC'), '2026-07-11');
+  assert.strictEqual(isoDateInZone(lateUtc, 'Europe/Berlin'), '2026-07-12');
+});
+
+// ---------------------------------------------------------------------------
+// groundedStartDescription
+// ---------------------------------------------------------------------------
+
+test('groundedStartDescription carries today and tomorrow as positive anchors', () => {
+  const out = groundedStartDescription('Start datetime as ISO 8601 string', {
+    today: '2026-07-11', tomorrow: '2026-07-12', weekday: 'Saturday',
+  });
+  assert.ok(out.includes('2026-07-11'), 'names today');
+  assert.ok(out.includes('2026-07-12'), 'names tomorrow');
+  assert.ok(out.includes('Saturday'), 'names the weekday');
+  assert.ok(out.startsWith('Start datetime as ISO 8601 string'), 'keeps the base description');
+  // Mason discipline: declarative, no NEVER-stack.
+  assert.ok(!/never/i.test(out), 'no NEVER directive');
+});
+
+test('groundedStartDescription tolerates an empty base description', () => {
+  const out = groundedStartDescription('', { today: '2026-07-11', tomorrow: '2026-07-12', weekday: 'Saturday' });
+  assert.ok(out.includes('2026-07-11') && out.includes('2026-07-12'));
+});
+
+// ---------------------------------------------------------------------------
+// injectLiveDate — the rendered-prompt behavior
+// ---------------------------------------------------------------------------
+
+test('injectLiveDate writes the live date into calendar_create_event start at build time', () => {
+  const tools = [createTool('calendar_create_event')];
+  const [out] = injectLiveDate(tools, FIXED, 'Europe/Berlin');
+  const desc = out.function.parameters.properties.start.description;
+  assert.ok(desc.includes('2026-07-11'), 'today injected');
+  assert.ok(desc.includes('2026-07-12'), 'tomorrow injected');
+});
+
+test('injectLiveDate does NOT mutate the shared registration object', () => {
+  const tools = [createTool('calendar_create_event')];
+  const before = tools[0].function.parameters.properties.start.description;
+  injectLiveDate(tools, FIXED, 'Europe/Berlin');
+  const after = tools[0].function.parameters.properties.start.description;
+  assert.strictEqual(after, before, 'input schema untouched — a later turn cannot inherit a stale date');
+  assert.strictEqual(after, 'Start datetime as ISO 8601 string');
+});
+
+test('injectLiveDate returns fresh objects for grounded tools (structural clone)', () => {
+  const tools = [createTool('calendar_create_event')];
+  const [out] = injectLiveDate(tools, FIXED, 'Europe/Berlin');
+  assert.notStrictEqual(out, tools[0]);
+  assert.notStrictEqual(out.function.parameters.properties.start, tools[0].function.parameters.properties.start);
+  // Untouched siblings may stay shared — only start is rewritten.
+  assert.strictEqual(out.function.parameters.properties.title, tools[0].function.parameters.properties.title);
+});
+
+test('injectLiveDate grounds every calendar tool that has a start', () => {
+  for (const name of GROUNDED_TOOLS) {
+    const [out] = injectLiveDate([createTool(name)], FIXED, 'UTC');
+    const desc = out.function.parameters.properties.start.description;
+    assert.ok(desc.includes('2026-07-11'), `${name} grounded`);
+  }
+});
+
+test('injectLiveDate passes non-calendar tools through by reference', () => {
+  const other = { type: 'function', function: { name: 'deck_create_card', description: 'x', parameters: { type: 'object', properties: { start: { type: 'string', description: 'unrelated start' } } } } };
+  const [out] = injectLiveDate([other], FIXED, 'UTC');
+  assert.strictEqual(out, other, 'not a grounded tool — untouched, even though it has a start property');
+});
+
+test('injectLiveDate leaves a grounded tool without a start property untouched', () => {
+  const noStart = { type: 'function', function: { name: 'calendar_check_availability', description: 'x', parameters: { type: 'object', properties: {} } } };
+  const [out] = injectLiveDate([noStart], FIXED, 'UTC');
+  assert.strictEqual(out, noStart);
+});
+
+test('injectLiveDate tomorrow rolls month/year boundaries', () => {
+  const nye = new Date('2026-12-31T09:00:00Z');
+  const [out] = injectLiveDate([createTool('calendar_create_event')], nye, 'UTC');
+  const desc = out.function.parameters.properties.start.description;
+  assert.ok(desc.includes('2026-12-31'), 'today = NYE');
+  assert.ok(desc.includes('2027-01-01'), 'tomorrow rolls into next year');
+});
+
+test('injectLiveDate tolerates a non-array input', () => {
+  assert.strictEqual(injectLiveDate(null, FIXED, 'UTC'), null);
+  assert.strictEqual(injectLiveDate(undefined, FIXED, 'UTC'), undefined);
+});
+
+setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/test/unit/integrations/caldav-client.test.js
+++ b/test/unit/integrations/caldav-client.test.js
@@ -738,7 +738,8 @@ asyncTest('TC-EVENT-GUARD-001: createEvent rejects a start more than 24h in the 
     assert.fail('Should have rejected the past-dated event');
   } catch (error) {
     assert.ok(error.message.includes('in the past'), 'message names the past-date rejection');
-    assert.ok(error.message.includes('Current date/time is'), 'message names the current datetime for self-correction');
+    assert.ok(error.message.includes('Today is'), 'message names the current datetime for self-correction');
+    assert.ok(/recompute/i.test(error.message), 'message directs a retry, not just a fact (#168 — model parroted the old fact-only message)');
   }
 });
 
@@ -806,7 +807,7 @@ asyncTest('TC-EVENT-GUARD-005: updateEvent rejects an update that reschedules th
     assert.fail('Should have rejected rescheduling to the past');
   } catch (error) {
     assert.ok(error.message.includes('in the past'), 'update inherits the same past-date rejection');
-    assert.ok(error.message.includes('Current date/time is'), 'same corrective message shape as createEvent');
+    assert.ok(error.message.includes('Today is') && /recompute/i.test(error.message), 'same declarative + retry shape as createEvent');
   }
 });
 

--- a/test/unit/llm/tool-capability-probe.test.js
+++ b/test/unit/llm/tool-capability-probe.test.js
@@ -33,15 +33,31 @@ function captureLogger() {
   };
 }
 
+// The probe now sends TWO requests per capable candidate (#168): the tool-call
+// item (mark_ready) then the date-grounding item (schedule_event). A stub must
+// answer both. `dateStart` decides the second answer — omit for a grounded
+// tomorrow (fixed probe today is 2026-06-15 → tomorrow 2026-06-16).
+function dualStub({ dateStart = '2026-06-16T15:00:00', dateToolCalls } = {}) {
+  return async (_model, req) => {
+    const toolName = req && req.tools && req.tools[0] && req.tools[0].function && req.tools[0].function.name;
+    if (toolName === 'schedule_event') {
+      if (dateToolCalls !== undefined) return { content: 'no call', toolCalls: dateToolCalls };
+      return { content: null, toolCalls: [{ name: 'schedule_event', arguments: { start: dateStart } }] };
+    }
+    return { content: null, toolCalls: [{ name: 'mark_ready', arguments: { ready: true } }] };
+  };
+}
+
 (async () => {
-  // TC-TCP-001: a model that answers with the probe tool call passes.
-  await asyncTest('TC-TCP-001: tool-call response → tool-call verdict', async () => {
+  // TC-TCP-001: a model that answers the tool-call probe AND grounds the date passes.
+  await asyncTest('TC-TCP-001: tool-call + grounded date → tool-call verdict', async () => {
     const probe = new ToolCapabilityProbe({
-      chatFn: async () => ({ content: null, toolCalls: [{ id: 'x', name: 'mark_ready', arguments: { ready: true } }] }),
+      chatFn: dualStub(),
       cacheDir: tmpCacheDir(), logger: captureLogger(),
     });
     const [v] = await probe.run([{ name: 'qwen3:8b' }]);
     assert.strictEqual(v.status, VERDICT.TOOL_CALL);
+    assert.ok(v.detail.includes('date grounded'), 'detail records the date item passed');
   });
 
   // TC-TCP-002: prose response → flagged.
@@ -86,14 +102,15 @@ function captureLogger() {
   await asyncTest('TC-TCP-005: cached verdict served without a new probe call', async () => {
     const dir = tmpCacheDir();
     let calls = 0;
-    const chatFn = async () => { calls++; return { content: null, toolCalls: [{ name: 'mark_ready' }] }; };
+    const inner = dualStub();
+    const chatFn = async (m, req) => { calls++; return inner(m, req); };
     const probe1 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
     await probe1.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
-    assert.strictEqual(calls, 1);
+    assert.strictEqual(calls, 2, 'a capable candidate is measured on both items (tool-call + date)');
 
     const probe2 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
     const [v] = await probe2.run([{ name: 'qwen3:8b', digest: 'sha256:abc' }]);
-    assert.strictEqual(calls, 1, 'warm boot serves the cached verdict');
+    assert.strictEqual(calls, 2, 'warm boot serves the cached verdict — no new probe calls');
     assert.strictEqual(v.status, VERDICT.TOOL_CALL);
     assert.ok(v.detail.includes('cached'));
   });
@@ -105,6 +122,66 @@ function captureLogger() {
     const out = await probe.run([{ name: 'm' }]);
     assert.deepStrictEqual(out, []);
     assert.ok(logger.lines.warn.some((l) => l.includes('Missing chatFn')));
+  });
+
+  // TC-TCP-007: tool-call capable but anchors the date to 2023 → date-ungrounded (#168).
+  await asyncTest('TC-TCP-007: 2023-anchored start → date-ungrounded verdict', async () => {
+    const probe = new ToolCapabilityProbe({
+      chatFn: dualStub({ dateStart: '2023-10-10T15:00:00' }),
+      cacheDir: tmpCacheDir(), logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'qwen3:8b' }]);
+    assert.strictEqual(v.status, VERDICT.DATE_UNGROUNDED);
+    assert.ok(v.detail.includes('off-window'), 'detail names the anchor failure');
+    assert.ok(v.detail.includes('2023-10-10'), 'detail records the emitted date');
+  });
+
+  // TC-TCP-008: date-ungrounded is a real measurement — it caches and demotes like prose.
+  await asyncTest('TC-TCP-008: date-ungrounded is cached (demotes like prose)', async () => {
+    const dir = tmpCacheDir();
+    let calls = 0;
+    const inner = dualStub({ dateStart: '2023-10-10T15:00:00' });
+    const chatFn = async (m, req) => { calls++; return inner(m, req); };
+    const probe1 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v1] = await probe1.run([{ name: 'qwen3:8b', digest: 'sha256:d' }]);
+    assert.strictEqual(v1.status, VERDICT.DATE_UNGROUNDED);
+    const callsAfterFirst = calls;
+
+    const probe2 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v2] = await probe2.run([{ name: 'qwen3:8b', digest: 'sha256:d' }]);
+    assert.strictEqual(v2.status, VERDICT.DATE_UNGROUNDED);
+    assert.strictEqual(calls, callsAfterFirst, 'a measured date failure is served from cache, not re-probed');
+  });
+
+  // TC-TCP-009: passes the tool-call item but answers the date item in prose → date-ungrounded.
+  await asyncTest('TC-TCP-009: prose on the date item → date-ungrounded', async () => {
+    const probe = new ToolCapabilityProbe({
+      chatFn: dualStub({ dateToolCalls: null }),
+      cacheDir: tmpCacheDir(), logger: captureLogger(),
+    });
+    const [v] = await probe.run([{ name: 'qwen3:8b' }]);
+    assert.strictEqual(v.status, VERDICT.DATE_UNGROUNDED);
+  });
+
+  // TC-TCP-010: a transport error on the date item → unmeasured, NOT cached (cold ≠ ungrounded).
+  await asyncTest('TC-TCP-010: date-item transport error → unmeasured, not cached', async () => {
+    const dir = tmpCacheDir();
+    let calls = 0;
+    const chatFn = async (_m, req) => {
+      calls++;
+      const toolName = req.tools[0].function.name;
+      if (toolName === 'schedule_event') throw new Error('socket hang up (cold on 2nd item)');
+      return { content: null, toolCalls: [{ name: 'mark_ready', arguments: { ready: true } }] };
+    };
+    const probe1 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v1] = await probe1.run([{ name: 'qwen3:8b', digest: 'sha256:e' }]);
+    assert.strictEqual(v1.status, VERDICT.UNMEASURED);
+    const after = calls;
+    // Second run re-probes both items (nothing poisoned the cache).
+    const probe2 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v2] = await probe2.run([{ name: 'qwen3:8b', digest: 'sha256:e' }]);
+    assert.strictEqual(v2.status, VERDICT.UNMEASURED);
+    assert.ok(calls > after, 'errored date measurement is not served from cache');
   });
 
   setTimeout(() => { summary(); exitWithCode(); }, 500);

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -2248,8 +2248,16 @@ async function initialize() {
                       if (v.status === VERDICT.PROSE) {
                         modelResolver.markToolIncapable(v.name);
                         console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} answered a tool-requiring instruction with prose — flagged (#118); runtime chain falls back on tool-call failure`);
+                      } else if (v.status === VERDICT.DATE_UNGROUNDED) {
+                        // #168: emits tool calls but anchors relative dates to its
+                        // training prior (~2023) even with the shipped grounding
+                        // anchor. Demote the tools seat honestly — the consequence
+                        // (which model serves tools next, at what latency) is the
+                        // #275 decision, surfaced here, not tuned away.
+                        modelResolver.markToolIncapable(v.name);
+                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} could not ground a relative date (${v.detail}) — flagged (#168); tools seat demotes to the next candidate`);
                       } else if (v.status === VERDICT.TOOL_CALL) {
-                        console.log(`[INIT] Tool-capability probe: ${v.name} → tool call OK${/\(cached\)/.test(v.detail || '') ? ' (cached)' : ''}`);
+                        console.log(`[INIT] Tool-capability probe: ${v.name} → tool call + date grounded OK${/\(cached\)/.test(v.detail || '') ? ' (cached)' : ''}`);
                       }
                     }
                   }


### PR DESCRIPTION
## What & why

`qwen3:8b` — the local-only tools seat — grounded "tomorrow" to its training prior (~October 2023) on **every** scheduling turn, in DE/EN/PT (#168). The `Today is …` system-prompt header didn't move it: buried under the ~443-line SOUL, the header sits far from the `start` argument the model generates. This PR puts the live date **next to the argument** — inside the calendar tool schema — and measures the effect on the real model.

## The fix, at two altitudes

**A. Prompt.** `calendar-date-grounding.js` injects the live date into `calendar_*.start.description` at the single per-turn tools-build seam (`agent-loop.js`), where the domain-subset and full-registry paths converge. It **clones** the schema, never mutating the shared registry object (a stale date could otherwise leak into a later turn). It's a pure helper shared by production, the probe, and the harness — one grounding text, never a copy that drifts. Code assembles the date *strings*; the model still computes the datetime — no NL parsing, no code-side relative-date resolution. The guard message (`caldav-client.js`) is reshaped from a bare fact to declarative + a retry directive, because the fact-only form let the model parrot the rejection instead of retrying.

**B. Probe.** `tool-capability-probe.js` gains a relative-date item: a model that emits tool calls but anchors the date off-window (2023) is `DATE_UNGROUNDED` and demotes the tools seat like prose. The fixture measures the model as-shipped (same grounding anchor production injects, fixed clock). If the prompt grounds the model, this is a regression pin; if not, the seat demotes honestly and the consequence is named, not tuned to protect an incumbent (#275 precedent). Rides the existing probe cache/idle discipline (#260); `PROBE_REV` bumped so stale verdicts re-measure.

## Empirical basis (live qwen3:8b)

Measured with a committed gap-closer harness (`test/manual/calendar-date-grounding-harness.js`) — real calendar schemas + the real `OllamaToolsProvider` against the box's Ollama — same six DE/EN/PT "schedule tomorrow" turns per row:

| Prompt condition | grounded / 6 |
|---|---|
| minimal prompt (date header prominent — diagnostic, isolates dilution) | 6/6 |
| **full-SOUL prompt (= production) — baseline** | **0/6** ← #168 |
| full-SOUL + date-in-schema, v1 (quoted `"tomorrow"`) | 4/6 |
| **full-SOUL + date-in-schema, v2 (refined) — shipped** | **6/6** ✅ |

The minimal-vs-SOUL contrast is the root cause: the model *can* ground when the header is prominent; production's prompt bulk dilutes it. v1's two misses weren't hallucinations — the model copied the literal token `tomorrowT15:00:00`; v2 de-quotes the relative word and adds a concrete ISO example, reaching 6/6.

## The fossil record

The phenomenon has a **fossil record**: three stale "Test" events in the production calendar were written by the bot's own create path in **February 2026** yet start on **2023-10-10** — the same anchor date, months apart, across separate invocations and code paths. The training-prior pull is stable over time, not an artifact of one harness run; the past-date guard is the only reason the fossils stopped accumulating. That stability is also why a boot-time capability probe can measure this reliably — a failure this consistent is exactly what a fixture can pin.

## Tests

- `test/unit/agent/calendar-date-grounding.test.js` — 12 cases: rendered-prompt (schema carries today at a fixed clock), no mutation of the shared registry object, structural clone, month/year rollover, zone correctness.
- `test/unit/llm/tool-capability-probe.test.js` — date item: grounded → `tool-call`, 2023-anchor → `date-ungrounded` (cached, demotes), prose-on-date-item, transport-error → `unmeasured` (not cached).
- `test/unit/integrations/caldav-client.test.js` — guard assertions updated to the declarative + retry shape.

## Verification

Live: baseline `0/6` → shipped variant `6/6` on real qwen3:8b (full-SOUL, production-faithful; `think:false` as production sends). Suite `237/238`; the one red file is a pre-existing `wiki-steward` `_nextSteward` pollution (the test reads the live service's persisted lens state — passes `85/0` from a clean cwd), unrelated to this PR — filed and documented in #282.

## Scope notes

- No cloud-path changes — Haiku grounds correctly and reads the same improved description (inert).
- No new timeout/retry machinery — the retry is the model re-calling within the existing loop.
- Guard placement unchanged (PR-2); this PR reduces how often it fires, it remains the backstop.

Closes #168.
