### PR TITLE
fix(workflow): separate NC Mail link onto its own paragraph in trigger footer (#195)

### DIFF
--- a/src/lib/workflows/workflow-engine.js
+++ b/src/lib/workflows/workflow-engine.js
@@ -576,7 +576,7 @@ class WorkflowEngine {
     // Generic cards and other boards receive no grounding block.
     //
     // The From: footer is written by the email trigger ingest path (#185) as:
-    //   <body>\n\n---\nFrom: <Name> <addr>\nDate: ...\n[Open the original email in Mail](...)
+    //   <body>\n\n---\nFrom: <Name> <addr>\nDate: ...\n\n[Open the original email in Mail](...)
     // We parse from the RAW description (not the stripHtml version) because
     // stripHtml strips angle-bracket content (e.g. <alice@acme.com> → stripped).
     // This is structural parsing of a machine-authored marker — Rule 1 clean.
@@ -1307,7 +1307,14 @@ class WorkflowEngine {
         try {
           const mailUrl = await this.ncMailClient.resolveThreadUrl(trigger.locator, email.messageId);
           if (mailUrl) {
-            description += '\n[Open the original email in Mail](' + mailUrl + ')';
+            // #195: separate the Mail link from the Date footer line with a blank
+            // line, not a single "\n". A single newline is a Markdown soft break —
+            // Deck renders it inline, gluing the link onto the preceding line
+            // ("...Date: ...Open the original email in Mail"). A blank line makes
+            // the link its own paragraph, which every CommonMark renderer breaks.
+            // NOTE(#208): final card-description assembly ownership is moving into
+            // the engine; that consolidation should carry this separated form.
+            description += '\n\n[Open the original email in Mail](' + mailUrl + ')';
           } else {
             console.log('[Workflow] NC Mail back-link: no match for Message-ID ' + email.messageId + ' (message may not yet be synced) — omitting Mail link');
           }

--- a/test/unit/workflows/email-trigger-bridge.test.js
+++ b/test/unit/workflows/email-trigger-bridge.test.js
@@ -778,6 +778,8 @@ function makeEmail(overrides = {}) {
     assert.ok(/\nFrom:/.test(desc), 'footer must contain \\nFrom: line');
     assert.ok(/\[Open the original email in Mail\]\(/.test(desc),
       'footer must contain standalone [Open the original email in Mail](...) link');
+    assert.ok(/\n\n\[Open the original email in Mail\]\(/.test(desc),
+      '#195: Mail link must be its own paragraph (blank line before it), not a single \\n that Markdown glues onto the Date line');
     assert.ok(!desc.includes('Message-ID'), 'footer must NOT contain Message-ID');
   });
 

--- a/test/unit/workflows/research-grounding.test.js
+++ b/test/unit/workflows/research-grounding.test.js
@@ -102,8 +102,9 @@ function makeWb({ cardDescription = '' } = {}) {
 }
 
 // Post-B2 footer format: no Message-ID line (dropped by _ingestTriggerEmails after #206 fix).
+// #195: the Mail link is separated from the Date line by a blank line (own paragraph).
 const FROM_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22';
-const MAIL_LINK_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\n[Open the original email in Mail](https://nc.example.com/apps/mail/inbox/1234)';
+const MAIL_LINK_FOOTER = '\n\n---\nFrom: Alice Example <alice@acme.com>\nDate: 2026-06-22\n\n[Open the original email in Mail](https://nc.example.com/apps/mail/inbox/1234)';
 
 // ---------------------------------------------------------------------------
 // Helper: run engine against one wb, return captured processWorkflowTask calls


### PR DESCRIPTION
## What

Fixes the trigger-bridge footer so the "Open the original email in Mail" link renders on its own line instead of glued onto the Date line (#195, defect 1).

## Why

Relates to #195. The ingest footer appended the Mail link after the `Date:` line with a **single newline**, which Markdown treats as a soft break — Deck renders the link inline, hard to see and click.

Note on the issue's original symptom: the reported `<message-id>Open the original email in Mail` concatenation became **structurally impossible** once #206/#192 removed the Message-ID footer line (commit `3f866b7`). What remained was the single-newline separator between `Date:` and the link — this PR fixes that residual.

**Defect 2 of #195** (the resolved NC Mail URL pointing at the pre-move mailbox/thread after an IMAP folder move) is upstream NC Mail database state, not footer assembly. It is split out to its own discovery-first issue **#293** (cross-links #180).

## How

Emit a blank line before the link so it is its own paragraph, which every CommonMark renderer breaks regardless of Deck's soft-break configuration:

```diff
- description += '\n[Open the original email in Mail](' + mailUrl + ')';
+ description += '\n\n[Open the original email in Mail](' + mailUrl + ')';
```

`NOTE(#208)` marks that the pending card-description-assembly-ownership move should carry this separated form. The research-grounding footer fixture is updated and `TC-TRIGGER-28` gains a blank-line-separation assertion driven through the real ingest path.

## Testing

- `test/unit/workflows/email-trigger-bridge.test.js` → **28/28** (incl. the new `#195` blank-line assertion via `_ingestTriggerEmails`)
- `test/unit/workflows/research-grounding.test.js` → **18/18** (parser over the updated footer fixture)
- `npm run test:unit` → **240/240 test files pass**
- `npm run lint` → 0 errors
- **Live Deck round-trip:** created a card on the live board with a `Date:`-then-blank-line-then-link description, fetched it back (`GET`), and confirmed Deck stores the blank line (`\n\n`) byte-intact; card then deleted. Combined with the CommonMark guarantee that a blank line is a paragraph break, the link renders on its own line. In-situ rendered eyeball on the deployed build is the post-merge step.

- [x] Tests pass (`npm test`) — 240/240 unit files
- [x] Tested manually against a Nextcloud instance — live Deck create/read/delete round-trip
- [x] No language-specific logic added (multilingual by default)

## Checklist

- [x] Commit messages are descriptive
- [x] No credentials, IPs, or client-specific data in the diff
- [x] Documentation updated if needed (footer-format doc comment updated)
