### PR TITLE
test(wiki-steward): isolate makeFullDeps from the persisted state file (#282)

### DIFF
--- a/test/unit/maintenance/wiki-steward.test.js
+++ b/test/unit/maintenance/wiki-steward.test.js
@@ -149,6 +149,13 @@ function makeFullDeps(overrides = {}) {
     llmRouter:         makeMockRouter({ actions: [] }),
     observationLog:    makeObservationLog(),
     logger:            silentLogger,
+    // Isolate rotation/visit state from any persisted file. Without this the
+    // steward defaults dataDir to `cwd/data` and loads the live service's
+    // `data/wiki-steward-state.json`, so a "fresh" steward inherits a non-zero
+    // lens ring and the _nextSteward tests fail on a box where the service runs
+    // (green from a clean cwd). `dataDir: null` disables load and save (#282).
+    // Overridable — a persistence test can still pass its own tmp dataDir.
+    config:            { dataDir: null },
     ...overrides,
   };
 }


### PR DESCRIPTION
## What

`makeFullDeps()` in `test/unit/maintenance/wiki-steward.test.js` now passes `config: { dataDir: null }`, disabling the steward's state load/save so every test runs from a known zero rotation state.

## Why

The two `_nextSteward()` tests assert a fresh steward's ring starts at `knowledge` (index 0). Without a `config`, the constructor defaults `dataDir` to `cwd/data` (`wiki-steward.js:235-238`) and `_loadState` reads the **live service's** `data/wiki-steward-state.json`. On a box where the service runs, `lensIndex.People = 1`, so `_nextSteward('People')` returns `connection` and the tests fail under `npm run test:unit` — while passing `85/0` from a clean cwd. This is the durability-coupling instance tracked in #282, crossing the test boundary.

## Verification

With `data/wiki-steward-state.json` present (the condition that failed): the file now passes **85/0**; full unit suite green. No test in the file exercised persistence, so nothing else is affected; the default stays overridable (a persistence test can pass its own tmp `dataDir`).

Refs #282.