### PR TITLE
fix(guardrail): Phase 1 approval-custody tightenings — delete tool-keyed cache (#265) + write-class downgrade floor (#290)

### DIFF
--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -25,7 +25,10 @@ const { surfaceText, hasSurfaceText, toolLabel, fieldLabel } = require('./surfac
  *   2. Same-turn — "did the user's own message explicitly request this action?"
  *      (the anti-nagging downgrade). One LLM call at this chokepoint, posed with
  *      the tool label and the rendered args. Any answer but a clear YES runs the
- *      ceremony: the failure direction is always toward asking.
+ *      ceremony: the failure direction is always toward asking. Write-class tools
+ *      are ineligible for this downgrade entirely (#290, Phase 1 T-B) — a request
+ *      may never manufacture the authority to waive its own ceremony; judgment
+ *      escalates severity, never lowers it past the threshold.
  *
  * Neither question is answered by a cache. A prior approval authorizes the one
  * call it was granted for; the tool-keyed skip cache that let it leak across
@@ -749,8 +752,16 @@ class GuardrailEnforcer {
       return { allowed: false, reason: `${toolName} requires approval but no interactive session available` };
     }
 
-    // MEDIUM: the user's own message may already be the authorization
-    if (severity === 'MEDIUM') {
+    // MEDIUM: the user's own message may already be the authorization — but a
+    // write-class tool is ineligible for this downgrade (#290, Phase 1 T-B). A
+    // request cannot manufacture the authority to waive its own ceremony;
+    // judgment keeps escalation authority only, never loosening past the
+    // threshold. The floor is structural, not a more-consistent judgment: the
+    // same delete request was judged YES in PT and NO in DE at one boot (S126
+    // T5), and the fix for a language-inconsistent security judgment is to
+    // remove its loosening authority, not to seek consistency. Non-write-class
+    // MEDIUM tools still downgrade as before.
+    if (severity === 'MEDIUM' && !getWriteClassTools().has(toolName)) {
       const requested = await this._userRequestedAction(conversationHistory, toolName, toolArgs);
       if (requested) {
         this.logger.info(`[GuardrailEnforcer] checkApproval: ${toolName} → LOW (user's message requested this action)`);

--- a/src/lib/agent/guardrail-enforcer.js
+++ b/src/lib/agent/guardrail-enforcer.js
@@ -27,6 +27,10 @@ const { surfaceText, hasSurfaceText, toolLabel, fieldLabel } = require('./surfac
  *      the tool label and the rendered args. Any answer but a clear YES runs the
  *      ceremony: the failure direction is always toward asking.
  *
+ * Neither question is answered by a cache. A prior approval authorizes the one
+ * call it was granted for; the tool-keyed skip cache that let it leak across
+ * targets is gone (#265, Phase 1 T-A). Bound one-shot approvals arrive in Phase 2.
+ *
  * @module agent/guardrail-enforcer
  */
 
@@ -196,9 +200,13 @@ class GuardrailEnforcer {
     // key: `${guardrailTitle}:${toolName}` → { result: 'YES'|'NO', timestamp }
     this.matchCache = new Map();
 
-    // Approval cache: once a guardrail is approved for a tool, don't re-ask on retry.
-    // key: `${guardrailTitle}:${toolName}` → timestamp of approval
-    this.approvalCache = new Map();
+    // The tool-keyed approval cache is gone (#265, Phase 1 T-A). It skipped the
+    // ceremony for MATCH_CACHE_TTL after any one approval, keyed by tool name
+    // alone — so a "ja" for deleting card A silently authorized a later delete
+    // of card B on the same tool. There is no fast-path exit now: every
+    // write-class call ceremonies fresh until Phase 2's bound one-shot approvals
+    // land. The semantic matchCache above is a different cache (does a guardrail
+    // govern a tool CATEGORY) and keeps its own TTL.
 
     // Tracks the timestamp of the last consumed HITL response so the poll
     // doesn't re-match the same message (poll reads the Talk API, which carries
@@ -259,15 +267,6 @@ class GuardrailEnforcer {
       const title = guardrail.title || '';
       if (!title) continue;
 
-      const approvalKey = `${title}:${toolName}`;
-
-      // Skip guardrails already approved for this tool (prevents re-asking on retry)
-      const approved = this.approvalCache.get(approvalKey);
-      if (approved && (Date.now() - approved) < MATCH_CACHE_TTL) {
-        this.logger.info(`[GuardrailEnforcer] ${toolName}: "${title}" → SKIP (already approved)`);
-        continue;
-      }
-
       const matchResult = await this._evaluateGuardrail(title, toolName, toolArgs);
 
       if (matchResult === 'YES') {
@@ -289,8 +288,8 @@ class GuardrailEnforcer {
           return { allowed: false, reason: `Guardrail "${title}" — action denied or timed out` };
         }
 
-        // User approved — cache approval so retries don't re-ask
-        this.approvalCache.set(approvalKey, Date.now());
+        // User approved. The approval authorizes this call only — no cache, so a
+        // later call ceremonies fresh (#265, Phase 1 T-A).
         this.logger.info(`[GuardrailEnforcer] ${toolName}: "${title}" → APPROVED by user`);
       }
     }
@@ -759,15 +758,9 @@ class GuardrailEnforcer {
       }
     }
 
-    // MEDIUM and HIGH: full HITL via Talk
+    // MEDIUM and HIGH: full HITL via Talk. No approval cache (#265, Phase 1 T-A):
+    // every call renders its own ceremony; a prior approval never carries over.
     this.logger.info(`[GuardrailEnforcer] checkApproval: ${toolName} → ${severity} severity, requesting HITL`);
-
-    const approvalKey = `toolguard:${toolName}`;
-    const cached = this.approvalCache.get(approvalKey);
-    if (cached && (Date.now() - cached) < MATCH_CACHE_TTL) {
-      this.logger.info(`[GuardrailEnforcer] checkApproval: ${toolName} → SKIP (already approved)`);
-      return { allowed: true, reason: null };
-    }
 
     // The label is rendered in the user's language here, at the offer's birth,
     // and stored on the PendingAction record with it. A resolution minutes later
@@ -776,7 +769,6 @@ class GuardrailEnforcer {
     const response = await this._requestToolApproval(label, toolName, toolArgs, roomToken, language);
 
     if (response.decision === 'yes') {
-      this.approvalCache.set(approvalKey, Date.now());
       return { allowed: true, reason: null };
     }
 

--- a/test/unit/agent/guardrail-enforcer.test.js
+++ b/test/unit/agent/guardrail-enforcer.test.js
@@ -923,9 +923,12 @@ async function runTests() {
     assert.strictEqual(result.allowed, true);
   });
 
-  // --- Approval cache ---
+  // --- No approval cache: every GATE-governed call ceremonies fresh (#265, T-A) ---
 
-  await asyncTest('approval cache skips re-asking on retry for same guardrail+tool', async () => {
+  await asyncTest('GATE path: a second call on a different target ceremonies fresh (no cache)', async () => {
+    // The tool-keyed skip cache is deleted. An approval authorizes only the call
+    // it was granted for; a later call — even same tool, same room — renders its
+    // own ceremony. This is the GATE-path parallel of the T6 regression.
     const now = Date.now();
     const queue = createMockTalkQueue();
     const enforcer = makeEnforcer({
@@ -934,32 +937,18 @@ async function runTests() {
       talkSendQueue: queue,
       conversationContext: createMockConversationContext([
         { role: 'user', content: 'yes', timestamp: Math.ceil(now / 1000) + 1 }
-      ])
+      ]),
+      confirmationTimeoutMs: 200,
+      pollIntervalMs: 50
     });
 
     const r1 = await enforcer.check('mail_send', { to: 'a@b.com' }, 'room1');
     assert.strictEqual(r1.allowed, true);
-    assert.strictEqual(queue._getSent().length, 1);
+    assert.strictEqual(queue._getSent().length, 1, 'first call ceremonies');
 
-    const r2 = await enforcer.check('mail_send', { to: 'a@b.com' }, 'room1');
-    assert.strictEqual(r2.allowed, true);
-    assert.strictEqual(queue._getSent().length, 1);
-  });
-
-  await asyncTest('approval cache does not cross different tool names', async () => {
-    const now = Date.now();
-    const enforcer = makeEnforcer({
-      cockpitManager: createMockCockpit([gateGuardrail('Confirm everything')]),
-      ollamaProvider: createDualMockOllama('YES', 'APPROVE'),
-      talkSendQueue: createMockTalkQueue(),
-      conversationContext: createMockConversationContext([
-        { role: 'user', content: 'yes', timestamp: Math.ceil(now / 1000) + 1 }
-      ])
-    });
-
-    await enforcer.check('mail_send', { to: 'a@b.com' }, 'room1');
-    assert.ok(enforcer.approvalCache.has('Confirm everything:mail_send'));
-    assert.ok(!enforcer.approvalCache.has('Confirm everything:file_delete'));
+    // Different target, same tool, same room — the old cache would have skipped.
+    await enforcer.check('mail_send', { to: 'different@b.com' }, 'room1');
+    assert.strictEqual(queue._getSent().length, 2, 'second call renders a fresh ceremony, not a SKIP');
   });
 
   await asyncTest('denial is not cached — re-asks on retry after denial', async () => {
@@ -990,7 +979,6 @@ async function runTests() {
 
     const r1 = await enforcer.check('mail_send', { to: 'a@b.com' }, 'room1');
     assert.strictEqual(r1.allowed, false);
-    assert.ok(!enforcer.approvalCache.has('Confirm email:mail_send'));
 
     const r2 = await enforcer.check('mail_send', { to: 'a@b.com' }, 'room1');
     assert.strictEqual(r2.allowed, true);
@@ -1140,7 +1128,10 @@ async function runTests() {
     assert.strictEqual(queue._getSent().length, 1);
   });
 
-  await asyncTest('TC-APPROVE-005: checkApproval caches approval on yes', async () => {
+  await asyncTest('TC-APPROVE-005: a second delete on a different card ceremonies fresh (T-A, #265 T6 shape)', async () => {
+    // The #265 leak, inverted into a regression test. An approval for card 42
+    // must NOT carry over to a later delete of card 99. No tool-keyed cache: the
+    // second call renders its own ceremony.
     const now = Date.now();
     const queue = createMockTalkQueue();
     const enforcer = makeEnforcer({
@@ -1149,17 +1140,17 @@ async function runTests() {
       conversationContext: createMockConversationContext([
         { role: 'user', content: 'yes', timestamp: Math.ceil(now / 1000) + 1 }
       ]),
-      confirmationTimeoutMs: 500,
+      confirmationTimeoutMs: 200,
       pollIntervalMs: 50
     });
 
-    await enforcer.checkApproval('deck_delete_card', { cardId: 42 }, 'room1', []);
-    assert.ok(enforcer.approvalCache.has('toolguard:deck_delete_card'));
+    const r1 = await enforcer.checkApproval('deck_delete_card', { cardId: 42 }, 'room1', []);
+    assert.strictEqual(r1.allowed, true, 'first delete approved via ceremony');
+    assert.strictEqual(queue._getSent().length, 1, 'first call ceremonies');
 
-    // Second call should hit cache — no new message sent
-    const r2 = await enforcer.checkApproval('deck_delete_card', { cardId: 99 }, 'room1', []);
-    assert.strictEqual(r2.allowed, true);
-    assert.strictEqual(queue._getSent().length, 1); // only 1 message, not 2
+    // Different card, same tool, same room, inside what was the old TTL window.
+    await enforcer.checkApproval('deck_delete_card', { cardId: 99 }, 'room1', []);
+    assert.strictEqual(queue._getSent().length, 2, 'second call renders a fresh ceremony, not a SKIP');
   });
 
   await asyncTest('TC-APPROVE-006: checkApproval blocks on timeout', async () => {

--- a/test/unit/agent/guardrail-enforcer.test.js
+++ b/test/unit/agent/guardrail-enforcer.test.js
@@ -1069,7 +1069,31 @@ async function runTests() {
     assert.ok(result.reason.includes('no interactive session'));
   });
 
-  await asyncTest('TC-APPROVE-002: checkApproval downgrades MEDIUM tool when the user asked for it', async () => {
+  await asyncTest('TC-APPROVE-002: write-class tool ceremonies even when the request is verdict=YES (T-B, #290)', async () => {
+    // The T5 shape, inverted. deck_delete_card is write-class, so the downgrade
+    // is ineligible: even a downgrade verdict=YES cannot waive the ceremony. The
+    // request may not manufacture the authority to authorize itself.
+    const queue = createMockTalkQueue();
+    const enforcer = makeEnforcer({
+      ollamaProvider: createMockDowngradeOllama('YES'),
+      talkSendQueue: queue,
+      conversationContext: createMockConversationContext([]),
+      confirmationTimeoutMs: 150,
+      pollIntervalMs: 50
+    });
+
+    const history = [
+      { role: 'user', content: 'Please delete the card Q3 Planning' }
+    ];
+    const result = await enforcer.checkApproval('deck_delete_card', { card: 'Q3 Planning' }, 'room1', history);
+    assert.strictEqual(result.allowed, false, 'no self-authorized execute for a write-class tool');
+    assert.strictEqual(queue._getSent().length, 1, 'the ceremony must render despite verdict=YES');
+  });
+
+  await asyncTest('TC-APPROVE-002b: non-write-class MEDIUM tool still downgrades on verdict=YES (T-B scoping)', async () => {
+    // The floor is scoped to the write class. A hypothetical non-write MEDIUM
+    // tool still takes the anti-nagging downgrade — judgment keeps its loosening
+    // authority everywhere the ceremony invariant does not apply.
     const queue = createMockTalkQueue();
     const enforcer = makeEnforcer({
       ollamaProvider: createMockDowngradeOllama('YES'),
@@ -1077,12 +1101,11 @@ async function runTests() {
       conversationContext: createMockConversationContext([])
     });
 
-    const history = [
-      { role: 'user', content: 'Please delete the card Q3 Planning' }
-    ];
-    const result = await enforcer.checkApproval('deck_delete_card', { card: 'Q3 Planning' }, 'room1', history);
-    assert.strictEqual(result.allowed, true);
-    assert.strictEqual(queue._getSent().length, 0, 'no ceremony when the request was the authorization');
+    const history = [{ role: 'user', content: 'look up the Q3 report' }];
+    // 'knowledge_search' is not in any write-class set → MEDIUM, downgrade eligible.
+    const result = await enforcer.checkApproval('knowledge_search', { query: 'Q3 report' }, 'room1', history);
+    assert.strictEqual(result.allowed, true, 'downgrade still applies off the write class');
+    assert.strictEqual(queue._getSent().length, 0, 'no ceremony for a downgraded non-write tool');
   });
 
   await asyncTest('TC-APPROVE-003: checkApproval asks HITL for MEDIUM tool when no confirmation', async () => {
@@ -1196,12 +1219,14 @@ async function runTests() {
     assert.strictEqual(enforcer._classifySeverity('delete_folder'), 'MEDIUM');
   });
 
-  // --- _userRequestedAction: the same-turn downgrade (#263) ---
+  // --- _userRequestedAction: the same-turn downgrade (#263), now floored (#290) ---
   //
-  // The regex table these replace was English-only: "delete the card X" skipped
-  // the ceremony, "Lösch die Karte X" did not. The decision is now the model's.
+  // The downgrade still runs the model for non-write tools. For write-class tools
+  // it is ineligible entirely (T-B): the ceremony renders regardless of verdict.
+  // #290 was a language-inconsistent verdict (YES in PT, NO in DE for the same
+  // delete); the floor makes language irrelevant by removing the loosening path.
 
-  await asyncTest('TC-APPROVE-010: downgrade decision is identical in DE, EN and PT', async () => {
+  await asyncTest('TC-APPROVE-010: a write-class delete ceremonies in DE, EN and PT even on verdict=YES (#290)', async () => {
     const messages = [
       'Delete the card Q3 Planning',
       'Lösch die Karte Q3 Planning',
@@ -1213,13 +1238,15 @@ async function runTests() {
       const enforcer = makeEnforcer({
         ollamaProvider: createMockDowngradeOllama('The message names the card and the action.\nYES'),
         talkSendQueue: queue,
-        conversationContext: createMockConversationContext([])
+        conversationContext: createMockConversationContext([]),
+        confirmationTimeoutMs: 150,
+        pollIntervalMs: 50
       });
       const result = await enforcer.checkApproval(
         'deck_delete_card', { card: 'Q3 Planning' }, 'room1', [{ role: 'user', content }]
       );
-      assert.strictEqual(result.allowed, true, `downgrade failed for: ${content}`);
-      assert.strictEqual(queue._getSent().length, 0, `ceremony ran for: ${content}`);
+      assert.strictEqual(result.allowed, false, `write-class must not self-authorize for: ${content}`);
+      assert.strictEqual(queue._getSent().length, 1, `ceremony must render for: ${content}`);
     }
   });
 


### PR DESCRIPTION
Approval Custody Arc, Phase 1. Two interim tightenings, both net deletion or near it. Fu shipped both (T-A scope widened per the Phase 0 finding to delete **both** tool-keyed approval caches). The Phase 2 chokepoint (`resolveAuthorization`) and the batch contract are out of scope.

## T-A — delete the tool-keyed approval cache (#265) — commit 1
Deletes the approval cache that skipped the ceremony for `MATCH_CACHE_TTL` after any one approval, keyed by tool name alone (so a "ja" for card A authorized a later delete of card B — S126 T6, +96s, different card).

Phase 0 found the mechanism in **two homes sharing one Map**: the `checkApproval` `toolguard:${toolName}` cache and the GATE-guardrail `${title}:${toolName}` cache. Both are deleted — cache-set, cache-check, and the `SKIP (already approved)` branch. The `approvalCache` field is gone.

`MATCH_CACHE_TTL` **stays**: the semantic `matchCache` (does a guardrail govern a tool CATEGORY) is a different cache and keeps its own use of the constant. Named per the Phase 0 residue rule.

Regression tests on **both** paths: a second call on a different target renders a fresh ceremony, never a SKIP.

## T-B — write-class ineligible for severity downgrade (#290) — commit 2
The MEDIUM anti-nagging downgrade let the requesting utterance authorize itself: a write-class delete judged `verdict=YES` executed at LOW with no ceremony. The judgment was also language-inconsistent (Phase 0: same delete → YES in PT, NO in DE/EN at one boot).

The downgrade now runs only for tools **outside** the write class (`getWriteClassTools()`, the single existing predicate — imported, not duplicated). Judgment keeps escalation authority, never lowers a write-class call past the ceremony threshold. Structural only — the downgrade prompt/examples/model call are untouched. Scoping test added (a non-write MEDIUM tool still downgrades).

## Hard-stop checks (Phase 0, cleared)
- The cache has **no** consumer beyond the approval-skip check (P8).
- The downgrade check gates **only** write-class MEDIUM approval — no load-bearing non-write flow (P7). Every `REQUIRES_APPROVAL` tool is write-class, so in practice every approval-gated call now ceremonies; the scoping keeps the downgrade available to any future non-write MEDIUM tool.

## Verification
- Full unit suite green (240/240 files); guardrail-enforcer suite 90/90 including the new T6 (both paths) and T5 (three languages) regression tests.
- **On-Prime Talk gates (Gate 1–4) pending merge + deploy** — the service runs the deployed `next` from the shared checkout; the live ceremony gates run once this lands. Report to Fu at that point.

Closes progression toward #265 and #290 (Phase 1 interim; full closure in Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)