### PR TITLE
fix(llm): admission gate yields boot measurement to serving; probes join the idle lane (#285)

### DIFF
--- a/src/lib/integrations/heartbeat-manager.js
+++ b/src/lib/integrations/heartbeat-manager.js
@@ -159,6 +159,14 @@ class HeartbeatManager {
       ? config.getGoldenSetProbe
       : null;
 
+    // ToolCapabilityProbe idle lane (#285): a thunk, like getGoldenSetProbe. The
+    // boot probe measures only the seated tool models; the idle branch drains
+    // one non-boot / provisional tool-capable candidate per pulse so capability
+    // calibration converges in downtime instead of competing with serving.
+    this.getToolCapabilityProbe = typeof config.getToolCapabilityProbe === 'function'
+      ? config.getToolCapabilityProbe
+      : null;
+
     this.getNicheAssignment = typeof config.getNicheAssignment === 'function'
       ? config.getNicheAssignment
       : null;
@@ -627,6 +635,29 @@ class HeartbeatManager {
           } catch (err) {
             console.warn('[Heartbeat] Probe idle measurement error:', err.message);
             results.errors.push({ component: 'goldenSetProbe', error: err.message });
+          }
+        }
+
+        // ToolCapabilityProbe idle lane (#285): same shape as the golden-set
+        // lane above. The boot probe measures only the seated tool models; the
+        // non-boot candidates and any provisional (prior-rev) seats are drained
+        // here, one per pulse. Seat-neutral — it warms the capability cache for
+        // the next boot's verdict; the runtime QUICK chain still guards live.
+        const toolProbe = this.getToolCapabilityProbe ? this.getToolCapabilityProbe() : null;
+        if (toolProbe && typeof toolProbe.getUnmeasuredCandidates === 'function') {
+          try {
+            const unmeasured = toolProbe.getUnmeasuredCandidates();
+            if (unmeasured.length > 0) {
+              const r = await toolProbe.measureOne(unmeasured[0]);
+              if (r && r.measured) {
+                console.log(`[Heartbeat] Tool-probe idle measurement: ${r.name} → ${r.status}; ${unmeasured.length - 1} candidate(s) remain`);
+              } else {
+                console.log(`[Heartbeat] Tool-probe idle measurement: ${r?.name || unmeasured[0].name} incomplete (${r?.detail || 'unknown'}); will retry next idle pulse`);
+              }
+            }
+          } catch (err) {
+            console.warn('[Heartbeat] Tool-probe idle measurement error:', err.message);
+            results.errors.push({ component: 'toolCapabilityProbe', error: err.message });
           }
         }
 

--- a/src/lib/llm/golden-set-probe.js
+++ b/src/lib/llm/golden-set-probe.js
@@ -48,6 +48,11 @@ const crypto = require('crypto');
 const DEFAULT_THRESHOLD = 0.75;
 const CACHE_FILENAME = 'golden-set-probe.json';
 
+// How long a probe measurement will wait for a live turn to finish before it
+// proceeds anyway (admission gate, #285). Generous — measurement must eventually
+// happen; the gate trades its latency, never its existence.
+const DEFAULT_SERVING_WAIT_MS = 3 * 60 * 1000;
+
 // Bump when the MEANING of a cached score changes even though model digest and
 // fixture are identical — e.g. the decoding options probeClassify pins (m2:
 // temperature 0 + fixed seed, #232). Old-revision entries then miss the cache
@@ -70,14 +75,25 @@ class GoldenSetProbe {
    *   { version, threshold, languages: { EN:[...], DE:[...], PT:[...] } }.
    * @param {string} [opts.cacheDir] - Directory for the results cache.
    *   Defaults to `data/` under the process cwd.
+   * @param {Object} [opts.servingGate] - The shared serving-active admission
+   *   gate (shared/ollama-gate). When set, the measurement loop yields to a live
+   *   turn between fixture examples so a boot re-measurement walk never stampedes
+   *   serving (#285). Null → no yielding (the pre-#285 behaviour; tests that
+   *   don't exercise the gate omit it).
+   * @param {number} [opts.servingWaitMs] - Cap on the per-yield wait before the
+   *   probe proceeds anyway. Defaults to DEFAULT_SERVING_WAIT_MS.
    * @param {Object} [opts.logger=console]
    */
-  constructor({ classifyFn, fixture, cacheDir, logger } = {}) {
+  constructor({ classifyFn, fixture, cacheDir, servingGate, servingWaitMs, logger } = {}) {
     this.classifyFn = typeof classifyFn === 'function' ? classifyFn : null;
     this.fixture = fixture || null;
     this.cacheDir = cacheDir || path.resolve(process.cwd(), 'data');
     this._cacheFile = path.join(this.cacheDir, CACHE_FILENAME);
     this.logger = logger || console;
+    this.servingGate = servingGate && typeof servingGate.isServing === 'function' ? servingGate : null;
+    this._servingWaitMs = Number.isFinite(servingWaitMs) && servingWaitMs > 0
+      ? servingWaitMs
+      : DEFAULT_SERVING_WAIT_MS;
 
     // In-memory scores for the candidates most recently run(), keyed the
     // same way as the on-disk cache. select() reads only this — it makes
@@ -96,6 +112,14 @@ class GoldenSetProbe {
     // idle lane can drain the models run()'s early exit skipped without
     // re-deriving the list (#260). getUnmeasuredCandidates() defaults to it.
     this._lastCandidates = [];
+
+    // Current-rev cache keys seated PROVISIONALLY on a prior-rev score this boot
+    // (#285): a fixture/rev bump turns a cached score "not comparable," not the
+    // model "unknown." Rather than re-measure at boot (the stampede), the prior
+    // score seats select() and the key is marked here so the idle lane still
+    // re-measures it against the current fixture. Cleared per key by measureOne()
+    // once a current-rev measurement replaces the provisional seat.
+    this._provisional = new Set();
 
     // True only while run()'s measurement loop + final cache save are in flight.
     // The idle lane (getUnmeasuredCandidates) no-ops while set, so a nighttime
@@ -174,8 +198,19 @@ class GoldenSetProbe {
       if (candidate.name === this._incumbent) incumbentSettled = true;
 
       const cached = diskCache[key];
+      const priorScores = (cached && cached.scores) ? null : this._priorRevScores(diskCache, candidate);
       if (cached && cached.scores) {
         this._scores[key] = cached.scores;
+      } else if (priorScores) {
+        // #285: no current-rev score, but this model has a prior-rev score. Seat
+        // it PROVISIONALLY (it feeds select() like a measured score) and mark it
+        // for idle re-measurement, rather than re-measuring at boot where it
+        // competes with serving. A score from fixture v1 is a better prior than
+        // an unmeasured zero; the idle lane corrects it against the current
+        // fixture (and any #275-style demotion takes effect then).
+        this._scores[key] = priorScores;
+        this._provisional.add(key);
+        this.logger.log(`[GoldenSetProbe] ${candidate.name}: seated provisionally on a prior-rev score; re-measuring in idle.`);
       } else {
         const { scores, complete } = await this._measureCandidate(candidate);
         if (complete) {
@@ -369,6 +404,9 @@ class GoldenSetProbe {
     const diskCache = this._loadCache();
     return list.filter(c => {
       const key = this._cacheKey(c);
+      // A provisional seat (prior-rev score, #285) still needs a current-rev
+      // measurement, even though _scores[key] is populated for select().
+      if (this._provisional.has(key)) return true;
       if (this._scores[key]) return false;
       const cached = diskCache[key];
       return !(cached && cached.scores);
@@ -400,9 +438,12 @@ class GoldenSetProbe {
     // Load-modify-save so a concurrent seat write (SELECTION_KEY) or another
     // candidate's cached score is preserved — this runs long after run()'s save.
     const diskCache = this._loadCache();
-    diskCache[this._cacheKey(candidate)] = { scores, at: new Date().toISOString() };
+    const key = this._cacheKey(candidate);
+    diskCache[key] = { scores, at: new Date().toISOString() };
     this._saveCache(diskCache);
-    this._scores[this._cacheKey(candidate)] = scores;
+    this._scores[key] = scores;
+    // A current-rev measurement replaces any provisional seat for this key (#285).
+    this._provisional.delete(key);
     return { name: candidate.name, measured: true, complete: true, scores };
   }
 
@@ -431,6 +472,11 @@ class GoldenSetProbe {
       let correct = 0;
       let errored = 0;
       for (const item of examples) {
+        // Admission gate (#285): yield to a live turn before each example, so a
+        // boot walk that collides with serving pauses within one example's
+        // granularity and resumes after the turn. An in-flight classify is never
+        // aborted — the gate controls admission, not abortion.
+        await this._yieldToServing(candidate.name);
         try {
           const predicted = await this.classifyFn(candidate.name, item.message, lang);
           if (predicted && predicted.gate === item.gate &&
@@ -446,6 +492,58 @@ class GoldenSetProbe {
       scores[lang] = examples.length > 0 ? correct / examples.length : 0;
     }
     return { scores, complete };
+  }
+
+  /**
+   * @private
+   * Yield the Ollama slot to a live turn (#285). If the serving gate reports a
+   * user turn in flight, wait for it to finish (or the cap) before the next
+   * measurement item. No-op when no gate is wired or nothing is serving.
+   * @param {string} label - candidate name, for the log line.
+   */
+  async _yieldToServing(label) {
+    if (!this.servingGate || !this.servingGate.isServing()) return;
+    this.logger.log(`[GoldenSetProbe] probe paused: serving active, yielding (${label})`);
+    const r = await this.servingGate.idle(this._servingWaitMs);
+    if (r && r.timedOut) {
+      this.logger.warn(`[GoldenSetProbe] probe resumed after ${this._servingWaitMs}ms cap while still serving — measuring anyway (${label})`);
+    } else {
+      this.logger.log(`[GoldenSetProbe] probe resumed: serving idle (${label})`);
+    }
+  }
+
+  /**
+   * @private
+   * The candidate's stable identity in a cache key — the digest when present
+   * (survives a re-tag), else the name. The prefix before the fixture salt.
+   */
+  _candidateId(candidate) {
+    return (candidate && (candidate.digest || candidate.name)) || 'unknown';
+  }
+
+  /**
+   * @private
+   * The most recent cached score for this model under a DIFFERENT fixture salt
+   * than the current one (#285): same model identity, prior fixture/rev. Used to
+   * seat a model provisionally when its current-rev score is missing, instead of
+   * re-measuring at boot. Returns the score map, or null if the model has never
+   * been measured under any rev.
+   * @param {Object} diskCache
+   * @param {{name: string, digest?: string}} candidate
+   * @returns {Object<string, number>|null}
+   */
+  _priorRevScores(diskCache, candidate) {
+    const currentKey = this._cacheKey(candidate);
+    const id = this._candidateId(candidate);
+    let best = null;
+    for (const [k, v] of Object.entries(diskCache)) {
+      if (k === currentKey || k === SELECTION_KEY) continue;
+      if (!v || !v.scores) continue;
+      const sep = k.lastIndexOf('__');
+      if (sep < 0 || k.slice(0, sep) !== id) continue;
+      if (!best || (v.at && (!best.at || v.at > best.at))) best = v;
+    }
+    return best ? best.scores : null;
   }
 
   /**

--- a/src/lib/llm/tool-capability-probe.js
+++ b/src/lib/llm/tool-capability-probe.js
@@ -28,6 +28,19 @@
  *   tool-call failure. The probe converts that silent runtime discovery
  *   into a loud boot line.
  *
+ * Admission gate + idle lane (#285): at boot the probe measures ONLY the
+ *   models the resolver actually seats for tool-capable jobs (`bootSet`); every
+ *   other tool-capable candidate, plus any seated model whose only verdict is
+ *   from a prior PROBE_REV, is drained one-per-pulse by the heartbeat idle lane
+ *   (getUnmeasuredCandidates/measureOne) instead of at boot. A prior-rev verdict
+ *   seats PROVISIONALLY (its flag applies now; a re-measurement in idle
+ *   corrects it), so a PROBE_REV bump never turns into a boot-time re-measure
+ *   stampede against serving. Between measurement items the loop yields to a
+ *   live turn via the shared serving gate — the same one-serving-signal home
+ *   the heartbeat reads (shared/ollama-gate). Second instance of the #260
+ *   measure-vs-serve contention class; this is the admission control #260
+ *   deferred.
+ *
  * Second item (#168, PR-4): a model that produces a tool call can still anchor
  *   a relative date to its training prior (qwen3:8b emits ~October 2023 for
  *   "tomorrow"). After the tool-call check passes, the probe sends one canned
@@ -65,7 +78,14 @@ const CACHE_FILENAME = 'tool-capability-probe.json';
 // Bump when the probe schema/instruction or pass criterion changes — old
 // cached verdicts then re-measure instead of masquerading as comparable.
 // r2 (#168, PR-4): adds the relative-date grounding item below.
+// Since #285 a REV bump no longer re-measures at BOOT: the old-rev verdict
+// seats provisionally and the re-measure happens in the idle lane.
 const PROBE_REV = 2;
+
+// How long a probe measurement will wait for a live turn to finish before it
+// proceeds anyway (admission gate, #285). Generous — measurement must eventually
+// happen; the gate trades its latency, never its existence.
+const DEFAULT_SERVING_WAIT_MS = 3 * 60 * 1000;
 
 // The trivial probe function: one boolean argument, no room for ambiguity.
 const PROBE_TOOL = {
@@ -144,77 +164,213 @@ class ToolCapabilityProbe {
    *   transport of its own.
    * @param {string} [opts.cacheDir] - Directory for the results cache
    *   (defaults to `data/` under cwd, same as GoldenSetProbe).
+   * @param {Object} [opts.servingGate] - The shared serving-active admission
+   *   gate (shared/ollama-gate). When set, the measurement loop yields to a live
+   *   turn before each candidate and between the two items (#285). Null → no
+   *   yielding (pre-#285 behaviour; tests that don't exercise the gate omit it).
+   * @param {number} [opts.servingWaitMs] - Cap on the per-yield wait before the
+   *   probe proceeds anyway. Defaults to DEFAULT_SERVING_WAIT_MS.
    * @param {Object} [opts.logger=console]
    */
-  constructor({ chatFn, cacheDir, logger } = {}) {
+  constructor({ chatFn, cacheDir, servingGate, servingWaitMs, logger } = {}) {
     this.chatFn = typeof chatFn === 'function' ? chatFn : null;
     this.cacheDir = cacheDir || path.resolve(process.cwd(), 'data');
     this._cacheFile = path.join(this.cacheDir, CACHE_FILENAME);
     this.logger = logger || console;
+    this.servingGate = servingGate && typeof servingGate.isServing === 'function' ? servingGate : null;
+    this._servingWaitMs = Number.isFinite(servingWaitMs) && servingWaitMs > 0
+      ? servingWaitMs
+      : DEFAULT_SERVING_WAIT_MS;
+
+    // The candidate list from the most recent run(), so the heartbeat idle lane
+    // can drain the non-boot / provisional candidates without re-deriving it
+    // (#285, mirrors GoldenSetProbe._lastCandidates).
+    this._lastCandidates = [];
+
+    // Current-rev cache keys seated PROVISIONALLY on a prior-rev verdict this
+    // boot (#285): the flag applies now, but the key still needs a current-rev
+    // measurement, which the idle lane performs. Cleared per key by measureOne().
+    this._provisional = new Set();
+
+    // True only while run()'s boot loop + final cache save are in flight. The
+    // idle lane (getUnmeasuredCandidates) no-ops while set, so a boot run() and
+    // an idle pulse never interleave their cache writes (mirrors GoldenSetProbe).
+    this._running = false;
   }
 
   /**
-   * Probe each candidate once (sequential — one Ollama host serves these).
-   * @param {Array<{name: string, digest?: string}>} candidates
-   * @returns {Promise<Array<{name: string, status: string, detail: string}>>}
+   * Probe the boot set once (sequential — one Ollama host serves these) and
+   * return a verdict per boot candidate. Candidates outside `bootSet` are
+   * retained for the idle lane but not measured here (#285). A boot candidate
+   * with only a prior-PROBE_REV verdict seats PROVISIONALLY (its flag returned
+   * now, re-measurement deferred to idle) rather than re-measuring at boot.
+   *
+   * @param {Array<{name: string, digest?: string}>} candidates - the full
+   *   tool-capable candidate list (boot set ∪ idle-lane residents).
+   * @param {Object} [opts]
+   * @param {Array<string>|Set<string>} [opts.bootSet] - model names to measure
+   *   at boot (the seated minimal set). Absent → measure all at boot (pre-#285
+   *   default; callers that don't scope keep full boot behaviour).
+   * @returns {Promise<Array<{name: string, status: string, detail: string, provisional?: boolean}>>}
+   *   one entry per boot candidate that was measured or provisionally seated.
    */
-  async run(candidates) {
+  async run(candidates, opts = {}) {
     const list = Array.isArray(candidates) ? candidates.filter(c => c && typeof c.name === 'string') : [];
+    this._lastCandidates = list;
     if (list.length === 0 || !this.chatFn) {
       if (!this.chatFn) this.logger.warn('[ToolCapabilityProbe] Missing chatFn; skipping probe.');
       return [];
     }
 
+    const bootNames = opts && opts.bootSet
+      ? new Set(Array.isArray(opts.bootSet) ? opts.bootSet : [...opts.bootSet])
+      : null;
+
+    // Fence the idle lane out until this boot pass has persisted (mirrors
+    // GoldenSetProbe): the skip set isn't final and the save is pending.
+    this._running = true;
     const diskCache = this._loadCache();
     let cacheChanged = false;
     const results = [];
 
-    for (const candidate of list) {
-      const key = this._cacheKey(candidate);
-      const cached = diskCache[key];
-      if (cached && cached.status && cached.status !== VERDICT.UNMEASURED) {
-        results.push({ name: candidate.name, status: cached.status, detail: `${cached.detail || ''} (cached)`.trim() });
-        continue;
-      }
+    try {
+      for (const candidate of list) {
+        const key = this._cacheKey(candidate);
 
-      let status;
-      let detail;
-      try {
-        const res = await this.chatFn(candidate.name, {
-          system: PROBE_SYSTEM,
-          messages: [{ role: 'user', content: PROBE_MESSAGE }],
-          tools: [PROBE_TOOL],
-        });
-        const calls = res && Array.isArray(res.toolCalls) ? res.toolCalls : [];
-        if (calls.some(tc => tc && tc.name === PROBE_TOOL.function.name)) {
-          // Tool-call capable. Now the second item: can it ground a relative
-          // date (#168)? A throw here (transport) propagates to the catch →
-          // UNMEASURED, so a cold host never caches a false date failure.
-          const date = await this._probeDateGrounding(candidate.name);
-          status = date.status;
-          detail = date.detail;
-        } else {
-          status = VERDICT.PROSE;
-          const preview = res && typeof res.content === 'string' ? res.content.slice(0, 60) : '';
-          detail = `prose instead of tool call${preview ? `: "${preview}"` : ''}`;
+        // Not seated: never measured at boot — the idle lane drains it later.
+        if (bootNames && !bootNames.has(candidate.name)) continue;
+
+        const cached = diskCache[key];
+        if (cached && cached.status && cached.status !== VERDICT.UNMEASURED) {
+          results.push({ name: candidate.name, status: cached.status, detail: `${cached.detail || ''} (cached)`.trim() });
+          continue;
         }
-      } catch (err) {
-        // Transport error / timeout: NOT evidence of prose (#124 cold-start).
-        // Do not cache, do not flag; retry next boot.
-        status = VERDICT.UNMEASURED;
-        detail = err && err.message;
-        this.logger.warn(`[ToolCapabilityProbe] ${candidate.name}: probe errored (${detail}); not caching, will retry next boot.`);
+
+        // #285: no current-rev verdict, but a prior-rev verdict exists → seat it
+        // PROVISIONALLY (apply its flag now), re-measure in idle, not at boot.
+        const prior = this._priorRevEntry(diskCache, candidate);
+        if (prior) {
+          this._provisional.add(key);
+          this.logger.log(`[ToolCapabilityProbe] ${candidate.name}: seated provisionally on a prior-rev verdict (${prior.status}); re-measuring in idle.`);
+          results.push({
+            name: candidate.name,
+            status: prior.status,
+            detail: `${prior.detail || ''} (provisional, re-measuring in idle)`.trim(),
+            provisional: true,
+          });
+          continue;
+        }
+
+        // Genuinely unmeasured (new model, or a prior errored/uncached): measure.
+        await this._yieldToServing(candidate.name);
+        const { status, detail, complete } = await this._measureCandidate(candidate);
+        if (complete) {
+          diskCache[key] = { status, detail, at: new Date().toISOString() };
+          cacheChanged = true;
+        }
+        results.push({ name: candidate.name, status, detail });
       }
 
-      if (status !== VERDICT.UNMEASURED) {
-        diskCache[key] = { status, detail, at: new Date().toISOString() };
-        cacheChanged = true;
-      }
-      results.push({ name: candidate.name, status, detail });
+      if (cacheChanged) this._saveCache(diskCache);
+    } finally {
+      this._running = false;
     }
-
-    if (cacheChanged) this._saveCache(diskCache);
     return results;
+  }
+
+  /**
+   * Measure a single candidate on both items (tool-call, then #168 date
+   * grounding). Shared by run() (boot) and measureOne() (idle lane). A transport
+   * error on either item → UNMEASURED with complete:false (cold ≠ prose, #124):
+   * the caller neither caches nor flags it.
+   * @param {{name: string, digest?: string}} candidate
+   * @returns {Promise<{status: string, detail: string, complete: boolean}>}
+   * @private
+   */
+  async _measureCandidate(candidate) {
+    try {
+      const res = await this.chatFn(candidate.name, {
+        system: PROBE_SYSTEM,
+        messages: [{ role: 'user', content: PROBE_MESSAGE }],
+        tools: [PROBE_TOOL],
+      });
+      const calls = res && Array.isArray(res.toolCalls) ? res.toolCalls : [];
+      if (calls.some(tc => tc && tc.name === PROBE_TOOL.function.name)) {
+        // Tool-call capable. Yield to a live turn before the second item (#285),
+        // then probe date grounding (#168). A throw here (transport) propagates
+        // to the catch → UNMEASURED, so a cold host never caches a false failure.
+        await this._yieldToServing(candidate.name);
+        const date = await this._probeDateGrounding(candidate.name);
+        return { status: date.status, detail: date.detail, complete: true };
+      }
+      const preview = res && typeof res.content === 'string' ? res.content.slice(0, 60) : '';
+      return { status: VERDICT.PROSE, detail: `prose instead of tool call${preview ? `: "${preview}"` : ''}`, complete: true };
+    } catch (err) {
+      // Transport error / timeout: NOT evidence of prose (#124 cold-start).
+      const detail = err && err.message;
+      this.logger.warn(`[ToolCapabilityProbe] ${candidate.name}: probe errored (${detail}); not caching, will retry.`);
+      return { status: VERDICT.UNMEASURED, detail, complete: false };
+    }
+  }
+
+  /**
+   * The tool-capable candidates with no usable current-PROBE_REV verdict: those
+   * outside the boot set, plus any seated model seated provisionally on a
+   * prior-rev verdict (#285). The heartbeat idle lane drains one per pulse via
+   * measureOne(), so capability calibration converges in downtime instead of
+   * competing with serving at boot (part C). Consults the on-disk cache, not
+   * just this run's provisional set, so a candidate measured on a prior idle
+   * pulse is not re-measured.
+   * @param {Array<{name: string, digest?: string}>} [candidates] defaults to the
+   *   most recent run()'s list.
+   * @returns {Array} unmeasured/provisional candidates, input order preserved.
+   */
+  getUnmeasuredCandidates(candidates) {
+    // While a boot run() is measuring, the skip set isn't final and its save is
+    // pending — don't let the idle lane act on a moving target.
+    if (this._running) return [];
+    const source = Array.isArray(candidates) ? candidates : this._lastCandidates;
+    const list = (source || []).filter(c => c && typeof c.name === 'string');
+    if (list.length === 0) return [];
+    const diskCache = this._loadCache();
+    return list.filter(c => {
+      const key = this._cacheKey(c);
+      // A provisional seat still needs a current-rev measurement (#285).
+      if (this._provisional.has(key)) return true;
+      const cached = diskCache[key];
+      return !(cached && cached.status && cached.status !== VERDICT.UNMEASURED);
+    });
+  }
+
+  /**
+   * Measure one candidate and persist a current-PROBE_REV verdict — the idle
+   * lane's unit of work (#285), the seat-neutral analogue of GoldenSetProbe's
+   * measureOne(). It warms the cache so the NEXT boot's run() serves a current
+   * verdict (and applies any now-corrected flag) without measuring; it does not
+   * itself reseat. An incomplete (cold) measurement is not cached and stays in
+   * getUnmeasuredCandidates() for the next pulse.
+   * @param {{name: string, digest?: string}} candidate
+   * @returns {Promise<{name: string|null, measured: boolean, status: string, detail: string}>}
+   */
+  async measureOne(candidate) {
+    if (!candidate || typeof candidate.name !== 'string') {
+      return { name: null, measured: false, status: VERDICT.UNMEASURED, detail: 'invalid candidate' };
+    }
+    if (!this.chatFn) {
+      return { name: candidate.name, measured: false, status: VERDICT.UNMEASURED, detail: 'no chatFn' };
+    }
+    await this._yieldToServing(candidate.name);
+    const { status, detail, complete } = await this._measureCandidate(candidate);
+    if (!complete) {
+      return { name: candidate.name, measured: false, status, detail };
+    }
+    // Load-modify-save so a concurrent write is preserved (runs long after run()).
+    const key = this._cacheKey(candidate);
+    const diskCache = this._loadCache();
+    diskCache[key] = { status, detail, at: new Date().toISOString() };
+    this._saveCache(diskCache);
+    this._provisional.delete(key);
+    return { name: candidate.name, measured: true, status, detail };
   }
 
   /**
@@ -254,6 +410,58 @@ class ToolCapabilityProbe {
     return grounded
       ? { status: VERDICT.TOOL_CALL, detail: `tool call + date grounded (start ${startDay})` }
       : { status: VERDICT.DATE_UNGROUNDED, detail: `date anchored off-window: start ${startDay}, today ${PROBE_DATE_TODAY_ISO}` };
+  }
+
+  /**
+   * @private
+   * Yield the Ollama slot to a live turn (#285). If the serving gate reports a
+   * user turn in flight, wait for it to finish (or the cap) before the next
+   * measurement item. No-op when no gate is wired or nothing is serving.
+   * @param {string} label - candidate name, for the log line.
+   */
+  async _yieldToServing(label) {
+    if (!this.servingGate || !this.servingGate.isServing()) return;
+    this.logger.log(`[ToolCapabilityProbe] probe paused: serving active, yielding (${label})`);
+    const r = await this.servingGate.idle(this._servingWaitMs);
+    if (r && r.timedOut) {
+      this.logger.warn(`[ToolCapabilityProbe] probe resumed after ${this._servingWaitMs}ms cap while still serving — measuring anyway (${label})`);
+    } else {
+      this.logger.log(`[ToolCapabilityProbe] probe resumed: serving idle (${label})`);
+    }
+  }
+
+  /**
+   * @private
+   * The candidate's stable identity in a cache key — the digest when present
+   * (survives a re-tag), else the name. The prefix before the `__toolprobe_r*`
+   * suffix.
+   */
+  _candidateId(candidate) {
+    return (candidate && (candidate.digest || candidate.name)) || 'unknown';
+  }
+
+  /**
+   * @private
+   * The most recent cached verdict for this model under a DIFFERENT PROBE_REV
+   * (#285): same model identity, prior probe revision, a real (non-UNMEASURED)
+   * status. Used to seat a model provisionally when its current-rev verdict is
+   * missing, instead of re-measuring at boot. Returns the cache entry, or null.
+   * @param {Object} diskCache
+   * @param {{name: string, digest?: string}} candidate
+   * @returns {{status: string, detail?: string, at?: string}|null}
+   */
+  _priorRevEntry(diskCache, candidate) {
+    const currentKey = this._cacheKey(candidate);
+    const id = this._candidateId(candidate);
+    let best = null;
+    for (const [k, v] of Object.entries(diskCache)) {
+      if (k === currentKey) continue;
+      if (!v || !v.status || v.status === VERDICT.UNMEASURED) continue;
+      const sep = k.lastIndexOf('__');
+      if (sep < 0 || k.slice(0, sep) !== id) continue;
+      if (!best || (v.at && (!best.at || v.at > best.at))) best = v;
+    }
+    return best || null;
   }
 
   /** @private */

--- a/src/lib/providers/model-scout.js
+++ b/src/lib/providers/model-scout.js
@@ -236,6 +236,24 @@ class ModelScout {
   }
 
   /**
+   * Every tool-capable (Declared `tools`) text-generation model, smallest-first,
+   * for the tool-capability probe's idle lane (#285). The probe measures ONLY
+   * the seated boot set at boot; this is the full pool the idle lane drains one
+   * candidate per pulse so a model the maturation loop might later seat already
+   * has a capability verdict. Same {name, paramSize, digest} shape as
+   * getClassificationCandidates(); no param ceiling — tool models can be large
+   * and calibration runs in downtime.
+   * @returns {Array<{name: string, paramSize: number|null, digest: string|null}>}
+   */
+  getToolCandidates() {
+    if (!this._discovered || this._discovered.length === 0) return [];
+    return this._discovered
+      .filter(m => this._isTextGen(m) && this._capsOf(m).includes('tools'))
+      .sort((a, b) => this._compareSize(a, b))
+      .map(m => ({ name: m.name, paramSize: m.paramSize, digest: m.digest || null }));
+  }
+
+  /**
    * Get a compact text summary of discovered models for status display.
    * @returns {string}
    */

--- a/src/lib/shared/ollama-gate.js
+++ b/src/lib/shared/ollama-gate.js
@@ -1,9 +1,22 @@
 /**
- * Ollama Activity Gate — shared singleton to prevent heartbeat LLM calls
- * from blocking user message processing on single-slot Ollama instances.
+ * Ollama Activity Gate — shared singleton that keeps background LLM work from
+ * competing with live user message processing on single-slot Ollama instances.
  *
- * Message processor calls markUserActive() on message arrival.
- * Heartbeat checks isUserActive() before making LLM calls and defers if true.
+ * Two consumers, one truth ("is the box serving a user right now?"):
+ *   - Heartbeat / idle extractors call isUserActive() and skip their LLM work
+ *     while it is true (the original #-gate role).
+ *   - The boot/idle calibration probes (golden-set, tool-capability) call
+ *     isServing() between measurement items and await idle(cap) when it is true,
+ *     so a boot re-measurement walk yields to a live scheduling turn instead of
+ *     stampeding it (the measure-vs-serve admission gate, second instance of
+ *     the #260 class). isServing() is an alias of isUserActive() — deliberately
+ *     ONE serving signal, not a parallel latch that could drift from it.
+ *
+ * The turn is bracketed by the message processor: markUserActive() at process()
+ * entry, markUserDone() at every exit. The COOLDOWN_MS window is the safety net
+ * for exits that return before markUserDone() (skipped/deferred messages) — it
+ * bounds a leaked "active" to at most the cooldown rather than forever, which is
+ * why admission control here can trust a timestamp and needs no reference count.
  *
  * @module shared/ollama-gate
  * @license AGPL-3.0
@@ -12,6 +25,13 @@
 'use strict';
 
 const COOLDOWN_MS = 90_000; // 90s — covers classification + synthesis window
+
+// How often idle() re-checks the serving state. The probe yield granularity is
+// seconds (a paused example resumes ~a poll after the turn ends), not ms — a
+// coarse poll is enough and keeps the gate a plain timestamp with no waitlist.
+// A probe only polls while it is actively waiting for a turn to end (rare,
+// short-lived), so a sub-second interval costs nothing.
+const IDLE_POLL_MS = 200;
 
 let _lastUserMessageAt = 0;
 
@@ -33,5 +53,41 @@ module.exports = {
   isUserActive() {
     if (_lastUserMessageAt === 0) return false;
     return (Date.now() - _lastUserMessageAt) < COOLDOWN_MS;
-  }
+  },
+
+  /**
+   * Admission-gate alias of isUserActive(), read by the calibration probes.
+   * Same truth, named for the reader: "is the box serving a user right now?"
+   * @returns {boolean}
+   */
+  isServing() {
+    return this.isUserActive();
+  },
+
+  /**
+   * Resolve once the box is no longer serving a user, or after maxWaitMs —
+   * whichever comes first. A probe loop calls this between measurement items so
+   * a boot walk that collides with a live turn pauses and resumes after the
+   * turn, instead of contending for the single Ollama slot.
+   *
+   * The cap prevents starvation on a chatty deployment: measurement must
+   * eventually happen, so after maxWaitMs the probe proceeds anyway. The gate
+   * trades measurement latency, never its existence.
+   *
+   * @param {number} maxWaitMs - Upper bound on the wait (generous; minutes).
+   * @returns {Promise<{waited: boolean, timedOut: boolean}>}
+   */
+  idle(maxWaitMs) {
+    if (!this.isServing()) return Promise.resolve({ waited: false, timedOut: false });
+    const cap = Number.isFinite(maxWaitMs) && maxWaitMs > 0 ? maxWaitMs : COOLDOWN_MS;
+    const start = Date.now();
+    return new Promise(resolve => {
+      const tick = () => {
+        if (!this.isServing()) return resolve({ waited: true, timedOut: false });
+        if (Date.now() - start >= cap) return resolve({ waited: true, timedOut: true });
+        setTimeout(tick, IDLE_POLL_MS);
+      };
+      setTimeout(tick, IDLE_POLL_MS);
+    });
+  },
 };

--- a/test/unit/llm/golden-set-probe.test.js
+++ b/test/unit/llm/golden-set-probe.test.js
@@ -313,7 +313,7 @@ asyncTest('TC-PROBE-007: a transient all-error measurement is NOT cached and yie
   }
 });
 
-asyncTest('TC-PROBE-008: editing a label without bumping version invalidates the cache (content-hash salt)', async () => {
+asyncTest('TC-PROBE-008: a fixture-content change seats the prior score provisionally and defers re-measurement to idle (#285)', async () => {
   const cacheDir = uniqueTmpDir();
   try {
     const fixtureA = makeFixture();
@@ -324,16 +324,34 @@ asyncTest('TC-PROBE-008: editing a label without bumping version invalidates the
     const probeA = new GoldenSetProbe({ classifyFn, fixture: fixtureA, cacheDir, logger: silentLogger });
     await probeA.run(candidates);
     const afterA = callCount;
+    assert.ok(afterA > 0, 'first boot measures the model');
 
-    // Same version (1), but a label changed. The content-hash salt must differ,
-    // so the prior entry does NOT hit and the model is re-probed.
+    // Same version (1), but a label changed → the content-hash salt differs, so
+    // the current-rev key misses (the invalidation still happens). Under #285
+    // that miss does NOT re-measure at BOOT: the prior-rev score seats the model
+    // provisionally, and re-measurement is deferred to the idle lane so the boot
+    // walk never stampedes serving.
     const fixtureB = makeFixture();
     fixtureB.languages.DE[1].gate = 'knowledge'; // was 'action'
     const classifyFnB = async (...args) => { callCount++; return perfectClassifyFn(fixtureB)(...args); };
     const probeB = new GoldenSetProbe({ classifyFn: classifyFnB, fixture: fixtureB, cacheDir, logger: silentLogger });
-    await probeB.run(candidates);
+    const rB = await probeB.run(candidates);
 
-    assert.ok(callCount > afterA, 'a fixture content change must invalidate the cache even without a version bump');
+    assert.strictEqual(callCount, afterA, 'a fixture change must NOT re-measure at boot — the prior score seats provisionally');
+    assert.strictEqual(rB.model, 'm', 'the provisional prior score still seats select()');
+
+    // The provisional seat is queued for idle re-measurement…
+    assert.deepStrictEqual(probeB.getUnmeasuredCandidates(candidates).map(c => c.name), ['m'],
+      'a provisionally-seated model must appear in the idle lane for re-measurement');
+
+    // …and measureOne() (the idle-lane unit) re-measures it against the NEW
+    // fixture and clears the provisional flag.
+    const before = callCount;
+    const one = await probeB.measureOne(candidates[0]);
+    assert.ok(callCount > before, 'idle re-measurement runs the classifier against the current fixture');
+    assert.strictEqual(one.measured, true);
+    assert.deepStrictEqual(probeB.getUnmeasuredCandidates(candidates), [],
+      'after idle re-measurement the model is no longer provisional');
   } finally {
     fs.rmSync(cacheDir, { recursive: true, force: true });
   }
@@ -740,6 +758,87 @@ asyncTest('TC-EXIT-005: idle lane is fenced out while a boot run() is in flight'
     await running;
     // After run() completes the fence lifts and the skipped candidate surfaces.
     assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['big']);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+// ============================================================
+// Admission gate (#285): the measurement loop yields to a live turn between
+// fixture examples so a boot re-measurement walk never stampedes serving.
+// ============================================================
+
+console.log('\n--- Admission gate: probe yields to serving (#285) ---\n');
+
+// A deterministic fake of shared/ollama-gate: serving state and idle()
+// resolution are driven by the test, no real timers.
+function controllableGate() {
+  let serving = false;
+  let resolver = null;
+  return {
+    setServing(v) { serving = v; },
+    isServing: () => serving,
+    idle() { return new Promise(res => { resolver = res; }); },
+    release(result) {
+      const r = resolver; resolver = null;
+      if (r) r(result || { waited: true, timedOut: false });
+    },
+    get waiting() { return resolver !== null; },
+  };
+}
+
+asyncTest('TC-GATE-PROBE-001: run() pauses while serving and resumes after the turn — the turn is never queued behind probe calls', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    const seen = [];
+    const classifyFn = async (_model, message) => {
+      seen.push(message);
+      return truthMap(fixture)[message] || { gate: 'knowledge', domain: null };
+    };
+    const gate = controllableGate();
+    gate.setServing(true); // a live turn is in flight when the boot walk starts
+    const probe = new GoldenSetProbe({
+      classifyFn, fixture, cacheDir, servingGate: gate, logger: silentLogger,
+    });
+
+    const running = probe.run([{ name: 'm', paramSize: 3, digest: 'd' }]);
+    // Let run() reach its first pre-example yield.
+    await Promise.resolve(); await Promise.resolve();
+    assert.strictEqual(seen.length, 0, 'no classify runs while a turn is serving — the probe is parked at the gate');
+    assert.ok(gate.waiting, 'the probe is waiting on idle()');
+
+    // The turn ends; the gate releases the probe.
+    gate.setServing(false);
+    gate.release();
+    const result = await running;
+    assert.ok(seen.length > 0, 'the probe resumed and measured after serving went idle');
+    assert.strictEqual(result.model, 'm');
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('TC-GATE-PROBE-002: the wait cap lets the probe proceed on a chatty deployment (no starvation), and logs it', async () => {
+  const fixture = makeFixture();
+  const cacheDir = uniqueTmpDir();
+  try {
+    // Serving never ends; idle() always resolves at the cap (timedOut).
+    const gate = {
+      isServing: () => true,
+      idle: () => Promise.resolve({ waited: true, timedOut: true }),
+    };
+    const logger = capturingLogger();
+    const probe = new GoldenSetProbe({
+      classifyFn: perfectClassifyFn(fixture), fixture, cacheDir,
+      servingGate: gate, servingWaitMs: 1000, logger,
+    });
+    const result = await probe.run([{ name: 'm', paramSize: 3, digest: 'd' }]);
+    assert.strictEqual(result.model, 'm', 'measurement still completes after the cap fires');
+    assert.ok(
+      logger.warnings.some(w => w.includes('cap') && w.includes('measuring anyway')),
+      'the cap firing is logged loudly'
+    );
   } finally {
     fs.rmSync(cacheDir, { recursive: true, force: true });
   }

--- a/test/unit/llm/measure-vs-serve.test.js
+++ b/test/unit/llm/measure-vs-serve.test.js
@@ -1,0 +1,107 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * Measure-vs-serve admission gate — integration (#285).
+ *
+ * The per-module tests split the handshake in two (real gate + fake probe in
+ * golden-set-probe.test / fake gate + real probe here). This closes the seam:
+ * the REAL shared serving gate (shared/ollama-gate) composed with the REAL
+ * probes, real timers, the exact objects boot wiring constructs. A fake
+ * classify/chat stands in for Ollama — the subject is the ADMISSION handshake,
+ * not classification accuracy. It reproduces the beta stampede in miniature: a
+ * live turn is in flight when the boot walk starts, and the walk must yield.
+ *
+ * Run: node test/unit/llm/measure-vs-serve.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { asyncTest, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const gate = require('../../../src/lib/shared/ollama-gate');
+const GoldenSetProbe = require('../../../src/lib/llm/golden-set-probe');
+const { ToolCapabilityProbe, VERDICT } = require('../../../src/lib/llm/tool-capability-probe');
+
+const silent = { log: () => {}, warn: () => {}, info: () => {} };
+
+function tmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'measure-vs-serve-')); }
+
+const FIXTURE = {
+  version: 1, threshold: 0.75,
+  languages: {
+    EN: [{ id: 1, message: 'en1', gate: 'knowledge', domain: null }, { id: 2, message: 'en2', gate: 'action', domain: 'deck' }],
+    DE: [{ id: 1, message: 'de1', gate: 'knowledge', domain: null }, { id: 2, message: 'de2', gate: 'action', domain: 'deck' }],
+  },
+};
+const TRUTH = { en1: { gate: 'knowledge', domain: null }, en2: { gate: 'action', domain: 'deck' }, de1: { gate: 'knowledge', domain: null }, de2: { gate: 'action', domain: 'deck' } };
+
+console.log('\n=== Measure-vs-serve integration (#285) ===\n');
+
+(async () => {
+  await asyncTest('TC-MVS-001: a boot walk started mid-turn yields on the REAL gate and completes only after the turn', async () => {
+    gate.markUserDone(); // clean start
+    const dir = tmpDir();
+    try {
+      let classifyCount = 0;
+      const classifyFn = async (_m, message) => { classifyCount++; return TRUTH[message]; };
+      const probe = new GoldenSetProbe({ classifyFn, fixture: FIXTURE, cacheDir: dir, servingGate: gate, logger: silent });
+
+      // A live scheduling turn is in flight when the boot walk launches.
+      gate.markUserActive();
+      const running = probe.run([{ name: 'm', digest: 'd' }]);
+
+      // Give the probe real time to reach its first pre-example yield and park.
+      await new Promise(r => setTimeout(r, 150));
+      assert.strictEqual(classifyCount, 0, 'the boot walk must NOT classify while a turn is serving — this is the stampede the gate prevents');
+
+      // The turn finishes; the gate releases the parked probe.
+      gate.markUserDone();
+      const result = await running;
+      assert.strictEqual(classifyCount, 4, 'the walk resumed after the turn and measured every example');
+      assert.strictEqual(result.model, 'm');
+    } finally {
+      gate.markUserDone();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  await asyncTest('TC-MVS-002: tool probe boot set is scoped and the rest drains through the real idle lane', async () => {
+    gate.markUserDone();
+    const dir = tmpDir();
+    try {
+      let chatCount = 0;
+      const chatFn = async (_model, req) => {
+        chatCount++;
+        const name = req.tools[0].function.name;
+        if (name === 'schedule_event') return { content: null, toolCalls: [{ name, arguments: { start: '2026-06-16T15:00:00' } }] };
+        return { content: null, toolCalls: [{ name: 'mark_ready', arguments: { ready: true } }] };
+      };
+      const toolProbe = new ToolCapabilityProbe({ chatFn, cacheDir: dir, servingGate: gate, logger: silent });
+
+      const verdicts = await toolProbe.run(
+        [{ name: 'seated', digest: 'ta' }, { name: 'bench', digest: 'tb' }],
+        { bootSet: ['seated'] }
+      );
+      assert.strictEqual(verdicts.length, 1, 'only the seated model gets a boot verdict');
+      assert.strictEqual(verdicts[0].name, 'seated');
+      assert.strictEqual(verdicts[0].status, VERDICT.TOOL_CALL);
+      assert.strictEqual(chatCount, 2, 'the non-boot candidate is not measured at boot (2 items × 1 model)');
+
+      assert.deepStrictEqual(toolProbe.getUnmeasuredCandidates().map(c => c.name), ['bench'], 'the bench candidate is the idle lane\'s work');
+      const one = await toolProbe.measureOne({ name: 'bench', digest: 'tb' });
+      assert.strictEqual(one.measured, true);
+      assert.strictEqual(one.status, VERDICT.TOOL_CALL);
+      assert.deepStrictEqual(toolProbe.getUnmeasuredCandidates(), [], 'idle lane drained');
+    } finally {
+      gate.markUserDone();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  setTimeout(() => { summary(); exitWithCode(); }, 1500);
+})();

--- a/test/unit/llm/tool-capability-probe.test.js
+++ b/test/unit/llm/tool-capability-probe.test.js
@@ -184,5 +184,113 @@ function dualStub({ dateStart = '2026-06-16T15:00:00', dateToolCalls } = {}) {
     assert.ok(calls > after, 'errored date measurement is not served from cache');
   });
 
+  // ==========================================================================
+  // Admission gate + idle lane (#285)
+  // ==========================================================================
+
+  // TC-TCP-011: at boot, only the bootSet is measured; the rest defer to idle.
+  await asyncTest('TC-TCP-011: bootSet scopes boot measurement; non-boot candidates drain in the idle lane (#285)', async () => {
+    const dir = tmpCacheDir();
+    let calls = 0;
+    const inner = dualStub();
+    const chatFn = async (m, req) => { calls++; return inner(m, req); };
+    const probe = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+
+    const candidates = [{ name: 'seated', digest: 'd-a' }, { name: 'bench', digest: 'd-b' }];
+    const results = await probe.run(candidates, { bootSet: ['seated'] });
+
+    // Only the seated model is measured at boot (2 items = 2 calls); no results
+    // are emitted for the non-boot candidate.
+    assert.strictEqual(results.length, 1, 'only the boot set produces a boot verdict');
+    assert.strictEqual(results[0].name, 'seated');
+    assert.strictEqual(results[0].status, VERDICT.TOOL_CALL);
+    assert.strictEqual(calls, 2, 'the non-boot candidate is NOT measured at boot');
+
+    // The non-boot candidate is the idle lane's work.
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['bench']);
+
+    const r = await probe.measureOne({ name: 'bench', digest: 'd-b' });
+    assert.strictEqual(r.measured, true);
+    assert.strictEqual(r.status, VERDICT.TOOL_CALL);
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), [], 'idle lane drained');
+  });
+
+  // TC-TCP-012: a prior-PROBE_REV verdict seats provisionally at boot (no
+  // re-measure) and re-measures in idle.
+  await asyncTest('TC-TCP-012: a prior-rev verdict seats provisionally, re-measures in idle (#285)', async () => {
+    const dir = tmpCacheDir();
+    // Seed a PRIOR-rev cache entry (r1) for the model, as a REV bump would leave.
+    const priorKey = 'sha256:p__toolprobe_r1';
+    fs.writeFileSync(
+      path.join(dir, 'tool-capability-probe.json'),
+      JSON.stringify({ [priorKey]: { status: VERDICT.PROSE, detail: 'prose (r1)', at: '2026-01-01T00:00:00Z' } }),
+      'utf8'
+    );
+
+    let calls = 0;
+    const inner = dualStub();
+    const chatFn = async (m, req) => { calls++; return inner(m, req); };
+    const probe = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const candidate = { name: 'p-model', digest: 'sha256:p' };
+
+    const [v] = await probe.run([candidate], { bootSet: ['p-model'] });
+    assert.strictEqual(v.status, VERDICT.PROSE, 'the prior-rev verdict seats the flag provisionally');
+    assert.strictEqual(v.provisional, true, 'marked provisional');
+    assert.strictEqual(calls, 0, 'NO boot re-measurement — the stampede this fix removes');
+
+    // Queued for idle re-measurement…
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates().map(c => c.name), ['p-model']);
+
+    // …and measureOne re-measures against the current rev (now tool-call) and
+    // writes the current-rev entry; a demotion/promotion takes effect exactly
+    // as a fresh measurement would (here the model now passes).
+    const r = await probe.measureOne(candidate);
+    assert.strictEqual(r.measured, true);
+    assert.strictEqual(r.status, VERDICT.TOOL_CALL);
+    assert.ok(calls > 0, 'idle re-measurement calls the provider');
+    assert.deepStrictEqual(probe.getUnmeasuredCandidates(), [], 'no longer provisional');
+
+    // A fresh probe over the same dir now serves the current-rev verdict.
+    const probe2 = new ToolCapabilityProbe({ chatFn, cacheDir: dir, logger: captureLogger() });
+    const [v2] = await probe2.run([candidate], { bootSet: ['p-model'] });
+    assert.strictEqual(v2.status, VERDICT.TOOL_CALL);
+    assert.ok(/cached/.test(v2.detail), 'current-rev verdict is now cached');
+  });
+
+  // TC-TCP-013: the probe yields to a live turn between items, and the turn is
+  // never queued behind probe calls.
+  await asyncTest('TC-TCP-013: probe pauses while serving and resumes after the turn (#285)', async () => {
+    const order = [];
+    const gate = (() => {
+      let serving = true, resolver = null;
+      return {
+        setServing(v) { serving = v; },
+        isServing: () => serving,
+        idle() { return new Promise(res => { resolver = res; }); },
+        release() { const r = resolver; resolver = null; if (r) r({ waited: true, timedOut: false }); },
+        get waiting() { return resolver !== null; },
+      };
+    })();
+    const chatFn = async (_m, req) => {
+      order.push(req.tools[0].function.name);
+      if (req.tools[0].function.name === 'schedule_event') {
+        return { content: null, toolCalls: [{ name: 'schedule_event', arguments: { start: '2026-06-16T15:00:00' } }] };
+      }
+      return { content: null, toolCalls: [{ name: 'mark_ready', arguments: { ready: true } }] };
+    };
+    const probe = new ToolCapabilityProbe({ chatFn, cacheDir: tmpCacheDir(), servingGate: gate, logger: captureLogger() });
+
+    const running = probe.run([{ name: 'm', digest: 'd' }]);
+    await Promise.resolve(); await Promise.resolve();
+    assert.strictEqual(order.length, 0, 'no probe call while a turn is serving — parked at the gate');
+    assert.ok(gate.waiting, 'the probe is waiting on idle()');
+
+    gate.setServing(false);
+    gate.release();
+    const [v] = await running;
+    assert.strictEqual(v.status, VERDICT.TOOL_CALL, 'the probe resumed and measured after the turn');
+    assert.deepStrictEqual(order, ['mark_ready', 'schedule_event'], 'both items ran, in order, after serving idle');
+  });
+
   setTimeout(() => { summary(); exitWithCode(); }, 500);
 })();

--- a/test/unit/providers/model-scout.test.js
+++ b/test/unit/providers/model-scout.test.js
@@ -430,6 +430,28 @@ scenario('getClassificationCandidates() never goes dark — an all-large pool fa
   });
 });
 
+// -- getToolCandidates(): every tool-capable text model, smallest-first (#285) --
+scenario('getToolCandidates() returns tool-capable text models smallest-first, excluding non-tool/embedding/vision', async () => {
+  await withMock(mockFetch(TAGS_MODELS, SHOW_BY_MODEL), async () => {
+    const scout = new ModelScout({ ollamaEndpoint: 'http://localhost:11434', logger: silentLogger });
+    await scout.discover();
+    const names = scout.getToolCandidates().map(c => c.name);
+    // Only qwen3:8b and qwen2.5:3b declare `tools`; smaller-first → 3b before 8b.
+    assert.deepStrictEqual(names, ['qwen2.5:3b', 'qwen3:8b']);
+    assert.ok(!names.includes('gemma2:2b'), 'a text-only model is not a tool candidate');
+    assert.ok(!names.includes('nomic-embed-text:latest') && !names.includes('llava:7b'),
+      'embedding/vision specialists are never tool candidates');
+    // Shape mirrors getClassificationCandidates(): name/paramSize/digest.
+    const one = scout.getToolCandidates()[0];
+    assert.ok('name' in one && 'paramSize' in one && 'digest' in one, 'each candidate carries name/paramSize/digest');
+  });
+});
+
+scenario('getToolCandidates() is empty before discovery and with no tool-capable pool', async () => {
+  const scout = new ModelScout({ logger: silentLogger });
+  assert.deepStrictEqual(scout.getToolCandidates(), [], 'empty before discovery');
+});
+
 // Run the fetch-mocking scenarios sequentially, then report.
 (async () => {
   for (const { name, fn } of suite) {

--- a/test/unit/shared/ollama-gate.test.js
+++ b/test/unit/shared/ollama-gate.test.js
@@ -1,0 +1,76 @@
+/**
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (C) 2026 Moltagent contributors
+ *
+ * ollama-gate Unit Tests — the shared serving-active admission gate (#285).
+ *
+ * The gate is ONE serving signal read by two consumers: the heartbeat
+ * (isUserActive) and the calibration probes (isServing/idle). These tests cover
+ * the admission-gate additions: the isServing() alias and idle(cap), which let a
+ * probe loop yield to a live turn and resume after it, or proceed at the cap.
+ *
+ * Run: node test/unit/shared/ollama-gate.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { asyncTest, test, summary, exitWithCode } = require('../../helpers/test-runner');
+
+const gate = require('../../../src/lib/shared/ollama-gate');
+
+console.log('\n=== ollama-gate admission gate (#285) ===\n');
+
+// Each test leaves the gate idle so the next starts clean (module singleton).
+// The gate is a process-wide singleton, so these tests MUST run serially — they
+// are awaited in the IIFE below, never fired concurrently, or one test's turn
+// would leak into another's wait.
+function resetGate() { gate.markUserDone(); }
+
+(async () => {
+  test('TC-GATE-001: isServing() is an alias of isUserActive()', () => {
+    resetGate();
+    assert.strictEqual(gate.isServing(), false, 'idle at rest');
+    gate.markUserActive();
+    assert.strictEqual(gate.isServing(), true, 'serving while a turn is active');
+    assert.strictEqual(gate.isServing(), gate.isUserActive(), 'same truth, two names');
+    resetGate();
+    assert.strictEqual(gate.isServing(), false, 'markUserDone() clears serving');
+  });
+
+  await asyncTest('TC-GATE-002: idle() resolves immediately when nothing is serving', async () => {
+    resetGate();
+    const started = Date.now();
+    const r = await gate.idle(5000);
+    assert.strictEqual(r.waited, false, 'no wait when idle');
+    assert.strictEqual(r.timedOut, false);
+    assert.ok(Date.now() - started < 100, 'resolves without polling');
+  });
+
+  await asyncTest('TC-GATE-003: idle() waits while serving and resolves once the turn is done', async () => {
+    resetGate();
+    gate.markUserActive();
+    const p = gate.idle(5000);
+    // The turn finishes shortly after the probe began waiting.
+    setTimeout(() => gate.markUserDone(), 120);
+    const r = await p;
+    assert.strictEqual(r.waited, true, 'the probe waited for the turn');
+    assert.strictEqual(r.timedOut, false, 'it resumed because serving ended, not the cap');
+    assert.strictEqual(gate.isServing(), false);
+  });
+
+  await asyncTest('TC-GATE-004: idle() proceeds at the cap when serving never ends (no starvation)', async () => {
+    resetGate();
+    gate.markUserActive(); // never marked done — a chatty deployment
+    const started = Date.now();
+    const r = await gate.idle(120); // tiny cap for the test
+    assert.strictEqual(r.waited, true);
+    assert.strictEqual(r.timedOut, true, 'the cap fires so measurement is never starved');
+    assert.ok(Date.now() - started >= 120, 'waited at least the cap');
+    assert.strictEqual(gate.isServing(), true, 'the turn is still active — the probe proceeds anyway');
+    resetGate();
+  });
+
+  // A generous window so the real-timer waits above (all < ~300ms) complete.
+  setTimeout(() => { summary(); exitWithCode(); }, 2000);
+})();

--- a/webhook-server.js
+++ b/webhook-server.js
@@ -526,6 +526,13 @@ let judgeQueue = null; // Session 4: bounded judge-then-delete retention of judg
 let localJudge = null; // Session 4: heartbeat-idle grader for writing/thinking
 let nicheAssignment = null; // Session 5 (Layer 3): carrying-capacity plan over the winners
 let goldenSetProbe = null; // #260: retained so the heartbeat idle lane drains the candidates run()'s early exit skipped
+let toolCapabilityProbe = null; // #285: retained so the heartbeat idle lane drains non-boot / provisional tool candidates
+
+// #285: the shared serving-active admission gate. The message processor already
+// brackets every turn (markUserActive/markUserDone); the boot/idle calibration
+// probes read isServing()/idle() through this ONE home so a re-measurement walk
+// yields to a live turn instead of stampeding it.
+const servingGate = require('./src/lib/shared/ollama-gate');
 
 // Residency-signal sink for every local Ollama adapter (both families).
 // Late-bound: no-ops until NicheAssignment is constructed after discovery,
@@ -2182,6 +2189,7 @@ async function initialize() {
               classifyFn: (m, msg, lang) => intentRouter.probeClassify(m, msg, lang),
               fixture,
               cacheDir: path.join(__dirname, 'data'),
+              servingGate, // #285: yield the boot walk to a live turn
               logger: console,
             });
             // Retain the instance so the heartbeat idle lane can drain the
@@ -2231,23 +2239,40 @@ async function initialize() {
                     const toolProbe = new ToolCapabilityProbe({
                       chatFn: (model, req) => probeProvider.chat({ ...req, model }),
                       cacheDir: path.join(__dirname, 'data'),
+                      servingGate, // #285: yield the boot walk to a live turn
                       logger: console,
                     });
-                    const seen = new Set();
-                    const toolCandidates = [];
+                    // #285: the boot SET is only the seated tool models (measure
+                    // exactly what serves now); the full tool-capable pool is
+                    // handed to run() so the idle lane can drain the rest one per
+                    // pulse. Retain the instance for the heartbeat thunk.
+                    toolCapabilityProbe = toolProbe;
+                    const bootSet = new Set();
                     for (const job of ['tools', 'quick']) {
                       const r = modelResolver.resolve(job);
-                      if (r.model && String(r.provider || '').startsWith('ollama') && !seen.has(r.model)) {
-                        seen.add(r.model);
-                        const disc = (modelScout._discovered || []).find(m => m && m.name === r.model);
-                        toolCandidates.push({ name: r.model, digest: disc && disc.digest });
+                      if (r.model && String(r.provider || '').startsWith('ollama')) {
+                        bootSet.add(r.model);
                       }
                     }
-                    const verdicts = await toolProbe.run(toolCandidates);
+                    const digestOf = (name) => {
+                      const disc = (modelScout._discovered || []).find(m => m && m.name === name);
+                      return disc && disc.digest;
+                    };
+                    // Full tool-capable pool (idle-lane residents); ensure the
+                    // seated boot models are present even if discovery missed a cap.
+                    const toolCandidates = (typeof modelScout.getToolCandidates === 'function'
+                      ? modelScout.getToolCandidates()
+                      : []);
+                    const known = new Set(toolCandidates.map(c => c.name));
+                    for (const name of bootSet) {
+                      if (!known.has(name)) toolCandidates.push({ name, digest: digestOf(name) });
+                    }
+                    const verdicts = await toolProbe.run(toolCandidates, { bootSet });
                     for (const v of verdicts) {
+                      const prov = v.provisional ? ' (provisional; re-measured in idle)' : '';
                       if (v.status === VERDICT.PROSE) {
                         modelResolver.markToolIncapable(v.name);
-                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} answered a tool-requiring instruction with prose — flagged (#118); runtime chain falls back on tool-call failure`);
+                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} answered a tool-requiring instruction with prose — flagged (#118)${prov}; runtime chain falls back on tool-call failure`);
                       } else if (v.status === VERDICT.DATE_UNGROUNDED) {
                         // #168: emits tool calls but anchors relative dates to its
                         // training prior (~2023) even with the shipped grounding
@@ -2255,9 +2280,9 @@ async function initialize() {
                         // (which model serves tools next, at what latency) is the
                         // #275 decision, surfaced here, not tuned away.
                         modelResolver.markToolIncapable(v.name);
-                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} could not ground a relative date (${v.detail}) — flagged (#168); tools seat demotes to the next candidate`);
+                        console.warn(`[BOOT][WARN] Tool-capability probe: ${v.name} could not ground a relative date (${v.detail}) — flagged (#168)${prov}; tools seat demotes to the next candidate`);
                       } else if (v.status === VERDICT.TOOL_CALL) {
-                        console.log(`[INIT] Tool-capability probe: ${v.name} → tool call + date grounded OK${/\(cached\)/.test(v.detail || '') ? ' (cached)' : ''}`);
+                        console.log(`[INIT] Tool-capability probe: ${v.name} → tool call + date grounded OK${/\(cached\)/.test(v.detail || '') ? ' (cached)' : ''}${prov}`);
                       }
                     }
                   }
@@ -2663,6 +2688,10 @@ async function initialize() {
         // the async ModelScout discovery block, after this manager. The idle
         // lane drains its unmeasured candidates one per pulse.
         getGoldenSetProbe: () => goldenSetProbe,
+        // #285: same thunk pattern — the tool-capability probe is constructed in
+        // the same async block. The idle lane drains its non-boot / provisional
+        // tool candidates one per pulse.
+        getToolCapabilityProbe: () => toolCapabilityProbe,
         onOllamaTimings: ollamaTimingsSink,
         dailyBriefing,
         reviewUser: appConfig.cockpit?.adminUser || appConfig.knowledge?.adminUser || '',


### PR DESCRIPTION
## What

Makes measurement yield to serving. The boot/idle calibration probes (golden-set classification, tool-capability) no longer stampede a live turn for the single Ollama slot when a pull invalidates their caches.

## Why

Addresses #285 — second instance of the #260 measure-vs-serve contention class. A pull that bumps the golden-set fixture **and** the tool-probe `PROBE_REV` invalidates both probe caches; both then re-measure **at boot**, and a live scheduling turn times out competing for the GPU. (Leave the issue open for Fu to close on merge.)

## How

Three generators, three fixes:

- **A. Serving-active admission gate.** The turn is already bracketed by `ollama-gate` (`markUserActive`/`markUserDone`) and the heartbeat already reads it — so the fix **extends that one serving signal** with `isServing()`/`idle(cap)` rather than adding a parallel latch (signals keep custody; the briefing's separate-latch sketch was superseded by discovery). Both probes yield to a live turn **between** measurement items (never mid-request); a generous cap prevents starvation on a chatty deployment. **MessageProcessor is unchanged** — the seam already existed.
- **B. Invalidation decoupled from boot.** A REV/fixture-hash bump means a cached verdict is *not comparable*, not the model *unknown*: the prior-rev verdict/score seats **provisionally** and re-measures in the idle lane, not at boot. #275's demotion still governs the endpoint; this governs only the transition path.
- **C. Tool-capability probe joins the idle lane.** It measures only the seated boot set at boot (`bootSet`); every other tool-capable candidate and every provisional seat drains one-per-pulse via `getUnmeasuredCandidates`/`measureOne`, mirroring the golden-set lane (#260). Adds `ModelScout.getToolCandidates()`.

Net: `+920 / −68` across 5 source + 4 test files (2 new test files). No trust-boundary changes, no fixture/bar changes, no probe-call abortion (admission control only).

## Testing

- [x] Tests pass — `npm run test:unit` → **240/240 test files pass, 0 fail**; `npm run lint` → **exit 0, 0 errors**.
- [ ] Tested manually against a Nextcloud instance — **pending post-merge on Prime** via the forged-webhook harness (the #271/#274 organic-turn stand-in): restart into a boot re-measurement window, inject a signature-verified Talk scheduling turn, and capture the probe yielding (`probe paused: serving`) while the turn completes at normal latency. A real Talk turn from Fu is welcome bonus evidence.
- [x] No language-specific logic added (the gate is a boolean/timestamp; probes are language-agnostic; only operator log lines added).

New coverage: real-gate `idle`/cap; per-probe yield/cap/provisional-seating/idle-lane; `ModelScout.getToolCandidates`; and a **real-gate + real-probe integration test** that reproduces the stampede in miniature — a boot walk launched mid-turn parks at **0 classifies** while serving and resumes only after the turn.

## Checklist

- [x] Commit messages are descriptive
- [x] No credentials, IPs, or client-specific data in the diff
- [x] Documentation updated if needed (module Architecture Briefs updated in both probes and the gate)
