### PR TITLE
chore: hygiene batch — .editorconfig, .env.example, DE/PT READMEs, dep audit (#10, #11, #8, #9, #98)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 # Moltagent Environment Configuration
+#
+# DEPLOYMENT NOTE: The reference deployment (Prime VM) configures these variables
+# via systemd unit environment and credential files, not via a .env file.
+# This file documents all variables the codebase reads and serves as a template
+# for local development and alternative deployments.
+#
 # Copy this file to .env and customize values for your deployment
 # All values shown are defaults (except secrets which must be set)
 
@@ -56,6 +62,12 @@ OLLAMA_MODEL_CREDENTIAL=qwen3:14b-fast
 # the boot preflight probes it as an optional dependency.
 EMBEDDING_MODEL=nomic-embed-text
 
+# Proactive initiative level (0-3). Higher = more proactive behavior (default 1)
+INITIATIVE_LEVEL=1
+
+# Daily cloud spend budget (USD) for proactive operations (default 0.50)
+# PROACTIVE_DAILY_BUDGET=0.50
+
 # Boot preflight (#87): a REQUIRED dependency that is definitively absent
 # (Talk/Deck/Collectives app not installed) halts boot with a remediation line.
 # Set to "warn" to demote that halt to a warning (escape hatch; leave unset).
@@ -69,6 +81,20 @@ CLAUDE_MODEL_STANDARD=claude-sonnet-4-5-20250929
 
 # Ollama request timeout in ms (covers cold start + inference; default 5 min)
 OLLAMA_TIMEOUT=300000
+
+# Fast local model for classification/quick tasks (falls back to OLLAMA_CLASSIFY_MODEL)
+# OLLAMA_MODEL_FAST=qwen2.5:3b
+
+# Local classification model (the seated classifier under local-only trust)
+# OLLAMA_CLASSIFY_MODEL=qwen2.5:3b
+
+# Per-call Ollama timeouts (ms): generic tool calls, domain tool calls, classification
+# OLLAMA_TOOL_TIMEOUT=60000
+# OLLAMA_DOMAIN_TOOL_TIMEOUT=90000
+# OLLAMA_CLASSIFY_TIMEOUT=30000
+
+# Synthesis provider for knowledge answers: 'local' (default) or 'cloud'
+# SYNTHESIS_PROVIDER=local
 
 # DeepSeek — optional budget cloud tier (~$0.14/1M input tokens)
 # To enable: set the API key and uncomment, then add deepseek to providers.yaml
@@ -84,6 +110,10 @@ PORT=3000
 
 # Bind host (0.0.0.0 for all interfaces)
 HOST=0.0.0.0
+
+# Public base URL of this agent (used to build the OAuth callback redirect).
+# Falls back to NC_URL when unset.
+# AGENT_PUBLIC_URL=https://your-agent-host.example.com
 
 # =============================================================================
 # SECURITY
@@ -158,6 +188,12 @@ CACHE_TTL_OCS=30000
 # Credential cache
 CACHE_TTL_CREDENTIALS=30000
 
+# Collectives (wiki) cache
+CACHE_TTL_COLLECTIVES=60000
+
+# CardDAV (contacts) cache
+CACHE_TTL_CARDDAV=60000
+
 # =============================================================================
 # HEARTBEAT MANAGER
 # =============================================================================
@@ -210,6 +246,11 @@ DECK_BOARD_ID=8
 # Days before completed tasks are archived
 DECK_ARCHIVE_AFTER_DAYS=180
 
+# Board titles the bot resolves by name (created if absent)
+# DECK_TASK_BOARD=Moltagent Tasks
+# DECK_COCKPIT_BOARD=Moltagent Cockpit
+# DECK_PERSONAL_BOARD=Personal
+
 # =============================================================================
 # COCKPIT / OWNER IDENTITY
 # =============================================================================
@@ -220,12 +261,31 @@ DECK_ARCHIVE_AFTER_DAYS=180
 # If unset, calendar alerts fire for ALL visible events (shared calendars included).
 ADMIN_USER=
 
+# Cockpit control-plane board (Deck-as-config)
+# COCKPIT_ENABLED=true
+# COCKPIT_BOARD_TITLE=Moltagent Cockpit
+# COCKPIT_CACHE_TTL=300000
+
 # =============================================================================
 # KNOWLEDGE (Collectives Wiki)
 # =============================================================================
 
 # Admin user to share the knowledge collective with (empty = no sharing)
 # KNOWLEDGE_ADMIN_USER=your-admin-username
+
+# Collective (wiki) name the stewards maintain
+# KNOWLEDGE_COLLECTIVE=Moltagent Knowledge
+
+# Default decay window (days) before a fact is flagged stale
+# KNOWLEDGE_DECAY_DAYS=90
+
+# Default confidence for newly written facts: low | medium | high
+# KNOWLEDGE_DEFAULT_CONFIDENCE=medium
+
+# Freshness steward: periodic scan for stale pages
+# KNOWLEDGE_FRESHNESS_ENABLED=true
+# KNOWLEDGE_FRESHNESS_INTERVAL=3600000
+# KNOWLEDGE_FRESHNESS_MAX_PAGES=20
 
 # =============================================================================
 # LLM RESILIENCE
@@ -343,12 +403,21 @@ SPEACHES_URL=http://YOUR_OLLAMA_IP:8014
 # Enable voice pipeline
 # VOICE_ENABLED=true
 
+# Speaches request timeout (ms)
+# SPEACHES_TIMEOUT=30000
+
 # Speaches STT model
 # SPEACHES_STT_MODEL=Systran/faster-whisper-small
 
 # Speaches TTS model and voice
 # SPEACHES_TTS_MODEL=piper
 # SPEACHES_TTS_VOICE=en_US-amy-medium
+
+# Path to the ffmpeg binary used for audio transcoding
+# FFMPEG_PATH=ffmpeg
+
+# Max accepted audio duration (seconds) for a voice message
+# VOICE_MAX_DURATION=300
 
 # =============================================================================
 # TEXT EXTRACTION & OCR (scanned PDF processing)
@@ -370,6 +439,113 @@ OCR_LANGUAGES=eng+deu+por
 # Characters per page below which a PDF is considered scanned
 # Normal PDF pages have 2000-3000 chars; scanned pages have 0-20
 # OCR_CHARS_THRESHOLD=50
+
+# =============================================================================
+# TALK NOTIFICATIONS & CONVERSATION CONTEXT
+# =============================================================================
+
+# Display name the bot uses in Talk
+# TALK_BOT_NAME=Moltagent
+
+# Include recent room history as context on each turn
+# TALK_CONTEXT_ENABLED=true
+
+# History window: max messages, max token estimate, and max age (ms)
+# TALK_CONTEXT_MAX_MESSAGES=20
+# TALK_CONTEXT_MAX_TOKENS=4000
+# TALK_CONTEXT_MAX_AGE=7200000
+
+# Include system messages (joins/leaves/etc.) in the context window
+# TALK_CONTEXT_INCLUDE_SYSTEM=false
+
+# =============================================================================
+# CONTACTS (CardDAV)
+# =============================================================================
+
+# Address book name to read/write contacts in
+# CONTACTS_ADDRESS_BOOK=contacts
+
+# Contacts cache TTL (ms)
+# CONTACTS_CACHE_TTL=3600000
+
+# =============================================================================
+# TIMEZONE
+# =============================================================================
+
+# IANA timezone identifier used for date formatting and scheduling
+# TIMEZONE=UTC
+
+# =============================================================================
+# WEB READER (URL fetch + extract)
+# =============================================================================
+
+# Fetch timeout (ms), max download size (bytes), and max extracted text (chars)
+# WEB_READER_TIMEOUT=15000
+# WEB_READER_MAX_BYTES=5242880
+# WEB_READER_MAX_CHARS=12000
+
+# In-memory cache: TTL (ms) and max entries
+# WEB_READER_CACHE_TTL=3600000
+# WEB_READER_MAX_CACHE=50
+
+# User-Agent header sent when fetching pages
+# WEB_READER_USER_AGENT=Moltagent/1.0
+
+# =============================================================================
+# DOCUMENT INGESTION
+# =============================================================================
+
+# Enable Files ingestion pipeline
+# INGEST_ENABLED=true
+
+# Watched directories (comma-separated, relative to the user's Files root)
+# INGEST_WATCH_DIRS=Projects
+
+# Scan watched directories once at startup
+# INGEST_STARTUP_SCAN=true
+
+# =============================================================================
+# NC FLOW (workspace event awareness)
+# =============================================================================
+
+# Inbound webhook receiver (Nextcloud Flow / webhook_listeners → this agent)
+# NCFLOW_WEBHOOKS_ENABLED=false
+# NCFLOW_WEBHOOKS_HOST=0.0.0.0
+# NCFLOW_WEBHOOKS_PORT=3100
+# NCFLOW_WEBHOOKS_SECRET=
+# NCFLOW_WEBHOOKS_TRUSTED_IPS=
+# NCFLOW_WEBHOOKS_SHUTDOWN_TIMEOUT=5000
+
+# Activity-poll fallback (used when webhooks are not configured)
+# NCFLOW_ACTIVITY_ENABLED=true
+# NCFLOW_ACTIVITY_INTERVAL=60000
+# NCFLOW_ACTIVITY_MAX_EVENTS=50
+# NCFLOW_ACTIVITY_IGNORE_OWN=true
+# NCFLOW_ACTIVITY_IGNORE_USERS=
+# NCFLOW_ACTIVITY_ENABLED_TYPES=
+
+# Systemtags applied to processed items (numeric NC tag IDs)
+# NCFLOW_TAGS_ENABLED=true
+# NCFLOW_TAG_PENDING_ID=2
+# NCFLOW_TAG_PROCESSED_ID=5
+# NCFLOW_TAG_NEEDS_REVIEW_ID=8
+# NCFLOW_TAG_AI_FLAGGED_ID=11
+
+# =============================================================================
+# INFRASTRUCTURE MONITOR (self-heal via heald)
+# =============================================================================
+
+# Probe infrastructure health on the heartbeat and optionally self-heal
+# INFRA_MONITOR_ENABLED=true
+# INFRA_CHECK_INTERVAL=3
+# INFRA_PROBE_TIMEOUT=8000
+# INFRA_SELF_HEAL=true
+# INFRA_NOTIFY_ON_FAILURE=true
+
+# heald agent (remote self-heal executor). Unset URL = heald not deployed.
+# HEALD_URL=http://your-heald-host:7867
+# HEALD_TOKEN_CREDENTIAL=heald-token
+# HEALD_TIMEOUT=15000
 
 # =============================================================================
 # TESTING (do not use in production)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**English** | [Deutsch](readme_i18n/README.de.md) | [Português](readme_i18n/README.pt.md)
+
+---
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.png">

--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -1,0 +1,94 @@
+# Dependency Security Posture
+
+A fresh `npm install` surfaces an `npm audit` warning count that looks alarming
+(currently **18 vulnerabilities**, most of them in dev-only or transitive
+packages). This document is the project's documented stance: what each advisory
+is, whether it is reachable at runtime, and why it is fixed, deferred, or
+accepted. It exists so an installer seeing that number can find the reasoning
+in-repo rather than guessing.
+
+Re-generate the numbers below with:
+
+```bash
+npm audit                 # full tree (dev + runtime) — the headline count
+npm audit --omit=dev      # runtime-only — what actually ships
+```
+
+## Snapshot
+
+| Scope | Count | Notes |
+| ----- | ----- | ----- |
+| Full tree (`npm audit`) | 18 (5 moderate, 13 high) | Includes the dev toolchain (eslint/lint-staged and their transitive deps). Never shipped or executed in production. |
+| Runtime (`npm audit --omit=dev`) | **11 (2 moderate, 9 high)** | After the `undici` override below (was 12 before). |
+
+`--omit=dev` is the number that matters for a deployed instance: the reference
+deployment installs with `npm ci --omit=dev`, so the dev-toolchain advisories
+are not present on the running box.
+
+## Fixed in this change
+
+### undici — pinned via `overrides`
+
+- Advisory cluster: request/response smuggling, unbounded-memory / DoS, CRLF and
+  header-injection issues (GHSA-2mjp-6q6p-2qxm and others).
+- Reached transitively as `cheerio@1.2.0 → undici`. `cheerio` accepts
+  `undici@^7.19.0`; the patched line `7.28.0` is inside that range, so the fix is
+  a clean, non-breaking pin — no direct dependency changes major version.
+
+```jsonc
+// package.json
+"overrides": {
+  "undici": "^7.28.0"
+}
+```
+
+This clears the entire `undici` cluster from `npm audit --omit=dev` (12 → 11).
+
+## Accepted — no patched version exists
+
+### SheetJS / xlsx (high)
+
+- **GHSA-4r6h-8v6p-xvw6** — Prototype Pollution
+- **GHSA-5pgg-2g8v-p4x9** — ReDoS
+- Direct dependency `xlsx@^0.18.5`. Upstream has published **no fixed version on
+  the npm registry** (`npm audit` reports *No fix available*); an `overrides`
+  pin has nothing patched to point at.
+- **Exposure & mitigation:** `xlsx` parses spreadsheet files a user has
+  deliberately handed to the agent. Treat spreadsheet input as untrusted at the
+  parsing boundary; do not parse attachments from unauthenticated senders.
+  Migrating off SheetJS (or to its non-npm CDN build, which carries the fixes)
+  is the real remediation and is out of scope for a hygiene change.
+
+## Deferred — fix requires a major-version change of a direct dependency
+
+Project policy (see `CLAUDE.md`): no major-version bumps of direct dependencies
+inside a hygiene change; each is its own change with its own testing.
+
+- **nodemailer** (high, `<=9.0.0`) — direct `^8.0.0` (and transitively via
+  `mailparser`). The fix lands only in `9.x`; adopting it is a direct-dependency
+  major bump and a deliberate SMTP-path revalidation, tracked separately.
+- **imap** (high, `>=0.8.18`) and its dependency chain **semver** (ReDoS) and
+  **utf7** — direct `imap@^0.8.19`. `npm`'s only offered fix is `imap@0.8.17`, a
+  **breaking downgrade** that would lose fixes and features. Replacing the `imap`
+  client is the correct long-term move, tracked separately.
+
+## Deferred — transitive fixes available (follow-up override/refresh pass)
+
+These have patched versions reachable without a direct-dependency major bump.
+They are **not** pinned in this change so it stays minimal and independently
+testable; a dedicated pass can add the overrides and re-run the suite.
+
+| Package | Sev | Reached via | Fix path |
+| ------- | --- | ----------- | -------- |
+| `@xmldom/xmldom` (`<=0.8.12`) | high | `mammoth` | override to `~0.8.13` |
+| `linkify-it` (`<=5.0.0`) | high | `mailparser` | override to a patched release |
+| `postcss` (`<8.5.10`) | moderate | `@extractus/article-extractor → sanitize-html` | override to `^8.5.10` |
+| `underscore` (`<=1.13.7`) | high | `mammoth → lop → duck` | override to a patched release |
+| `js-yaml` (`4.0.0 – 4.1.1`) | moderate | direct `^4.1.1` | in-range refresh (no major bump) |
+| `mailparser` (`2.1.0 – 3.9.8`) | high | direct `^3.9.3` | in-range refresh (no major bump) |
+
+## Verification
+
+- `npm ci` → clean install from the committed lockfile (`undici@7.28.0` resolved).
+- `npm test` → 246/246 test files pass with the override applied.
+- `npm audit --omit=dev` → 11 (2 moderate, 9 high); the `undici` cluster is gone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "moltagent-deck",
-  "version": "1.0.0",
+  "name": "moltagent",
+  "version": "0.1.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "moltagent-deck",
-      "version": "1.0.0",
+      "name": "moltagent",
+      "version": "0.1.0-beta",
       "license": "AGPL-3.0",
       "dependencies": {
         "@extractus/article-extractor": "^8.0.20",
@@ -3202,9 +3202,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7"
   },
+  "overrides": {
+    "undici": "^7.28.0"
+  },
   "lint-staged": {
     "*.js": "eslint"
   }

--- a/readme_i18n/README.de.md
+++ b/readme_i18n/README.de.md
@@ -1,0 +1,289 @@
+[English](../README.md) | **Deutsch** | [Português](README.pt.md)
+
+---
+
+> ℹ️ **Übersetzungshinweis:** Maßgeblich ist die [englische README](../README.md). Diese Übersetzung wird von Hand gepflegt und kann dem Original hinterherhinken — bei Abweichungen gilt die englische Fassung.
+
+---
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/logo-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="../assets/logo-light.png">
+    <img alt="Moltagent" src="../assets/logo-light.png" height="200">
+  </picture>
+</p>
+
+# Moltagent
+
+**Souveräne KI-Agenten-Plattform auf Nextcloud-Basis.**
+
+Dein KI-Mitarbeiter. Deine Infrastruktur. Deine Regeln.
+
+[![CI](https://github.com/moltagent/moltagent/actions/workflows/test.yml/badge.svg)](https://github.com/moltagent/moltagent/actions/workflows/test.yml)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
+<p align="center">
+  <a href="https://public.moltagent.cloud">
+    <img src="../assets/architecture-preview.png" alt="Moltagent-Architektur" width="800">
+  </a>
+</p>
+<p align="center"><em>Live-Architektur unter <a href="https://public.moltagent.cloud">public.moltagent.cloud</a></em></p>
+
+---
+
+> ⚠️ **Status: Beta. Gebaut für unseren Gebrauch, geteilt mit dir.**
+> 
+> Moltagent läuft in Produktion für seinen Schöpfer. Ich nutze ihn täglich für Content-Workflows, Wissensmanagement und redaktionelle Abläufe. Aber die Architektur entwickelt sich noch, und einige Funktionen sind noch teilweise umgesetzt.
+> 
+> Der `main`-Branch ist das, was wir in Produktion laufen lassen. Der `next`-Branch ist die aktive Entwicklung. Rechne mit Breaking Changes auf `next`.
+> 
+> Es fehlt der Feinschliff. Es ist ein funktionierendes System, das ich teile, weil ich glaube, dass souveräne KI-Infrastruktur Open Source sein sollte.
+> 
+> **Wie das entwickelt wird:** Der gesamte Codebase entsteht in Zusammenarbeit mit Claude (Anthropic). Ein Mensch (ich) definiert die Architektur, schreibt Briefings, trifft Design-Entscheidungen, rezensiert jeden Commit und testet in Produktion. Claude setzt um. Jede Funktion beginnt als schriftliche Spezifikation, nicht als Prompt. Nenne es vibe-coding wenn du willst, für mich ist es KI-unterstützte Entwicklung. Ich könnte nie Code von Claudes Qualität produzieren, aber ich kann bessere Architektur und kreative Lösungen schaffen.
+
+---
+
+## Warum es das gibt
+
+Ich bin Seriengründer und helfe Menschen dabei, Unternehmen zu führen. Redaktionsbüros, Content-Produktion, Kundenarbeit. Wir brauchten einen KI-Assistenten, der E-Mail, Kalender, Recherche und Content-Workflows im kleinen Team handhaben könnte.
+
+Alles, das wir ausprobiert haben, hatte das gleiche Problem: Unsere Daten verlassen unsere Infrastruktur und landen auf fremden Servern, unter fremder Jurisdiktion, unter fremden Nutzungsbedingungen. Selbst wenn dir GDPR egal ist, läufst du Gefahr, deine Arbeit, deine Einrichtung und deinen Geschäftskontext zu verlieren, wenn sich das politische oder kommerzielle Rahmenwerk verschiebt. Und genau das passiert gerade.
+
+Anmeldedaten werden weiß Gott wo gespeichert. Es gibt keine Möglichkeit zu prüfen, was die KI zugegriffen und getan hat. Kein Kill-Switch, der in unter einer Minute funktioniert. Revokation kann zum Albtraum werden.
+
+Wir suchten nach etwas, das auf unserer eigenen Infrastruktur läuft, möglicherweise auf einem Rechner im Keller einer stromausfallsicheren Farm. Es sollte sich mit den Tools integrieren, die wir bereits nutzen, und uns echte Kontrolle geben. Und irgendwie gab es das nicht.
+
+Also habe ich es gebaut.
+
+Moltagent ist ein KI-Mitarbeiter, der in Nextcloud lebt. Er hat sein eigenes Konto, seine eigenen Dateien, seinen eigenen Kalender, sein eigenes Task-Board und E-Mail. Du teilst mit ihm, was du teilen möchtest, genau wie bei der Einarbeitung eines menschlichen Kollegen. Und du kannst jeden Zugriff mit einem Klick widerrufen, genau wie bei der Verabschiedung eines Angestellten.
+
+Ich teile es als Open Source, weil jedes Unternehmen KI sicher nutzen können sollte und souveräne Business-Infrastruktur nicht proprietär sein sollte.
+
+Nimm es, erkunde es, baue darauf auf. Verbessere es.
+
+Los geht's!
+
+---
+
+## Was es macht
+
+Moltagent ist ein digitales Mitglied für dein Team, kein persönlicher Assistent pro Nutzer. Es baut institutionelles Wissen über alle Interaktionen auf.
+
+**Funktioniert in Nextcloud**:
+Dateien, Kalender, Kontakte, E-Mail, Aufgaben, Wiki, Kanban-Boards. Keine externen SaaS-Abhängigkeiten für deine Daten.
+
+**Workflow-Engine**:
+Schreibe Regeln als einfache Sätze auf Kanban-Karten. Der Agent liest sie und führt sie aus. Keine visuelle Programmierung, keine Node-Graphen, kein Code. Menschliche Kontrollpunkte (GATE-Label) überall wo du editorisches Urteilsvermögen brauchst.
+
+**Lebendes Gedächtnis**:
+Wissens-Wiki mit Vertrauens-Tracking und Frische-Management. Der Agent lernt aus Dokumenten, Konversationen und Workflows. Wissen, das nicht abgerufen wird, verfällt natürlicherweise. Wissen, das benutzt wird, wird stärker.
+
+**Vertrauensgrenzen**:
+Jede Operation ist als vertraut oder nicht vertraut klassifiziert. Vertrauliche Arbeit läuft automatisch zu lokalem LLM. Anmeldedaten werden im Moment der Verwendung abgerufen, sofort verworfen. Nie auf der Festplatte gespeichert.
+
+**Souveräne Suche**:
+SearXNG + Stract + Mojeek. Kein Google, kein Tracking, keine Filter-Blasen.
+
+**Stimme und E-Mail**:
+Speech-to-Text, volle IMAP/SMTP-Integration. Mensch-im-Loop zum Senden.
+
+**Kostencontrolling**:
+Per-Modell-Budget-Erzwingung. Tägliche Limits, automatisches Fallback zu lokal wenn Budget aufgebraucht. Du weißt immer, was du ausgibst.
+
+**Mehrsprachig**:
+Deutsch, Englisch, Portugiesisch von Tag eins. Das LLM ist die Sprachschicht, nicht der Code.
+
+**Sofortige Sperrung**:
+Deaktiviere das Nextcloud-Konto des Agenten. Alle Zugriffe stoppen. Unter 60 Sekunden zur vollständigen Sperrung. Oder widerrufe einzelne API-Anmeldedaten bei Bedarf. Einfach.
+
+---
+
+## Wie es funktioniert
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                    YOUR INFRASTRUCTURE                    │
+│                                                           │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐  │
+│  │  Nextcloud    │  │  Moltagent    │  │  Ollama       │  │
+│  │  StorageShare │  │  Bot VM       │  │  (Local LLM)  │  │
+│  │               │  │               │  │               │  │
+│  │  • Identity   │  │               │  │               │  │
+│  │  • Files      │  │  • Agent      │  │  • Air-       │  │
+│  │  • Passwords  │  │    runtime    │  │    gapped     │  │
+│  │  • Calendar   │  │  • No secrets │  │  • Handles    │  │
+│  │  • Wiki       │  │    stored     │  │    sensitive  │  │
+│  │  • Audit logs │  │               │  │    ops        │  │
+│  └───────┬───────┘  └───────┬───────┘  └────────┬──────┘  │
+│          │    HTTPS         │   Ollama API      │         │
+│          │◄─────────────────┤◄──────────────────┤         │
+│          │                  │                   │         │
+│          │                  ├──► Cloud LLM APIs │         │
+│          │                  │   (allowlisted)   │         │
+└──────────┴──────────────────┴───────────────────┴─────────┘
+```
+
+Drei Komponenten, Netzwerk-isoliert. Kompromiss einer bedeutet nicht Kompromiss aller. Der Ollama-VM hat keinen Internet-Zugang und Anmeldedaten-sensible Operationen verlassen deine Infrastruktur nie.
+
+→ [Vollständige Architektur-Dokumentation](../docs/architecture.md)
+
+---
+
+## LLM-Provider
+
+Moltagent ist Provider-agnostisch mit 13 unterstützten Adaptern. Wähle deinen Tradeoff:
+
+| Preset          | Cockpit-Name | Was passiert                                            | Kosten     |
+| --------------- | ------------ | ------------------------------------------------------- | ---------- |
+| **all-local**   | Nur lokal    | Alles läuft auf deinem Ollama. Null Cloud-Kosten.      | €0         |
+| **smart-mix**   | Ausgewogen   | Cloud primär, lokal fallback. Pro Job-Typ optimiert.    | ~€3-20/mo  |
+| **cloud-first** | Premium      | Nur Cloud. Maximale Qualität.                           | ~€10-50/mo |
+
+Unterstützt: Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Perplexity, OpenRouter, xAI, Together, Fireworks, Ollama, oder füge deine eigene hinzu.
+
+Zwei harte Regeln unabhängig vom Preset: Anmeldedaten-Operationen bleiben immer lokal, und alle Presets fallen zu lokal zurück wenn Cloud nicht verfügbar ist. Dein Agent geht nie offline.
+
+→ [Vollständige Provider-Konfiguration und Job-Routing](../docs/providers.md)
+
+---
+
+## Aktueller Stand
+
+**Live-Entwicklungs-Dashboard unter** [public.moltagent.cloud](https://public.moltagent.cloud) - Einsatzkontrolle mit Funktions-Verifizierungsstatus, Architektur-Graph, Commit-Verlauf und Wissens-Lebens-Zyklus-Visualisierung. Live aktualisiert vom Production-VM.
+
+Wir nutzen Moltagent täglich für unsere eigenen Operationen. Hier ein Überblick des Standes:
+
+**Funktioniert und wird täglich genutzt:**
+
+- Nextcloud-Integration (Dateien, Kalender, Kontakte, E-Mail, Wiki, Kanban-Deck)
+- Workflow-Engine mit GATE/PAUSED/SCHEDULED/ERROR Label-Zustandsmaschine
+- Content-Pipeline (Ideen-Evaluation → Drafting → Revision → Editorial Review → Publishing)
+- Wissens-Wiki mit Dokument-Ingest und Entity-Extraktion
+- Souveräne Suche (SearXNG + Stract + Mojeek)
+- Voice-Pipeline (Speaches STT)
+- Kostenerfassung und Budget-Durchsetzung
+- LLM-Routing mit 13 Provider-Adaptern
+- 217 Tests, alle bestanden
+
+**Funktioniert aber wird noch verfeinert:**
+
+- Workflow-Scheduling und zeitgesteuerte Card-Aktivierung
+- Multi-Board-Spawning und Cross-Board-Workflows
+- Editorial-Feedback-Schleifen (Revisions-Zyklen)
+- Calendar Smart Meetings und RSVP-Tracking
+
+**Noch nicht gebaut:**
+
+- One-Click-Installer
+- Web-basierter Setup-Wizard
+- Chat-Plattform-Adapter (Slack, Telegram, WhatsApp)
+- Drupal / WordPress CMS-Integration
+- Föderation zwischen Moltagent-Instanzen
+
+**Bekannte Limitierungen:**
+
+- Schnelles Entwicklungstempo: Architektur kann sich zwischen Releases ändern
+- Gebaut für Linux + Nextcloud. Kein Windows, kein macOS, kein Docker (noch nicht)
+- Erfordert Vertrautheit mit systemd, SSH und grundlegender Server-Administration
+- Der Agent ist nur so gut wie das LLM, das ihn antreibt. Lokale Modelle handhaben einfache Workflows, aber komplexe redaktionelle Arbeit braucht Cloud-Modelle (das könnte sich aber bald ändern, angesichts der rasanten Entwicklung lokaler KI)
+
+---
+
+## Erste Schritte
+
+Moltagent läuft als systemd-Service auf Linux mit Nextcloud-Backend. Das empfohlene Setup nutzt drei Hetzner-VMs mit Netzwerk-Isolation. Monatliche Infrastruktur-Kosten: ~30 Euro/Monat für den Anfang, unter 250 Euro/Monat für ernsthaften Business.
+
+Das ist keine One-Click-Installation. Du musst mit Server-Administration vertraut sein oder jemand, der das ist.
+
+→ [Setup-Anleitung](../docs/quickstart.md) - Nextcloud-Konfiguration, VM-Deployment, Firewall-Regeln, Credential-Store
+
+→ [Erste Schritte](../docs/getting-started.md) - wenn es läuft, was du tatsächlich in deiner ersten Stunde tust
+
+---
+
+## Wie das gebaut wird
+
+Moltagent wird von einem Solo-Gründer mit Claude als Architektur- und Implementierungs-Partner entwickelt. Die Methodik:
+
+1. **Briefings, nicht Prompts** 
+   Jede Funktion beginnt als geschriebenes Architektur-Dokument, das das Problem, das Design, die Edge-Cases und die Exit-Kriterien beschreibt. Diese Briefings sind durchschnittlich 15-25KB groß. Es gibt über 70 davon.
+
+2. **Systemisches Denken vor Code** 
+   Wenn ein Bug auftaucht, patchen wir nicht die Instanz. Wir fragen: Was ist die Problemklasse? Was erzeugt sie? Kann man den Generator reparieren? Zwei Instanzen desselben Musters bedeutet: Hör auf zu patchen und find die strukturelle Ursache.
+
+3. **Das TAO guter Ingenieurskunst**
+   Kein Regex für Intelligenz. Wenn Code schwache KI kompensiert, verstärke die KI, statt mehr Code hinzuzufügen. Weniger Code, nicht mehr. Die richtige Lösung in der richtigen Höhe ersetzt fünf Lösungen in der falschen. Mehrsprachig von Anfang an. Wenn es nur auf Englisch funktioniert, ist es ein Prototyp, kein Feature.
+
+4. **GEBAUT ≠ VERIFIZIERT**
+   Eine Funktion ist nur vollständig nach bestätigtem Produktions-Verhalten, nicht nachdem Tests bestanden haben. Wir laufen jede Änderung in Produktion auf unserer eigenen Infrastruktur, bevor wir sie für fertig erklären.
+
+Die Commit-Historie spiegelt echte Debugging-Sessions, Architektur-Entscheidungen und Produktions-Beobachtungen. Das ist absicht. Ich möchte, dass der Entwicklungsprozess lesbar ist, nicht nur der finale Code.
+
+---
+
+## Philosophie
+
+### Das Angestellten-Modell
+
+Als ich im Januar 2026 von Agentischer KI erfuhr, war ich sofort Feuer und Flamme. Könnte es Workflows automatisieren, Finance-Admin handhaben, als interaktives Wissens-Repository für meine Kunden fungieren?
+
+Als ich tiefer grub, bekam ich Angst. Echte Angst. Anmeldedaten in Textdateien. Kein Revokations-Pfad. Keine Audit-Spur. Was ist mit Prompt-Injections?
+
+Ich verband die Punkte: Was wenn der KI-Agent in meinem Nextcloud lebt und alles bekommt, das meine Angestellten bekommen? Eine echte Identität, einen echten Workspace, echte Revokation.
+
+Das ist was Moltagent ist.
+
+### Souveräne KI
+
+Souveräne KI sollte kein Buzzword sein. Es bedeutet, dass dein Business nicht von jemand anderem weitergeführtes Funktionieren abhängt. Es läuft auf deiner Infrastruktur mit deinen Daten. Und wenn morgen ein Provider verschwindet, kannst du noch arbeiten.
+
+Moltagent läuft auf einem Rechner in deinem Büro, deiner Werkstatt oder deiner Farm. Oder auf einem virtuellen Server bei Hetzner. Du entscheidest.
+
+---
+
+## Dokumentation
+
+|                                            |                                                          |
+| ------------------------------------------ | -------------------------------------------------------- |
+| [Start](../docs/quickstart.md)              | Starte in 30 Minuten                                     |
+| [Erste Schritte](../docs/getting-started.md) | Deine erste Stunde: erstes Gespräch, Daten teilen, echte Aufgaben |
+| [Deployment-Anleitung](../docs/deployment.md)   | SearXNG, Speaches, E-Mail, Anmeldedaten, vollständiges Setup    |
+| [Architektur](../docs/architecture.md)     | Drei-VM-Isolation, Netzwerk-Segmentierung             |
+| [Sicherheits-Modell](../docs/security-model.md) | Vertrauensgrenzen, Credential-Brokering, Threat-Modell |
+| [Anmeldedaten](../docs/credentials.md)       | NC Passwords-Feld-Mapping für jeden Anmeldedaten      |
+| [Konfiguration](../docs/configuration.md)   | Vollständige Referenz für config.yaml                       |
+| [LLM-Provider](../docs/providers.md)       | 13 Adapter, Job-Routing, Kostenoptimierung          |
+
+---
+
+## Beitragen
+
+Dieses Projekt wird kollaborativ mit KI entwickelt. Wenn dir das nicht passt, okay. Der Code ist AGPL-3.0 lizenziert und spricht für sich selbst. 
+
+Siehe [CONTRIBUTING.md](../.github/CONTRIBUTING.md) für Richtlinien.
+
+**Sicherheitsprobleme:** Bitte melde sie unter [security@moltagent.cloud](mailto:security@moltagent.cloud). Öffne keine öffentlichen Issues für Sicherheitslücken.
+
+---
+
+## Lizenz
+
+[AGPL-3.0](../LICENSE)
+
+Wenn du Moltagent verbesserst, profitieren alle davon. 
+
+---
+
+## Danksagungen
+
+- [Nextcloud](https://nextcloud.com) - das Ökosystem, das souveräne KI möglich macht
+- [Ollama](https://ollama.com) - lokale LLM-Inferenz
+- [Claude](https://anthropic.com) - Architektur-Partner und Implementierungs-Mitarbeiter
+- Die Self-Hosted-Community, für die Wertschätzung von Souveränität über Bequemlichkeit
+
+---
+
+```
+Deine KI. Deine Infrastruktur. Deine Regeln.
+```

--- a/readme_i18n/README.pt.md
+++ b/readme_i18n/README.pt.md
@@ -1,0 +1,289 @@
+[English](../README.md) | [Deutsch](README.de.md) | **Português**
+
+---
+
+> ℹ️ **Nota de tradução:** A versão canônica é o [README em inglês](../README.md). Esta tradução é mantida manualmente e pode estar desatualizada em relação ao original — em caso de divergência, prevalece o inglês.
+
+---
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/logo-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="../assets/logo-light.png">
+    <img alt="Moltagent" src="../assets/logo-light.png" height="200">
+  </picture>
+</p>
+
+# Moltagent
+
+**Plataforma de agente IA soberana construída no Nextcloud.**
+
+Seu agente IA. Sua infraestrutura. Suas regras.
+
+[![CI](https://github.com/moltagent/moltagent/actions/workflows/test.yml/badge.svg)](https://github.com/moltagent/moltagent/actions/workflows/test.yml)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
+<p align="center">
+  <a href="https://public.moltagent.cloud">
+    <img src="../assets/architecture-preview.png" alt="Arquitetura Moltagent" width="800">
+  </a>
+</p>
+<p align="center"><em>Visualização da arquitetura em tempo real em <a href="https://public.moltagent.cloud">public.moltagent.cloud</a></em></p>
+
+---
+
+> ⚠️ **Status: Beta. Construído para nosso uso, compartilhado com você.**
+> 
+> Moltagent roda em produção para seu criador. Eu o uso diariamente para fluxos de conteúdo, gestão de conhecimento e operações editoriais. Mas a arquitetura ainda está evoluindo, e alguns recursos estão parcialmente implementados.
+> 
+> O branch `main` é o que rodamos em produção. O branch `next` é onde o desenvolvimento ativo acontece. Espere mudanças significativas em `next`.
+> 
+> Falta polimento. É um sistema funcional que estou compartilhando porque acredito que infraestrutura de IA soberana deve ser código aberto.
+> 
+> **Como é construído:** Todo o código é desenvolvido em colaboração com Claude (Anthropic). Uma pessoa (eu) define a arquitetura, escreve especificações, toma decisões de design, revisa cada commit e testa em produção. Claude implementa. Cada recurso começa como uma especificação escrita, não como um prompt. Chame de vibe-coding se quiser, para mim é desenvolvimento assistido por IA. Nunca conseguiria produzir código da qualidade que Claude produz, mas consigo criar melhor arquitetura e soluções criativas.
+
+---
+
+## Por que existe
+
+Sou empreendedor em série e ajudo pessoas a dirigir negócios. Redações, produção de conteúdo, trabalho com clientes. Precisávamos de um assistente de IA que pudesse lidar com e-mail, calendário, pesquisa e fluxos de trabalho de conteúdo entre pequenas equipes.
+
+Tudo o que tentamos tinha o mesmo problema: nossos dados saem da nossa infraestrutura, vivem em servidores de outra pessoa, sob a jurisdição de outra pessoa, com os termos de serviço de outra pessoa. Mesmo que você não se importe com GDPR, você está correndo o risco de perder seu trabalho, sua configuração e seu contexto de negócio se a estrutura política ou comercial mudar. E é isso que está acontecendo agora.
+
+Credenciais são armazenadas não se sabe onde. Não há como auditar o que a IA acessou e fez. Nenhum botão de desligamento que funcione em menos de um minuto. Revogar pode se tornar um pesadelo.
+
+Procuramos algo que rodasse em nossa própria infraestrutura, potencialmente em uma máquina no porão de uma fazenda fora da rede. Deveria se integrar com as ferramentas que já usamos e nos dar controle real. E de alguma forma, isso não existia.
+
+Então eu construí.
+
+Moltagent é um agente de IA que vive no Nextcloud. Tem sua própria conta, seus próprios arquivos, seu próprio calendário, seu próprio quadro de tarefas e e-mail. Você compartilha com ele o que quer compartilhar, exatamente como ao integrar um colega humano. E você pode revogar todo acesso com um clique, exatamente como ao desligar um funcionário.
+
+Estou compartilhando como código aberto porque todo negócio deveria poder usar IA com segurança e infraestrutura de negócio soberana não deve ser proprietária.
+
+Pegue, explore, construa sobre isso. Melhore.
+
+Vamos!
+
+---
+
+## O que faz
+
+Moltagent é um funcionário digital para sua equipe, não um assistente pessoal por usuário. Constrói conhecimento institucional em todas as interações.
+
+**Funciona no Nextcloud**:
+Arquivos, calendário, contatos, e-mail, tarefas, wiki, quadros kanban. Sem dependências externas de SaaS para seus dados.
+
+**Motor de fluxo de trabalho**:
+Escreva regras como frases simples em cartões kanban. O agente as lê e executa. Sem programação visual, sem gráficos de nós, sem código. Pontos de verificação humanos (rótulos GATE) onde quer que você precise de julgamento editorial.
+
+**Memória viva**:
+Wiki de conhecimento com rastreamento de confiança e gestão de frescor. O agente aprende com documentos, conversas e fluxos de trabalho. Conhecimento que não é acessado decai naturalmente. Conhecimento que é usado se fortalece.
+
+**Limites de confiança**:
+Toda operação classificada como confiável ou não confiável. Trabalho sensível é roteado automaticamente para LLM local. Credenciais buscadas no momento do uso, imediatamente descartadas. Nunca armazenadas em disco.
+
+**Busca soberana**:
+SearXNG + Stract + Mojeek. Sem Google, sem rastreamento, sem bolhas de filtro.
+
+**Voz e e-mail**:
+Fala-para-texto, integração completa IMAP/SMTP. Humano-no-loop para envio.
+
+**Medição de custos**:
+Aplicação de orçamento por modelo. Limites diários, fallback automático para local quando orçamento se esgota. Você sempre sabe o que está gastando.
+
+**Multilíngue**:
+Alemão, inglês, português desde o dia um. O LLM é a camada de linguagem, não o código.
+
+**Revogação instantânea**:
+Desative a conta Nextcloud do agente. Todo acesso cessa. Menos de 60 segundos para bloqueio completo. Ou revogue credenciais de API individuais quando necessário. Simples.
+
+---
+
+## Como funciona
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                    YOUR INFRASTRUCTURE                    │
+│                                                           │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐  │
+│  │  Nextcloud    │  │  Moltagent    │  │  Ollama       │  │
+│  │  StorageShare │  │  Bot VM       │  │  (Local LLM)  │  │
+│  │               │  │               │  │               │  │
+│  │  • Identity   │  │               │  │               │  │
+│  │  • Files      │  │  • Agent      │  │  • Air-       │  │
+│  │  • Passwords  │  │    runtime    │  │    gapped     │  │
+│  │  • Calendar   │  │  • No secrets │  │  • Handles    │  │
+│  │  • Wiki       │  │    stored     │  │    sensitive  │  │
+│  │  • Audit logs │  │               │  │    ops        │  │
+│  └───────┬───────┘  └───────┬───────┘  └────────┬──────┘  │
+│          │    HTTPS         │   Ollama API      │         │
+│          │◄─────────────────┤◄──────────────────┤         │
+│          │                  │                   │         │
+│          │                  ├──► Cloud LLM APIs │         │
+│          │                  │   (allowlisted)   │         │
+└──────────┴──────────────────┴───────────────────┴─────────┘
+```
+
+Três componentes, isolados em rede. Comprometimento de um não compromete os outros. O VM Ollama não tem acesso à Internet e operações sensíveis a credenciais nunca saem de sua infraestrutura.
+
+→ [Documentação de arquitetura completa](../docs/architecture.md)
+
+---
+
+## Provedores de LLM
+
+Moltagent é agnóstico de provedor com 13 adaptadores suportados. Escolha seu compromisso:
+
+| Predefinição    | Nome no Cockpit | O que acontece                                          | Custo      |
+| --------------- | --------------- | ------------------------------------------------------- | ---------- |
+| **all-local**   | Apenas Local    | Tudo roda em seu Ollama. Zero custo de nuvem.          | €0         |
+| **smart-mix**   | Equilibrado     | Nuvem primária, fallback local. Otimizado por tipo de tarefa. | ~€3-20/mo  |
+| **cloud-first** | Premium         | Apenas nuvem. Qualidade máxima.                         | ~€10-50/mo |
+
+Suportado: Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Perplexity, OpenRouter, xAI, Together, Fireworks, Ollama, ou adicione o seu.
+
+Duas regras rígidas independentemente da predefinição: operações com credenciais sempre permanecem locais, e todas as predefinições voltam para local quando a nuvem não está disponível. Seu agente nunca fica offline.
+
+→ [Configuração completa de provedores e roteamento de tarefas](../docs/providers.md)
+
+---
+
+## Estado atual
+
+**Dashboard de desenvolvimento em tempo real em** [public.moltagent.cloud](https://public.moltagent.cloud) - centro de controle com status de verificação de recursos, gráfico de arquitetura, histórico de commits e visualização do ciclo de vida do conhecimento. Atualizado em tempo real do VM de produção.
+
+Usamos Moltagent diariamente para nossas operações. Aqui está uma visão geral do status:
+
+**Funcionando e em uso diário:**
+
+- Integração Nextcloud (arquivos, calendário, contatos, e-mail, wiki, deck kanban)
+- Motor de fluxo de trabalho com máquina de estados de rótulo GATE/PAUSED/SCHEDULED/ERROR
+- Pipeline de conteúdo (avaliação de ideias → rascunho → revisão → revisão editorial → publicação)
+- Wiki de conhecimento com ingestão de documentos e extração de entidades
+- Busca soberana (SearXNG + Stract + Mojeek)
+- Pipeline de voz (Speaches STT)
+- Medição de custos e aplicação de orçamento
+- Roteamento de LLM com 13 adaptadores de provedor
+- 217 testes, todos passando
+
+**Funcionando, mas ainda sendo refinado:**
+
+- Agendamento de fluxo de trabalho e ativação de cartão cronometrado
+- Spawning de múltiplos quadros e fluxos de trabalho entre quadros
+- Loops de feedback editorial (ciclos de revisão)
+- Reuniões inteligentes no calendário e rastreamento de RSVP
+
+**Ainda não construído:**
+
+- Instalador com um clique
+- Assistente de configuração baseado em web
+- Adaptadores de plataforma de chat (Slack, Telegram, WhatsApp)
+- Integração CMS Drupal / WordPress
+- Federação entre instâncias Moltagent
+
+**Limitações conhecidas:**
+
+- Ritmo acelerado de desenvolvimento: a arquitetura pode mudar entre lançamentos
+- Projetado para Linux + Nextcloud. Sem Windows, sem macOS, sem Docker (ainda não)
+- Requer familiaridade com systemd, SSH e administração básica de servidor
+- O agente é tão bom quanto o LLM que o impulsiona. Modelos locais lidam com fluxos de trabalho simples, mas trabalho editorial complexo precisa de modelos de nuvem (o que pode mudar em breve, dado o desenvolvimento rápido de IA local)
+
+---
+
+## Primeiros passos
+
+Moltagent roda como um serviço systemd no Linux com backend Nextcloud. A configuração recomendada usa três VMs Hetzner com isolamento de rede. Custo de infraestrutura mensal: ~30 euros/mês para iniciantes, menos de 250 euros/mês para negócio sério.
+
+Isso não é uma instalação com um clique. Você precisa estar confortável com administração de servidor ou ter alguém que esteja.
+
+→ [Guia de configuração](../docs/quickstart.md) - configuração Nextcloud, implantação de VM, regras de firewall, armazém de credenciais
+
+→ [Primeiros passos](../docs/getting-started.md) - uma vez que está rodando, o que você realmente faz na sua primeira hora
+
+---
+
+## Como é construído
+
+Moltagent é desenvolvido por um fundador solo usando Claude como parceiro de arquitetura e implementação. A metodologia:
+
+1. **Especificações, não prompts** 
+   Cada recurso começa como um documento arquitetônico escrito que descreve o problema, o design, os casos extremos e os critérios de saída. Essas especificações têm em média 15-25KB cada. Existem mais de 70 delas.
+
+2. **Pensamento sistêmico antes de código** 
+   Quando um bug aparece, não corrigimos a instância. Perguntamos: que classe de problema é este? O que o gera? O gerador pode ser corrigido? Duas instâncias do mesmo padrão significa parar de corrigir e encontrar a causa estrutural.
+
+3. **O TAO da boa engenharia**
+   Sem regex para inteligência. Se o código está compensando por IA fraca, fortaleça a IA, não adicione mais código. Menos código, não mais. A solução correta na altitude correta substitui cinco soluções na altitude errada. Multilíngue por padrão. Se funciona apenas em inglês, é um protótipo, não um recurso.
+
+4. **CONSTRUÍDO ≠ VERIFICADO**
+   Um recurso é completo apenas depois de comportamento confirmado em produção, não depois que os testes passam. Rodamos cada mudança em produção em nossa própria infraestrutura antes de chamar de pronto.
+
+O histórico de commits reflete sessões reais de depuração, decisões arquitetônicas e observações de produção. Isso é intencional. Quero que o processo de desenvolvimento seja legível, não apenas o código final.
+
+---
+
+## Filosofia
+
+### O modelo de emprego
+
+Quando aprendi sobre IA agentiva em janeiro de 2026, fiquei imediatamente entusiasmado. Poderia automatizar fluxos de trabalho, lidar com administração financeira, agir como um repositório de conhecimento interativo para meus clientes?
+
+Quando aprofundei, fiquei com medo. Muito medo. Credenciais em arquivos de texto. Nenhum caminho de revogação. Nenhum rastreamento de auditoria. E quanto a injeções de prompt?
+
+Conectei os pontos: e se o agente de IA vivesse no meu Nextcloud e tivesse tudo que meus funcionários têm? Uma identidade real, um espaço de trabalho real, revogação real.
+
+Isso é o que Moltagent é.
+
+### IA soberana
+
+IA soberana não deveria ser um modismo. Significa que seu negócio não depende da operação contínua de outra pessoa. Roda em sua infraestrutura com seus dados. E se qualquer provedor desaparecer amanhã, você ainda consegue continuar trabalhando.
+
+Moltagent roda em uma máquina em seu escritório, oficina ou fazenda. Ou em um servidor virtual na Hetzner. Sua escolha.
+
+---
+
+## Documentação
+
+|                                            |                                                          |
+| ------------------------------------------ | -------------------------------------------------------- |
+| [Iniciar](../docs/quickstart.md)           | Comece em 30 minutos                                     |
+| [Primeiros passos](../docs/getting-started.md) | Sua primeira hora: primeira conversa, compartilhamento de dados, tarefas reais |
+| [Guia de implantação](../docs/deployment.md)   | SearXNG, Speaches, e-mail, credenciais, configuração completa |
+| [Arquitetura](../docs/architecture.md)    | Isolamento de VM tríplice, segmentação de rede           |
+| [Modelo de segurança](../docs/security-model.md) | Limites de confiança, mediação de credenciais, modelo de ameaça |
+| [Credenciais](../docs/credentials.md)     | Mapeamento de campo Senhas NC para cada credencial       |
+| [Configuração](../docs/configuration.md)  | Referência completa para config.yaml                     |
+| [Provedores de LLM](../docs/providers.md) | 13 adaptadores, roteamento de tarefas, otimização de custos |
+
+---
+
+## Contribuindo
+
+Este projeto é desenvolvido colaborativamente com IA. Se isso incomoda você, tudo bem. O código é licenciado sob AGPL-3.0 e fala por si.
+
+Veja [CONTRIBUTING.md](../.github/CONTRIBUTING.md) para diretrizes.
+
+**Problemas de segurança:** Por favor reporte via [security@moltagent.cloud](mailto:security@moltagent.cloud). Não abra issues públicas para vulnerabilidades.
+
+---
+
+## Licença
+
+[AGPL-3.0](../LICENSE)
+
+Se você melhorar Moltagent, essas melhorias beneficiam a todos. 
+
+---
+
+## Agradecimentos
+
+- [Nextcloud](https://nextcloud.com) - o ecossistema que torna a IA soberana possível
+- [Ollama](https://ollama.com) - inferência de LLM local
+- [Claude](https://anthropic.com) - parceiro de arquitetura e colaborador de implementação
+- A comunidade auto-hospedada, por valorizar soberania sobre conveniência
+
+---
+
+```
+Sua IA. Sua infraestrutura. Suas regras.
+```


### PR DESCRIPTION
## What

Hygiene batch — docs & config. Adds `.editorconfig` (#10), completes `.env.example` (#11), adds German + Portuguese README translations (#8, #9), and documents the dependency audit posture with a safe `undici` pin (#98).

## Why

Backlog hygiene items. Relates to #10, #11, #8, #9, #98. `#70` was pulled out of this batch (its fix is generator-level — handlers re-throw with `execute()` as the single error chokepoint — and joins the error-custody family for its own session). No `Closes` keywords: `next` squash-merges do not auto-close, and the issues carry per-item evidence comments.

## How

- **#10 `.editorconfig`** — UTF-8, LF, 2-space, final newline, trim trailing whitespace; Markdown exempted from trimming (double-space is a meaningful break there). No reformatting sweep.
- **#11 `.env.example`** — the authoritative key set is `process.env.*` reads **plus** `config.js` `env*()` helper names = **162 keys**. The file documented 97; it now documents all 162 (each with a placeholder + one-line comment), grouped by `config.js`'s own sections. A top-of-file note records that the reference deployment configures these via the systemd unit, not a `.env` file.
- **#8 / #9 translations** — native-quality DE and PT under `readme_i18n/`, language switcher across all three READMEs, and an **EN-canonical translation-freshness note** at the top of each translation. Badges, links, and the architecture ASCII diagram (a fenced code block) carry over unchanged; the prior pass had translated the diagram labels and broken the box-border alignment — restored to the English original. DE read-through fixed `Föderabverband`→`Föderation`, `Sololründer`→`Solo-Gründer`, `buddelste`→`grub`, `anmeldedaten-sensitive`→`Anmeldedaten-sensible`, `Kostenmetering`→`Kostenerfassung`.
- **#98 audit** — `overrides` pin for `undici@^7.28.0` (inside cheerio's `^7.19.0` range) clears the undici advisory cluster from the runtime audit with **no direct-dependency major bump**. `SECURITY-DEPS.md` documents the full posture: `xlsx` has no npm-registry fix (accepted + mitigation); `nodemailer`/`imap` need major changes (deferred per policy); transitive in-range fixes listed as a follow-up pass.

### #11 authoritative-vs-documented (grep comparison)

```
authoritative keys (process.env.* ∪ config.js env*() names): 162
documented in .env.example (incl. commented examples):       165
in code but NOT documented:                                  0
```

### #98 `npm audit` before/after

```
BEFORE (next):            npm audit --omit=dev  → 12 (2 moderate, 10 high)
AFTER (undici override):  npm audit --omit=dev  → 11 (2 moderate,  9 high)   # undici cluster cleared
full tree (npm audit):    18 (5 moderate, 13 high)                            # dev toolchain; never shipped
package-lock.json diff: 14 lines (undici only)
```

## Testing

Verified in a clean worktree off current `next`:

- `npm ci` → clean install from the committed lockfile (`undici@7.28.0` resolved)
- `npm test` → **246/246 test files pass**
- `npm run lint` → exit 0 (0 errors; pre-existing warnings only)
- #11: grep comparison above (0 undocumented)
- #8/#9: all relative links in both translations resolve on the branch; brand casing clean (no `MoltAgent`)

- [x] Tests pass (`npm test`) — 246/246
- [ ] Tested manually against a Nextcloud instance — N/A (docs/config)
- [x] No language-specific logic added (multilingual by default)

## Checklist

- [x] Commit messages are descriptive (one commit per issue)
- [x] No credentials, IPs, or client-specific data in the diff (host placeholders only)
- [x] Documentation updated if needed
