### PR TITLE
docs(llm): name the serving gate's mid-turn tail bound (#287)

### DIFF
--- a/src/lib/shared/ollama-gate.js
+++ b/src/lib/shared/ollama-gate.js
@@ -49,6 +49,15 @@ module.exports = {
   /**
    * Returns true if a user message is being processed or was very recent.
    * Heartbeat should skip LLM calls when this returns true.
+   *
+   * Bound (#287): the timestamp is set at turn entry and NOT refreshed mid-turn,
+   * so a turn longer than COOLDOWN_MS loses tail protection for its final
+   * seconds — a probe parked on idle() can resume while the turn's last tool
+   * call is still in flight (the #285 stampede turn ran ~97s). Small, bounded
+   * harm; not fixed here because the timestamp model is exactly what keeps this
+   * gate reference-count-free. Candidate fix (#287): refresh the timestamp once
+   * per agent-loop iteration — extends protection to arbitrarily long turns
+   * without changing the gate's shape.
    */
   isUserActive() {
     if (_lastUserMessageAt === 0) return false;


### PR DESCRIPTION
## What
Names, in `isUserActive()`'s JSDoc, the known bound Fable surfaced reviewing #286: the serving gate's timestamp is set at turn entry and not refreshed mid-turn, so a turn longer than `COOLDOWN_MS` (the #285 stampede turn ran ~97s) loses tail protection for its final seconds.

## Why
Document the limitation in place. **Not** fixed here — the timestamp model is what keeps the gate reference-count-free; the candidate fix (refresh the timestamp per agent-loop iteration) is tracked in #287 for its own scope + verification, and deliberately does not ride the merged #286.

## How
One JSDoc paragraph pointing at #287. Doc-only, no behavior change.

## Testing
- [x] `node test/unit/shared/ollama-gate.test.js` → 4/4; `eslint` → 0 errors. Gate still loads (isServing/idle present).

Relates #285, #286, #287.